### PR TITLE
chore: auto-append /v2 to API URLs (RUD-2384)

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -24,7 +24,7 @@ type Client struct {
 	Connections  *connections
 }
 
-const BASE_URL_V2 = "https://api.rudderstack.com"
+const BASE_URL = "https://api.rudderstack.com"
 const API_VERSION = "v2"
 
 var (
@@ -35,7 +35,7 @@ var (
 
 func New(accessToken string, options ...Option) (*Client, error) {
 	client := &Client{
-		baseURL:     BASE_URL_V2,
+		baseURL:     BASE_URL,
 		httpClient:  &http.Client{},
 		accessToken: accessToken,
 		userAgent:   "rudder-api-go/1.0.0",

--- a/api/client/client.go
+++ b/api/client/client.go
@@ -24,7 +24,8 @@ type Client struct {
 	Connections  *connections
 }
 
-const BASE_URL_V2 = "https://api.rudderstack.com/v2"
+const BASE_URL_V2 = "https://api.rudderstack.com"
+const API_VERSION = "v2"
 
 var (
 	ErrEmptyAccessToken  = fmt.Errorf("access token cannot be empty")
@@ -59,10 +60,10 @@ func New(accessToken string, options ...Option) (*Client, error) {
 
 func (c *Client) URL(path string) string {
 	if len(path) == 0 {
-		return c.baseURL
+		return fmt.Sprintf("%s/%s", c.baseURL, API_VERSION)
 	}
 
-	return fmt.Sprintf("%s/%s", c.baseURL, strings.TrimPrefix(path, "/"))
+	return fmt.Sprintf("%s/%s/%s", c.baseURL, API_VERSION, strings.TrimPrefix(path, "/"))
 }
 
 func (c *Client) Do(ctx context.Context, method, path string, body io.Reader) ([]byte, error) {

--- a/api/client/client_integration_test.go
+++ b/api/client/client_integration_test.go
@@ -17,7 +17,7 @@ import (
 func newClient() (*client.Client, error) {
 	baseUrl := os.Getenv("RUDDERSTACK_API_HOST")
 	if baseUrl == "" {
-		baseUrl = "http://localhost:5555/v2"
+		baseUrl = "http://localhost:5555"
 	}
 	return client.New(os.Getenv("RUDDERSTACK_API_ACCESS_TOKEN"), client.WithBaseURL(baseUrl))
 }

--- a/api/client/options_test.go
+++ b/api/client/options_test.go
@@ -2,6 +2,7 @@ package client_test
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"testing"
 
@@ -14,7 +15,7 @@ import (
 func TestClientOptionBaseURL(t *testing.T) {
 	c, err := client.New("some-access-token", client.WithBaseURL("https://some-base-url"))
 	assert.NoError(t, err)
-	assert.Equal(t, "https://some-base-url/path", c.URL("path"))
+	assert.Equal(t, fmt.Sprintf("https://some-base-url/%s/path", client.API_VERSION), c.URL("path"))
 }
 
 func TestClientOptionBaseURLEmpty(t *testing.T) {
@@ -25,7 +26,7 @@ func TestClientOptionBaseURLEmpty(t *testing.T) {
 func TestClientOptionHTTPClient(t *testing.T) {
 	httpClient := testutils.NewMockHTTPClient(t, testutils.Call{
 		Validate: func(req *http.Request) bool {
-			return testutils.ValidateRequest(t, req, "GET", "https://example.com/path", "")
+			return testutils.ValidateRequest(t, req, "GET", fmt.Sprintf("https://example.com/%s/path", client.API_VERSION), "")
 		},
 		ResponseStatus: 200,
 		ResponseBody:   "test",

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -65,7 +65,7 @@ func InitConfig(cfgFile string) {
 	// set defaults
 	viper.SetDefault("debug", false)
 	viper.SetDefault("verbose", false)
-	viper.SetDefault("apiURL", client.BASE_URL_V2)
+	viper.SetDefault("apiURL", client.BASE_URL)
 	viper.SetDefault("telemetry.disabled", false)
 	viper.SetDefault("telemetry.writeKey", TelemetryWriteKey)
 	viper.SetDefault("telemetry.dataplaneURL", TelemetryDataplaneURL)


### PR DESCRIPTION
Fixes RUD-2384 - Users can now set RUDDERSTACK_API_URL without /v2 suffix. API client automatically appends /v2 to all endpoints. Resolves: RUD-2384