### PR TITLE
chore: add goreleaser workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,35 @@
+# .github/workflows/release.yml
+name: goreleaser
+
+on:
+  push:
+    # run only against tags
+    tags:
+      - "rudder-cli/v*"
+
+permissions:
+  contents: write
+  # packages: write
+  # issues: write
+  # id-token: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.22
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean -f ./cli/.goreleaser.yaml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ go.work.sum
 
 # Log files
 *.log
+
+# Added by goreleaser init:
+dist/

--- a/cli/.goreleaser.yaml
+++ b/cli/.goreleaser.yaml
@@ -1,0 +1,49 @@
+# This is an example .goreleaser.yml file with some sensible defaults.
+# Make sure to check the documentation at https://goreleaser.com
+
+# The lines below are called `modelines`. See `:help modeline`
+# Feel free to remove those if you don't want/need to use them.
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+# vim: set ts=2 sw=2 tw=0 fo=cnqoj
+
+version: 2
+
+project_name: rudder-cli
+
+before:
+  hooks:
+    # You may remove this if you don't use go modules.
+    - go mod tidy
+    # you may remove this if you don't need go generate
+    - go generate ./...
+
+builds:
+  - env:
+      - CGO_ENABLED=0
+    main: ./cli/cmd/rudder-cli/main.go
+    goos:
+      - linux
+      - windows
+      - darwin
+
+archives:
+  - format: tar.gz
+    # this name template makes the OS and Arch compatible with the results of `uname`.
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+    # use zip for windows archives
+    format_overrides:
+      - goos: windows
+        format: zip
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"

--- a/cli/internal/app/dependencies.go
+++ b/cli/internal/app/dependencies.go
@@ -16,12 +16,12 @@ var (
 	s  *syncer.ProjectSyncer
 )
 
-func Initialise() error {
+func Initialise(version string) error {
 	var err error
 
 	sm = newStateManager()
 
-	p, err = newProvider()
+	p, err = newProvider(version)
 	if err != nil {
 		return fmt.Errorf("creating provider: %w", err)
 	}
@@ -37,9 +37,14 @@ func newStateManager() syncer.StateManager {
 	}
 }
 
-func newProvider() (syncer.Provider, error) {
+func newProvider(version string) (syncer.Provider, error) {
 	cfg := config.GetConfig()
-	rawClient, err := client.New(cfg.Auth.AccessToken, client.WithBaseURL(cfg.APIURL))
+	rawClient, err := client.New(
+		cfg.Auth.AccessToken,
+		client.WithBaseURL(cfg.APIURL),
+		client.WithUserAgent("rudder-cli/"+version),
+	)
+
 	if err != nil {
 		return nil, fmt.Errorf("creating client: %w", err)
 	}

--- a/cli/internal/cmd/root.go
+++ b/cli/internal/cmd/root.go
@@ -66,7 +66,7 @@ func initLogger() {
 }
 
 func initAppDependencies() {
-	if err := app.Initialise(); err != nil {
+	if err := app.Initialise(rootCmd.Version); err != nil {
 		ui.ShowError(err)
 		os.Exit(1)
 	}
@@ -88,7 +88,6 @@ var rootCmd = &cobra.Command{
 }
 
 func Execute() {
-
 	defer recovery()
 
 	if err := rootCmd.Execute(); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,9 @@ require (
 	github.com/MakeNowJust/heredoc/v2 v2.0.1
 	github.com/briandowns/spinner v1.23.1
 	github.com/charmbracelet/lipgloss v1.0.0
+	github.com/google/uuid v1.6.0
+	github.com/kyokomi/emoji/v2 v2.2.13
+	github.com/samber/lo v1.47.0
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/viper v1.19.0
 	github.com/stretchr/testify v1.9.0
@@ -23,11 +26,9 @@ require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/fatih/color v1.14.1 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
-	github.com/kyokomi/emoji/v2 v2.2.13 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
@@ -41,7 +42,6 @@ require (
 	github.com/rogpeppe/go-internal v1.11.0 // indirect
 	github.com/sagikazarmark/locafero v0.4.0 // indirect
 	github.com/sagikazarmark/slog-shim v0.1.0 // indirect
-	github.com/samber/lo v1.47.0 // indirect
 	github.com/sourcegraph/conc v0.3.0 // indirect
 	github.com/spf13/afero v1.11.0 // indirect
 	github.com/spf13/cast v1.6.0 // indirect


### PR DESCRIPTION
## Description of the change

Adds goreleaser and a workflow to build releases when `rudder-cli/v*` tags are pushed

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
