### PR TITLE
fix: update and delete provider functions also receive previous state as inputs

### DIFF
--- a/cli/pkg/provider/property.go
+++ b/cli/pkg/provider/property.go
@@ -6,7 +6,10 @@ import (
 	"github.com/rudderlabs/rudder-iac/api/client"
 	"github.com/rudderlabs/rudder-iac/cli/internal/syncer"
 	"github.com/rudderlabs/rudder-iac/cli/internal/syncer/resources"
+	"github.com/rudderlabs/rudder-iac/cli/pkg/logger"
 )
+
+var log = logger.New("provider")
 
 type PropertyProvider struct {
 	client client.DataCatalog
@@ -38,10 +41,16 @@ func (p *PropertyProvider) Create(ctx context.Context, ID string, resourceType s
 	return &data, nil
 }
 
-func (p *PropertyProvider) Update(_ context.Context, ID string, resourceType string, data resources.ResourceData) (*resources.ResourceData, error) {
+func (p *PropertyProvider) Update(_ context.Context, ID string, resourceType string, data resources.ResourceData, state resources.ResourceData) (*resources.ResourceData, error) {
 	return nil, nil
 }
 
-func (p *PropertyProvider) Delete(_ context.Context, ID string, resourceType string, data resources.ResourceData) error {
+func (p *PropertyProvider) Delete(ctx context.Context, ID string, resourceType string, state resources.ResourceData) error {
+	log.Info("Deleting property", "data", state)
+	id := state["id"].(string)
+	log.Info("Deleting property", "id", id)
+	if err := p.client.DeleteProperty(ctx, id); err != nil {
+		return err
+	}
 	return nil
 }


### PR DESCRIPTION
## Description of the change

Previously Update and Delete functions only received latest inputs from graph (YAML), making it impossible for deletes to find generated ids, and hard for Updates to use the current tracking plans API.

- Update function also receives an additional ResourceData argument with data from state before the update.
- Delete function no longer receives the YAML ResourceData (it's always going to be nil) and receives current state instead.


## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
