### PR TITLE
fix: panic because of improper initialisation of state

### DIFF
--- a/cli/internal/providers/composite.go
+++ b/cli/internal/providers/composite.go
@@ -85,7 +85,7 @@ func (p *CompositeProvider) GetResourceGraph() (*resources.Graph, error) {
 }
 
 func (p *CompositeProvider) LoadState(ctx context.Context) (*state.State, error) {
-	var state *state.State = nil
+	var state *state.State = state.EmptyState()
 	for _, provider := range p.Providers {
 		s, err := provider.LoadState(ctx)
 		if err != nil {
@@ -97,7 +97,7 @@ func (p *CompositeProvider) LoadState(ctx context.Context) (*state.State, error)
 		} else {
 			state, err = state.Merge(s)
 			if err != nil {
-				return nil, fmt.Errorf("error merging provider states")
+				return nil, fmt.Errorf("error merging provider states: %s", err)
 			}
 		}
 	}

--- a/cli/internal/providers/datacatalog/provider.go
+++ b/cli/internal/providers/datacatalog/provider.go
@@ -41,9 +41,10 @@ func (p *Provider) GetSupportedKinds() []string {
 
 func (p *Provider) GetSupportedTypes() []string {
 	return []string{
-		"property",
-		"event",
-		"trackingplan",
+		provider.PropertyResourceType,
+		provider.EventResourceType,
+		provider.TrackingPlanResourceType,
+		provider.CustomTypeResourceType,
 	}
 }
 

--- a/cli/internal/providers/retl/provider.go
+++ b/cli/internal/providers/retl/provider.go
@@ -64,7 +64,7 @@ func (p *Provider) GetResourceGraph() (*resources.Graph, error) {
 }
 
 func (p *Provider) LoadState(ctx context.Context) (*state.State, error) {
-	return nil, nil
+	return state.EmptyState(), nil
 }
 
 func (p *Provider) PutResourceState(ctx context.Context, URN string, state *state.ResourceState) error {

--- a/cli/internal/syncer/state/serializer.go
+++ b/cli/internal/syncer/state/serializer.go
@@ -6,7 +6,6 @@ import (
 	"github.com/rudderlabs/rudder-iac/cli/internal/syncer/resources"
 )
 
-const LatestVersion = "1.0.0"
 const RudderRef = "$__rudderRef"
 
 func ToJSON(state *State) (json.RawMessage, error) {

--- a/cli/internal/syncer/state/state.go
+++ b/cli/internal/syncer/state/state.go
@@ -11,8 +11,11 @@ type State struct {
 	Resources map[string]*ResourceState `json:"resources"`
 }
 
+const LatestVersion = "1.0.0"
+
 func EmptyState() *State {
 	return &State{
+		Version:   LatestVersion,
 		Resources: make(map[string]*ResourceState),
 	}
 }


### PR DESCRIPTION
## Description of the change

The previous multi-provider PR had the following issues:
- State wasn't properly initialized while merging (no version was there)
- RETL provider's implementation was returning nil instead of EmptyState
- Data Catalog provider didn't specify the correct resource types as supported

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
