### PR TITLE
fix: docker images are built on tag pushes, instead of releases

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,9 +1,10 @@
 name: Docker Build and Push
 
 on:
-  release:
-    types: [published]
   push:
+    # Run on version tags and main branch
+    tags:
+      - "v*"
     branches:
       - main
   pull_request:
@@ -27,13 +28,15 @@ jobs:
       - name: Set Docker Tag
         id: docker_tag
         run: |
-          if [[ ${{ github.event_name }} == 'release' ]]; then
-            echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
+          if [[ ${{ github.ref_type }} == 'tag' ]]; then
+            # For version tags (v0.1.0), use version number (0.1.0)
+            echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_ENV
           else
-            # For both main pushes and PRs, use branch name
+            # For PR, use PR branch name
             if [[ ${{ github.event_name }} == 'pull_request' ]]; then
               BRANCH=$GITHUB_HEAD_REF
             else
+              # For main branch push
               BRANCH=$GITHUB_REF_NAME
             fi
             # Sanitize branch name for docker tag
@@ -47,11 +50,12 @@ jobs:
           TELEMETRY_DATAPLANE_URL: ${{ vars.TELEMETRY_DATAPLANE_URL }}
         run: |
           make docker-build
-          if [[ ${{ github.event_name }} == 'release' ]]; then
-            # For releases, also tag and push latest
+          if [[ ${{ github.ref_type }} == 'tag' ]]; then
+            # For version tags, also push as latest
             docker tag rudderlabs/rudder-cli:$VERSION rudderlabs/rudder-cli:latest
             docker push rudderlabs/rudder-cli:$VERSION
             docker push rudderlabs/rudder-cli:latest
           else
+            # For branches and PRs just push with version tag
             docker push rudderlabs/rudder-cli:$VERSION
           fi


### PR DESCRIPTION
## Description of the change

> Description here

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
