### PR TITLE
fix: update identity_section to identity_applied

### DIFF
--- a/api/client/catalog.go
+++ b/api/client/catalog.go
@@ -79,7 +79,7 @@ type TrackingPlanUpsertEvent struct {
 	Name            string                       `json:"name"`
 	Description     string                       `json:"description"`
 	EventType       string                       `json:"eventType"`
-	IdentitySection string                       `json:"identitySection"`
+	IdentityApplied string                       `json:"identitySection"`
 	Rules           TrackingPlanUpsertEventRules `json:"rules"`
 }
 

--- a/cli/pkg/localcatalog/tracking_plan.go
+++ b/cli/pkg/localcatalog/tracking_plan.go
@@ -35,7 +35,7 @@ type TPEvent struct {
 	Description     string
 	Type            string
 	AllowUnplanned  bool
-	IdentitySection string
+	IdentityApplied string
 	Properties      []*TPEventProperty
 }
 
@@ -68,7 +68,7 @@ type TPRule struct {
 type TPRuleEvent struct {
 	Ref             string `json:"$ref"`
 	AllowUnplanned  bool   `json:"allow_unplanned"`
-	IdentitySection string `json:"identity_section"`
+	IdentityApplied string `json:"identity_applied"`
 }
 
 type TPRuleProperty struct {
@@ -188,7 +188,7 @@ func expandEventRefs(rule *TPRule, fetcher CatalogResourceFetcher) (*TPEvent, er
 		Description:     event.Description,
 		Type:            event.Type,
 		AllowUnplanned:  rule.Event.AllowUnplanned,
-		IdentitySection: rule.Event.IdentitySection,
+		IdentityApplied: rule.Event.IdentityApplied,
 		Properties:      make([]*TPEventProperty, 0),
 	}
 

--- a/cli/pkg/provider/state/trackingplan.go
+++ b/cli/pkg/provider/state/trackingplan.go
@@ -186,7 +186,7 @@ type TrackingPlanEventArgs struct {
 	Description     string
 	Type            string
 	AllowUnplanned  bool
-	IdentitySection string
+	IdentityApplied string
 	Properties      []*TrackingPlanPropertyArgs
 }
 
@@ -199,7 +199,7 @@ func (args *TrackingPlanEventArgs) Diff(other *TrackingPlanEventArgs) bool {
 		return true
 	}
 
-	if args.IdentitySection != other.IdentitySection {
+	if args.IdentityApplied != other.IdentityApplied {
 		return true
 	}
 
@@ -274,7 +274,7 @@ func (args *TrackingPlanArgs) FromCatalogTrackingPlan(from *localcatalog.Trackin
 			Description:     event.Description,
 			Type:            event.Type,
 			AllowUnplanned:  event.AllowUnplanned,
-			IdentitySection: event.IdentitySection,
+			IdentityApplied: event.IdentityApplied,
 			Properties:      properties,
 		})
 	}
@@ -336,7 +336,7 @@ func (args *TrackingPlanArgs) FromResourceData(from resources.ResourceData) {
 			LocalID:         MustString(event, "localId"),
 			Type:            MustString(event, "type"),
 			AllowUnplanned:  MustBool(event, "allowUnplanned"),
-			IdentitySection: String(event, "identitySection", ""),
+			IdentityApplied: String(event, "identityApplied", ""),
 			Properties:      make([]*TrackingPlanPropertyArgs, 0),
 		}
 
@@ -389,7 +389,7 @@ func (args *TrackingPlanArgs) ToResourceData() resources.ResourceData {
 			"description":     event.Description,
 			"type":            event.Type,
 			"allowUnplanned":  event.AllowUnplanned,
-			"identitySection": event.IdentitySection,
+			"identityApplied": event.IdentityApplied,
 			"properties":      properties,
 		})
 	}

--- a/cli/pkg/provider/state/trackingplan_test.go
+++ b/cli/pkg/provider/state/trackingplan_test.go
@@ -49,7 +49,7 @@ func TestTrackingPlanArgs_Diff(t *testing.T) {
 				Type:            "event-type",
 				LocalID:         "event-local-id-updated", // added
 				AllowUnplanned:  false,
-				IdentitySection: "traits",
+				IdentityApplied: "traits",
 			}).
 			WithEvent(&state.TrackingPlanEventArgs{
 				Name:            "event-name-1",
@@ -57,7 +57,7 @@ func TestTrackingPlanArgs_Diff(t *testing.T) {
 				Type:            "event-type-1",
 				LocalID:         "event-local-id-1",
 				AllowUnplanned:  true, // updated
-				IdentitySection: "",
+				IdentityApplied: "",
 			}).Build()
 
 		fromArgs := factory.NewTrackingPlanArgsFactory().
@@ -67,7 +67,7 @@ func TestTrackingPlanArgs_Diff(t *testing.T) {
 				Type:            "event-type",
 				LocalID:         "event-local-id",
 				AllowUnplanned:  true,
-				IdentitySection: "context.traits",
+				IdentityApplied: "context.traits",
 			}).
 			WithEvent(&state.TrackingPlanEventArgs{
 				Name:            "event-name-1",
@@ -75,7 +75,7 @@ func TestTrackingPlanArgs_Diff(t *testing.T) {
 				Type:            "event-type-1",
 				LocalID:         "event-local-id-1",
 				AllowUnplanned:  false,
-				IdentitySection: "",
+				IdentityApplied: "",
 			}).Build()
 
 		diffed := fromArgs.Diff(toArgs)

--- a/cli/pkg/provider/trackingplan.go
+++ b/cli/pkg/provider/trackingplan.go
@@ -223,12 +223,12 @@ func getUpsertEvent(from *state.TrackingPlanEventArgs) client.TrackingPlanUpsert
 	var (
 		requiredProps   = make([]string, 0)
 		propLookup      = make(map[string]interface{})
-		identitySection = from.IdentitySection
+		identityApplied = from.IdentityApplied
 	)
 
 	// If the identity section empty, default to properties
-	if from.IdentitySection == "" {
-		identitySection = PropertiesIdentity
+	if from.IdentityApplied == "" {
+		identityApplied = PropertiesIdentity
 	}
 
 	// Only for simple types
@@ -264,8 +264,8 @@ func getUpsertEvent(from *state.TrackingPlanEventArgs) client.TrackingPlanUpsert
 		Name:            from.Name,
 		Description:     from.Description,
 		EventType:       from.Type,
-		IdentitySection: identitySection,
-		Rules: getRulesBasedonIdentity(identitySection, &client.TrackingPlanUpsertEventProperties{
+		IdentityApplied: identityApplied,
+		Rules: getRulesBasedonIdentity(identityApplied, &client.TrackingPlanUpsertEventProperties{
 			Type:                 "object",
 			AdditionalProperties: from.AllowUnplanned,
 			Required:             requiredProps,

--- a/cli/pkg/provider/trackingplan_test.go
+++ b/cli/pkg/provider/trackingplan_test.go
@@ -58,7 +58,7 @@ func TestTrackingPlanProvider_Create(t *testing.T) {
 					"description":     "event-description",
 					"type":            "event-type",
 					"allowUnplanned":  false,
-					"identitySection": "",
+					"identityApplied": "",
 					"properties": []map[string]interface{}{
 						{
 							"name":        "property",
@@ -163,7 +163,7 @@ func TestTrackingPlanProvider_Update(t *testing.T) {
 					"description":     "event-description",
 					"type":            "event-type",
 					"allowUnplanned":  false,
-					"identitySection": "",
+					"identityApplied": "",
 					"properties": []map[string]interface{}{
 						{
 							"name":        "property",
@@ -267,7 +267,7 @@ func TestTrackingPlanProvider_UpdateWithUpsertEvent(t *testing.T) {
 					"description":     "event-description-1",
 					"type":            "event-type-1",
 					"allowUnplanned":  true,
-					"identitySection": "",
+					"identityApplied": "",
 					"properties": []map[string]interface{}{
 						{
 							"name":        "property-1",


### PR DESCRIPTION
## Description of the change

Moving `identity_section` to `identity_applied` in the YAML and the subsequent state to be more inline with the business rules.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
