### PR TITLE
fix: auth logic does not expect an access token to already exist in config

### DIFF
--- a/cli/internal/cmd/root.go
+++ b/cli/internal/cmd/root.go
@@ -66,10 +66,7 @@ func initLogger() {
 }
 
 func initAppDependencies() {
-	if err := app.Initialise(rootCmd.Version); err != nil {
-		ui.ShowError(err)
-		os.Exit(1)
-	}
+	app.Initialise(rootCmd.Version)
 }
 
 func SetVersion(v string) {

--- a/cli/internal/cmd/trackingplan/apply/apply.go
+++ b/cli/internal/cmd/trackingplan/apply/apply.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/MakeNowJust/heredoc/v2"
-	"github.com/rudderlabs/rudder-iac/cli/internal/app"
+	"github.com/rudderlabs/rudder-iac/cli/internal/cmd/trackingplan/common"
 	"github.com/rudderlabs/rudder-iac/cli/internal/cmd/trackingplan/validate"
 	"github.com/rudderlabs/rudder-iac/cli/internal/syncer"
 	"github.com/rudderlabs/rudder-iac/cli/internal/syncer/resources"
@@ -55,7 +55,12 @@ func NewCmdTPApply() *cobra.Command {
 			log.Debug("tp apply", "dryRun", dryRun, "confirm", confirm)
 			log.Debug("identifying changes for the upstream catalog")
 
-			if err := app.Syncer().Sync(
+			s, err := common.NewSyncer()
+			if err != nil {
+				return err
+			}
+
+			if err := s.Sync(
 				context.Background(),
 				createResourceGraph(localcatalog),
 				syncer.SyncOptions{

--- a/cli/internal/cmd/trackingplan/common/deps.go
+++ b/cli/internal/cmd/trackingplan/common/deps.go
@@ -1,0 +1,20 @@
+package common
+
+import (
+	"github.com/rudderlabs/rudder-iac/cli/internal/app"
+	"github.com/rudderlabs/rudder-iac/cli/internal/syncer"
+)
+
+func NewSyncer() (*syncer.ProjectSyncer, error) {
+	d, err := app.NewDeps()
+	if err != nil {
+		return nil, err
+	}
+
+	s, err := syncer.New(d.Provider(), d.StateManager())
+	if err != nil {
+		return nil, err
+	}
+
+	return s, nil
+}

--- a/cli/internal/cmd/trackingplan/destroy/destroy.go
+++ b/cli/internal/cmd/trackingplan/destroy/destroy.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/MakeNowJust/heredoc/v2"
-	"github.com/rudderlabs/rudder-iac/cli/internal/app"
+	"github.com/rudderlabs/rudder-iac/cli/internal/cmd/trackingplan/common"
 	"github.com/rudderlabs/rudder-iac/cli/internal/syncer"
 	"github.com/rudderlabs/rudder-iac/cli/pkg/logger"
 	"github.com/spf13/cobra"
@@ -34,7 +34,12 @@ func NewCmdTPDestroy() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			log.Debug("tp destroy", "dryRun", dryRun, "confirm", confirm)
 
-			errors := app.Syncer().Destroy(context.Background(), syncer.SyncOptions{
+			s, err := common.NewSyncer()
+			if err != nil {
+				return err
+			}
+
+			errors := s.Destroy(context.Background(), syncer.SyncOptions{
 				DryRun:  dryRun,
 				Confirm: confirm,
 			})

--- a/cli/internal/syncer/syncer.go
+++ b/cli/internal/syncer/syncer.go
@@ -27,11 +27,19 @@ type StateManager interface {
 	Save(context.Context, *state.State) error
 }
 
-func New(p Provider, sm StateManager) *ProjectSyncer {
+func New(p Provider, sm StateManager) (*ProjectSyncer, error) {
+	if p == nil {
+		return nil, fmt.Errorf("provider is required")
+	}
+
+	if sm == nil {
+		return nil, fmt.Errorf("state manager is required")
+	}
+
 	return &ProjectSyncer{
 		provider:     p,
 		stateManager: sm,
-	}
+	}, nil
 }
 
 type SyncOptions struct {

--- a/cli/internal/syncer/syncer_test.go
+++ b/cli/internal/syncer/syncer_test.go
@@ -45,7 +45,7 @@ func TestSyncerCreate(t *testing.T) {
 	stateManager.Save(context.Background(), state.EmptyState())
 	provider := &testutils.DataCatalogProvider{}
 
-	s := syncer.New(provider, stateManager)
+	s, _ := syncer.New(provider, stateManager)
 	err := s.Sync(context.Background(), targetGraph, syncer.SyncOptions{})
 	assert.Nil(t, err)
 
@@ -186,7 +186,7 @@ func TestSyncerDelete(t *testing.T) {
 	// Create empty target graph (all resources should be deleted)
 	targetGraph := resources.NewGraph()
 
-	s := syncer.New(provider, stateManager)
+	s, _ := syncer.New(provider, stateManager)
 	err := s.Sync(context.Background(), targetGraph, syncer.SyncOptions{})
 	assert.Nil(t, err)
 


### PR DESCRIPTION
## Description of the change

- app dependencies (provider, state manager) are lazily initialized, only version is kept as a global variable during cobra init.
- creating a Syncer is now moved to a common package in tp
- added some extra validations in syncer.New function


## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
