### PR TITLE
feat(cli): change display_name to name in Event and Property models

### DIFF
--- a/.clinerules
+++ b/.clinerules
@@ -1,0 +1,50 @@
+# Cline Rules for Rudder IAC
+
+## Process Workflows
+
+### Linear Issue Management
+
+1. Issue Status Updates
+
+   - Issue status is automatically updated by GitHub PR status
+   - DO NOT manually update issue status
+   - Wait for GitHub automation to reflect changes
+
+2. Implementation Process
+   - Review and understand issue requirements
+   - Make necessary code changes
+   - Implement comprehensive tests
+   - Submit PR for review
+   - Let automation handle status updates
+
+### Code Changes
+
+1. Model Updates
+
+   - Always test YAML parsing after schema changes
+
+2. Testing Requirements
+   - Write tests before submitting PR
+   - Validate against existing YAML configs
+   - Verify reference resolution still works
+   - Check for breaking changes
+
+## Project Conventions
+
+1. YAML Configuration
+
+   - Use `name` for actual field/event names
+   - Use `display_name` only for UI display purposes
+   - Document schema changes clearly
+
+2. Pull Request Process
+
+   - Implementation complete with tests
+   - PR triggers status updates in Linear
+   - Wait for automated status updates
+
+3. Commit Messages
+   - Use conventional commits format
+   - Type prefix based on module (e.g. `feat(cli)`, `fix(api)`)
+   - Don't include Linear issue in commit title (it's in branch name)
+   - First commit's title becomes PR title when squash merged

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ go.work.sum
 
 # Added by goreleaser init:
 dist/
+
+# Cline memory-bank
+memory-bank

--- a/cli/internal/cmd/trackingplan/apply/apply.go
+++ b/cli/internal/cmd/trackingplan/apply/apply.go
@@ -37,7 +37,7 @@ func NewCmdTPApply() *cobra.Command {
 			the changes based on the last recorded state. The diff is then applied to the upstream.
 		`),
 		Example: heredoc.Doc(`
-			$ rudder-cli tp apply --loc </path/to/dir or file> --dry-run
+			$ rudder-cli tp apply --location </path/to/dir or file> --dry-run
 		`),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			// Here we might need to do validate
@@ -75,7 +75,7 @@ func NewCmdTPApply() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&catalogDir, "loc", "l", "", "Path to the directory containing the catalog files  or catalog file itself")
+	cmd.Flags().StringVarP(&catalogDir, "location", "l", "", "Path to the directory containing the catalog files  or catalog file itself")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Only show the changes and not apply them")
 	cmd.Flags().BoolVar(&confirm, "confirm", true, "Confirm the changes before applying")
 	return cmd

--- a/cli/internal/cmd/trackingplan/validate/validate.go
+++ b/cli/internal/cmd/trackingplan/validate/validate.go
@@ -27,7 +27,7 @@ func NewCmdTPValidate() *cobra.Command {
 		Short: "Validate locally defined catalog",
 		Long:  "Validate locally defined catalog",
 		Example: heredoc.Doc(`
-			$ rudder-cli tp validate --loc <path-to-catalog-dir or file>
+			$ rudder-cli tp validate --location <path-to-catalog-dir or file>
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			dc, err := localcatalog.Read(catalogDir)
@@ -45,7 +45,7 @@ func NewCmdTPValidate() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&catalogDir, "loc", "l", "", "Path to the directory containing the catalog files or catalog file itself")
+	cmd.Flags().StringVarP(&catalogDir, "location", "l", "", "Path to the directory containing the catalog files or catalog file itself")
 	return cmd
 }
 

--- a/cli/pkg/localcatalog/loader_test.go
+++ b/cli/pkg/localcatalog/loader_test.go
@@ -24,7 +24,7 @@ func TestExtractCatalogEntity(t *testing.T) {
         spec:
           properties:
             - id: write_key
-              display_name: "Write Key"
+              name: "Write Key"
               type: string
               description: KSUID identifier for the source embedded in the SDKs
               propConfig:
@@ -58,7 +58,7 @@ func TestExtractCatalogEntity(t *testing.T) {
         spec:
           events:
             - id: user_signed_up
-              display_name: "User Signed Up"
+              name: "User Signed Up"
               event_type: track
               description: "Triggered when user successfully signed up"
               categories:
@@ -90,7 +90,7 @@ func TestExtractCatalogEntity(t *testing.T) {
         spec:
           events:
             - id: user_signed_up
-              display_name: "User Signed Up"
+              name: "User Signed Up"
               event_type: track
               description: "Triggered when user successfully signed up"
               categories:
@@ -109,14 +109,14 @@ func TestExtractCatalogEntity(t *testing.T) {
         spec:
           properties:
             - id: username
-              display_name: "Username of the customer"
+              name: "Username of the customer"
               type: string
               description: "Username of the customer used for login"
               propConfig:
                 minLength: 10
                 maxLength: 63
             - id: button_signin
-              display_name: "Button used for signin in the app"
+              name: "Button used for signin in the app"
               type: string
               description: "Button used for signin in the app"
               propConfig:

--- a/cli/pkg/localcatalog/model.go
+++ b/cli/pkg/localcatalog/model.go
@@ -16,7 +16,7 @@ type ResourceDefinition struct {
 
 type Property struct {
 	LocalID     string                 `json:"id"`
-	Name        string                 `json:"display_name"`
+	Name        string                 `json:"name"`
 	Description string                 `json:"description"`
 	Type        string                 `json:"type"`
 	Config      map[string]interface{} `json:"propConfig"`
@@ -44,7 +44,7 @@ func ExtractProperties(rd *ResourceDefinition) ([]Property, error) {
 
 type Event struct {
 	LocalID     string   `json:"id"`
-	Name        string   `json:"display_name"`
+	Name        string   `json:"name"`
 	Type        string   `json:"event_type"`
 	Description string   `json:"description"`
 	Categories  []string `json:"categories"`

--- a/cli/pkg/localcatalog/testdata/events_batch_1.yaml
+++ b/cli/pkg/localcatalog/testdata/events_batch_1.yaml
@@ -5,6 +5,6 @@ metadata:
 spec:
   events:
     - id: user_signed_up
-      display_name: "User Signed Up"
+      name: "User Signed Up"
       event_type: track
       description: "User signed up for the app"

--- a/cli/pkg/localcatalog/testdata/events_batch_2.yaml
+++ b/cli/pkg/localcatalog/testdata/events_batch_2.yaml
@@ -5,6 +5,6 @@ metadata:
 spec:
   events:
     - id: source_created
-      display_name: "Source Created"
+      name: "Source Created"
       event_type: track
       description: "Source created by the user"

--- a/cli/pkg/localcatalog/testdata/properties_batch_1.yaml
+++ b/cli/pkg/localcatalog/testdata/properties_batch_1.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   properties:
     - id: write_key
-      display_name: "Write Key"
+      name: "Write Key"
       type: string
       description: KSUID identifier for the source embedded in the SDKs
       propConfig:
@@ -13,18 +13,18 @@ spec:
         maxLength: 48
 
     - id: source_type
-      display_name: "Source Type"
+      name: "Source Type"
       type: string
       description: "Type of the source"
       propConfig:
         enum:
-        - web
-        - server
-        - mobile
-        - iot
+          - web
+          - server
+          - mobile
+          - iot
 
     - id: source_name
-      display_name: "Source name"
+      name: "Source name"
       description: "Name of the source"
       type: string
       propConfig:

--- a/cli/pkg/localcatalog/testdata/properties_batch_2.yaml
+++ b/cli/pkg/localcatalog/testdata/properties_batch_2.yaml
@@ -5,19 +5,19 @@ metadata:
 spec:
   properties:
     - id: email
-      display_name: "Email ID New"
+      name: "Email ID New"
       type: string
       description: "Email of the user"
       propConfig:
         pattern: ^[\w\-.]+@([\w-]+\.)+[\w-]{2,4}$.
 
     - id: country
-      display_name: "Country"
+      name: "Country"
       type: string
       description: "Location of the user"
       propConfig:
-        enum: 
-        - US
-        - UK
-        - India
-        - Canada
+        enum:
+          - US
+          - UK
+          - India
+          - Canada

--- a/cli/pkg/validate/required_keys.go
+++ b/cli/pkg/validate/required_keys.go
@@ -42,7 +42,7 @@ func (rk *RequiredKeysValidator) Validate(dc *catalog.DataCatalog) []ValidationE
 			if event.Type == "track" {
 				if event.Name == "" {
 					errors = append(errors, ValidationError{
-						error:     fmt.Errorf("display_name field is mandatory on track event"),
+						error:     fmt.Errorf("name field is mandatory on track event"),
 						Reference: reference,
 					})
 				}


### PR DESCRIPTION
## Description of the change

This PR makes two changes:
1. Changes the display_name field to name in Event and Property models to align with schema requirements
2. Updates the --loc CLI flag to --location for better clarity (shorthand -l remains unchanged)

## Type of change

[x] New feature (non-breaking change that adds functionality)

## Related issues

CP-3569

## Checklists

### Development

[x] Lint rules pass locally
[x] The code changed/added as part of this pull request has been covered with tests
[x] All tests related to the changed code pass in development

### Code review 

[ ] This pull request has a descriptive title and information useful to a reviewer
[ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
[ ] Changes have been reviewed by at least one other engineer
[ ] Issue from task tracker has a link to this pull request