### PR TITLE
chore: setup e2e test infrastructure

### DIFF
--- a/.cursor/rules/code-styling.mdc
+++ b/.cursor/rules/code-styling.mdc
@@ -1,7 +1,7 @@
 ---
 description: 
 globs: 
-alwaysApply: false
+alwaysApply: true
 ---
 # Code Styling Conventions
 
@@ -10,12 +10,50 @@ alwaysApply: false
 ## Go Code Style
 
 - Follow standard Go formatting (use `gofmt` or `go fmt`)
-- Follow [Effective Go](mdc:https:/golang.org/doc/effective_go) guidelines
 - Keep functions small and focused on a single responsibility
 - Use meaningful variable and function names
 - Document public functions and packages with comments
-- Use `any` instead of `interface{}`
-- When writing comments for the changes, you should always comment on the `why` and `not the what`
+- **MUST** Use `any` instead of `interface{}`
+
+## Constants Over Magic Numbers
+- Replace hard-coded values with named constants
+- Use descriptive constant names that explain the value's purpose
+- Keep constants at the top of the file or in a dedicated constants file
+
+## Meaningful Names
+- Variables, functions, and classes should reveal their purpose
+- Names should explain why something exists and how it's used
+- Avoid abbreviations unless they're universally understood
+
+## Smart Comments
+- Don't comment on what the code does - make the code self-documenting
+- Use comments to explain why something is done a certain way
+- Document APIs, complex algorithms, and non-obvious side effects
+
+## Single Responsibility
+- Each function should do exactly one thing
+- Functions should be small and focused
+- If a function needs a comment to explain what it does, it should be split
+
+## DRY (Don't Repeat Yourself)
+- Extract repeated code into reusable functions
+- Share common logic through proper abstraction
+- Maintain single sources of truth
+
+## Clean Structure
+- Keep related code together
+- Organize code in a logical hierarchy
+- Use consistent file and folder naming conventions
+
+## Encapsulation
+- Hide implementation details
+- Expose clear interfaces
+- Move nested conditionals into well-named functions
+
+## Code Quality Maintenance
+- Refactor continuously
+- Fix technical debt early
+- Leave code cleaner than you found it
 
 ## Error Handling
 

--- a/.github/workflows/test-with-coverage.yml
+++ b/.github/workflows/test-with-coverage.yml
@@ -30,7 +30,7 @@ jobs:
         run: make test-all
 
       - name: upload cli logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: cli.log

--- a/.github/workflows/test-with-coverage.yml
+++ b/.github/workflows/test-with-coverage.yml
@@ -27,7 +27,14 @@ jobs:
         run: go version
 
       - name: running tests
-        run: make test
+        run: make test-all
+
+      - name: upload cli logs
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: cli.log
+          path: ~/.rudder/cli.log
 
       - name: upload coverage reports to Codecov
         uses: codecov/codecov-action@v5

--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,12 @@ clean:
 	rm -rf bin
 
 .PHONY: test
-test: ## Run all unit tests
-	go test --race --covermode=atomic --coverprofile=coverage.out ./...
+test: ## Run all unit tests (excluding e2e)
+	@go test --race --covermode=atomic --coverprofile=coverage.out $(shell go list ./... | grep -v /cli/tests)
+
+.PHONY: test-e2e
+test-e2e: ## Run end-to-end tests
+	go test --race --covermode=atomic --coverprofile=coverage-e2e.out ./cli/tests/...
 
 .PHONY: test-it
 test-it: ## Run all test, including integration tests
@@ -43,3 +47,6 @@ docker-build: ## Build Docker image
 		--build-arg TELEMETRY_DATAPLANE_URL=$(TELEMETRY_DATAPLANE_URL) \
 		-t $(REGISTRY)/$(IMAGE_NAME):$(VERSION) \
 		-f cli/Dockerfile .
+
+.PHONY: test-all
+test-all: test test-e2e ## Run all unit and end-to-end tests

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -75,6 +75,7 @@ func InitConfig(cfgFile string) {
 	viper.BindEnv("telemetry.writeKey", "RUDDERSTACK_CLI_TELEMETRY_WRITE_KEY")
 	viper.BindEnv("telemetry.dataplaneURL", "RUDDERSTACK_CLI_TELEMETRY_DATAPLANE_URL")
 	viper.BindEnv("telemetry.disabled", "RUDDERSTACK_CLI_TELEMETRY_DISABLED")
+	viper.BindEnv("debug", "RUDDERSTACK_CLI_DEBUG")
 
 	// load configuration
 	_ = viper.ReadInConfig()


### PR DESCRIPTION
## Description of the change

Setting up the infrastructure for e2e test with:
1. New `RUDDERSTACK_CLI_DEBUG` env variable to bind to debugging enablement
2. New `make test-e2e` and `make test-all` commands to check run the e2e test and all tests with `make test` for now running the fast tests.
3. Update the `github action` to upload the `~/.rudder/cli.log` artifact within the test run.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
