### PR TITLE
feat: syncer updats state after every operation, instead of at the end

### DIFF
--- a/cli/internal/testutils/memorystatemanager.go
+++ b/cli/internal/testutils/memorystatemanager.go
@@ -12,6 +12,9 @@ import (
 // the behavior of a persistent state store which would have to persist a JSON instead of a Go struct.
 type MemoryStateManager struct {
 	json json.RawMessage
+	// SaveLog is a log of all the states, in JSON format, that have been saved to the manager.
+	// This can be used in tests to check how many times the state has been saved and what the state was at each point.
+	SaveLog []json.RawMessage
 }
 
 func (m *MemoryStateManager) Load(_ context.Context) (*state.State, error) {
@@ -29,5 +32,6 @@ func (m *MemoryStateManager) Save(_ context.Context, s *state.State) error {
 		return err
 	}
 	m.json = json
+	m.SaveLog = append(m.SaveLog, json)
 	return nil
 }


### PR DESCRIPTION
## Description of the change

syncer updats state after every operation, instead of at the end.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
