### PR TITLE
feat: provider functions can return errors

### DIFF
--- a/cli/internal/testutils/mockresources.go
+++ b/cli/internal/testutils/mockresources.go
@@ -28,7 +28,7 @@ func NewMockTrackingPlan(ID string, data resources.ResourceData) *resources.Reso
 type DataCatalogProvider struct {
 }
 
-func (p *DataCatalogProvider) Create(_ context.Context, ID string, resourceType string, data resources.ResourceData) *resources.ResourceData {
+func (p *DataCatalogProvider) Create(_ context.Context, ID string, resourceType string, data resources.ResourceData) (*resources.ResourceData, error) {
 	payload := make(resources.ResourceData)
 
 	for k, v := range data {
@@ -38,10 +38,10 @@ func (p *DataCatalogProvider) Create(_ context.Context, ID string, resourceType 
 	payload["id"] = fmt.Sprintf("generated-%s-%s", resourceType, ID)
 	payload["operation"] = "create"
 
-	return &payload
+	return &payload, nil
 }
 
-func (p *DataCatalogProvider) Update(_ context.Context, ID string, resourceType string, data resources.ResourceData) *resources.ResourceData {
+func (p *DataCatalogProvider) Update(_ context.Context, ID string, resourceType string, data resources.ResourceData) (*resources.ResourceData, error) {
 	payload := make(resources.ResourceData)
 
 	for k, v := range data {
@@ -50,10 +50,10 @@ func (p *DataCatalogProvider) Update(_ context.Context, ID string, resourceType 
 
 	payload["operation"] = "update"
 
-	return &payload
+	return &payload, nil
 }
 
-func (p *DataCatalogProvider) Delete(_ context.Context, ID string, resourceType string, data resources.ResourceData) *resources.ResourceData {
+func (p *DataCatalogProvider) Delete(_ context.Context, ID string, resourceType string, data resources.ResourceData) (*resources.ResourceData, error) {
 	payload := make(resources.ResourceData)
 
 	for k, v := range data {
@@ -62,5 +62,5 @@ func (p *DataCatalogProvider) Delete(_ context.Context, ID string, resourceType 
 
 	payload["operation"] = "delete"
 
-	return &payload
+	return &payload, nil
 }

--- a/cli/pkg/provider/property.go
+++ b/cli/pkg/provider/property.go
@@ -18,7 +18,7 @@ func NewPropertyProvider(dc client.DataCatalog) syncer.Provider {
 	}
 }
 
-func (p *PropertyProvider) Create(ctx context.Context, ID string, resourceType string, data resources.ResourceData) *resources.ResourceData {
+func (p *PropertyProvider) Create(ctx context.Context, ID string, resourceType string, data resources.ResourceData) (*resources.ResourceData, error) {
 
 	payload := client.PropertyCreate{
 		Name:        data["display_name"].(string),
@@ -27,17 +27,21 @@ func (p *PropertyProvider) Create(ctx context.Context, ID string, resourceType s
 		Config:      data["propConfig"].(map[string]interface{}),
 	}
 
-	property, _ := p.client.CreateProperty(ctx, payload)
+	property, err := p.client.CreateProperty(ctx, payload)
+	if err != nil {
+		return nil, err
+	}
+
 	data["id"] = property.ID
 	data["workspaceID"] = property.WorkspaceId
 
-	return &data
+	return &data, nil
 }
 
-func (p *PropertyProvider) Update(_ context.Context, ID string, resourceType string, data resources.ResourceData) *resources.ResourceData {
-	return nil
+func (p *PropertyProvider) Update(_ context.Context, ID string, resourceType string, data resources.ResourceData) (*resources.ResourceData, error) {
+	return nil, nil
 }
 
-func (p *PropertyProvider) Delete(_ context.Context, ID string, resourceType string, data resources.ResourceData) *resources.ResourceData {
-	return nil
+func (p *PropertyProvider) Delete(_ context.Context, ID string, resourceType string, data resources.ResourceData) (*resources.ResourceData, error) {
+	return nil, nil
 }


### PR DESCRIPTION
## Description of the change

Provider functions can now return errors, which are taken into account during the Sync process

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
