### PR TITLE
fix: 'custom-types' kind added to Data Catalog provider supported kinds

### DIFF
--- a/cli/internal/providers/datacatalog/provider.go
+++ b/cli/internal/providers/datacatalog/provider.go
@@ -36,7 +36,7 @@ func (p *Provider) LoadSpec(path string, s *specs.Spec) error {
 }
 
 func (p *Provider) GetSupportedKinds() []string {
-	return []string{"properties", "events", "tp"}
+	return []string{"properties", "events", "tp", "custom-types"}
 }
 
 func (p *Provider) GetSupportedTypes() []string {


### PR DESCRIPTION
## Description of the change

The 'custom-types' kind is added to the Data Catalog provider's list of supported kinds.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
