### PR TITLE
feat: introducing import command for retl sources 

### DIFF
--- a/cli/internal/cmd/import/import.go
+++ b/cli/internal/cmd/import/import.go
@@ -1,0 +1,21 @@
+package importcmd
+
+import (
+	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/spf13/cobra"
+)
+
+func NewCmdImport() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "import <command>",
+		Short: "Import remote resources to local configuration",
+		Long:  "Import remote resources from various providers into local YAML configuration files",
+		Example: heredoc.Doc(`
+			$ rudder-cli import retl-source --local-id my-model --remote-id abc123 --workspace-id ws456
+		`),
+	}
+
+	cmd.AddCommand(NewCmdRetlSource())
+
+	return cmd
+}

--- a/cli/internal/cmd/import/retl-source.go
+++ b/cli/internal/cmd/import/retl-source.go
@@ -1,0 +1,157 @@
+package importcmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/rudderlabs/rudder-iac/cli/internal/app"
+	"github.com/rudderlabs/rudder-iac/cli/internal/cmd/telemetry"
+	"github.com/rudderlabs/rudder-iac/cli/internal/importutils"
+	"github.com/rudderlabs/rudder-iac/cli/internal/logger"
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/retl"
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/retl/sqlmodel"
+	"github.com/rudderlabs/rudder-iac/cli/internal/ui"
+	"github.com/spf13/cobra"
+)
+
+var (
+	retlSourceImportLog = logger.New("import", logger.Attr{
+		Key:   "cmd",
+		Value: "retl-source",
+	})
+)
+
+func NewCmdRetlSource() *cobra.Command {
+	var (
+		localID     string
+		remoteID    string
+		workspaceID string
+		location    string
+		sqlLocation string
+		err         error
+	)
+
+	cmd := &cobra.Command{
+		Use:   "retl-source",
+		Short: "Import remote RETL SQL Model to local configuration",
+		Long: heredoc.Doc(`
+			Import a remote RETL SQL Model source into a local YAML configuration file.
+			This command fetches the remote SQL Model using the provided remote ID,
+			creates a local YAML configuration with the specified local ID, and embeds
+			import metadata for tracking.
+			
+			Optionally, you can specify a separate location for SQL files using --sql-location.
+			When provided, the SQL content will be saved as a separate .sql file and the
+			YAML configuration will reference it using the 'file' field instead of inline 'sql'.
+		`),
+		Example: heredoc.Doc(`
+			$ rudder-cli import retl-source --local-id my-model --remote-id abc123 --workspace-id ws456
+			$ rudder-cli import retl-source -i analytics-model -r def789 -w ws123 -l ./models
+			$ rudder-cli import retl-source --local-id analytics-model --remote-id def789 --workspace-id ws123 --location ./models --sql-location ./sql
+			$ rudder-cli import retl-source -i analytics-model -r def789 -w ws123 -l ./models -s ./sql
+		`),
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			// Validate required flags
+			if localID == "" {
+				return fmt.Errorf("--local-id is required")
+			}
+			if remoteID == "" {
+				return fmt.Errorf("--remote-id is required")
+			}
+			if workspaceID == "" {
+				return fmt.Errorf("--workspace-id is required")
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			retlSourceImportLog.Debug("import retl-source", "localID", localID, "remoteID", remoteID, "workspaceID", workspaceID, "location", location, "sqlLocation", sqlLocation)
+			retlSourceImportLog.Debug("importing remote RETL SQL Model to local configuration")
+
+			defer func() {
+				telemetry.TrackCommand("import retl-source", err, []telemetry.KV{
+					{K: "localID", V: localID},
+					{K: "remoteID", V: remoteID},
+					{K: "workspaceID", V: workspaceID},
+					{K: "location", V: location},
+					{K: "sqlLocation", V: sqlLocation},
+				}...)
+			}()
+
+			// Get dependencies
+			deps, err := app.NewDeps()
+			if err != nil {
+				return fmt.Errorf("initialising dependencies: %w", err)
+			}
+
+			// Cast to RETL provider to access Import method
+			retlProvider, ok := deps.Providers().RETL.(*retl.Provider)
+			if !ok {
+				return fmt.Errorf("failed to cast RETL provider")
+			}
+
+			resources, err := retlProvider.Import(cmd.Context(), sqlmodel.ResourceType, importutils.ImportArgs{
+				RemoteID:    remoteID,
+				LocalID:     localID,
+				WorkspaceID: workspaceID,
+			})
+			if err != nil {
+				return fmt.Errorf("importing RETL SQL Model: %w", err)
+			}
+			// write the sql to the sqlLocation
+			if sqlLocation != "" {
+				for _, resource := range resources {
+					resourceData := *resource.ResourceData
+					err = writeSQLToFile(resourceData, sqlLocation, localID)
+					if err != nil {
+						return fmt.Errorf("writing SQL file: %w", err)
+					}
+					resourceData[sqlmodel.FileKey] = fmt.Sprintf("%s/%s.sql", sqlLocation, localID)
+					delete(resourceData, sqlmodel.SQLKey)
+				}
+			}
+
+			// Perform the import
+			err = importutils.Import(cmd.Context(), sqlmodel.ResourceType, resources, location)
+			if err != nil {
+				return fmt.Errorf("importing RETL SQL Model: %w", err)
+			}
+
+			retlSourceImportLog.Info("Successfully imported RETL SQL Model", "localID", localID, "remoteID", remoteID)
+			fmt.Printf("%s Successfully imported RETL SQL Model '%s' from remote ID '%s'\n",
+				ui.Color("✓", ui.Green), localID, remoteID)
+			fmt.Printf("Configuration saved to: %s/%s.yaml\n", location, localID)
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&localID, "local-id", "i", "", "Local identifier for the imported SQL Model (required)")
+	cmd.Flags().StringVarP(&remoteID, "remote-id", "r", "", "Remote RETL source ID to import (required)")
+	cmd.Flags().StringVarP(&workspaceID, "workspace-id", "w", "", "Workspace ID for the import metadata (required)")
+	cmd.Flags().StringVarP(&location, "location", "l", ".", "Directory where to save the YAML configuration file (default: current directory)")
+	cmd.Flags().StringVarP(&sqlLocation, "sql-location", "s", "", "Directory where to save SQL files separately (optional, if not provided SQL will be inline in YAML)")
+
+	// Mark required flags
+	cmd.MarkFlagRequired("local-id")
+	cmd.MarkFlagRequired("remote-id")
+	cmd.MarkFlagRequired("workspace-id")
+
+	return cmd
+}
+
+func writeSQLToFile(resourceData map[string]interface{}, sqlLocation string, localID string) error {
+	if _, err := os.Stat(sqlLocation); os.IsNotExist(err) {
+		return fmt.Errorf("SQL directory does not exist: %s", sqlLocation)
+	}
+
+	sql, ok := resourceData[sqlmodel.SQLKey].(string)
+	if !ok {
+		return fmt.Errorf("SQL key not found in resource data")
+	}
+	err := os.WriteFile(fmt.Sprintf("%s/%s.sql", sqlLocation, localID), []byte(sql), 0644)
+	if err != nil {
+		return fmt.Errorf("writing SQL file: %w", err)
+	}
+	return nil
+}

--- a/cli/internal/cmd/root.go
+++ b/cli/internal/cmd/root.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/kyokomi/emoji/v2"
 	"github.com/rudderlabs/rudder-iac/cli/internal/app"
+	importcmd "github.com/rudderlabs/rudder-iac/cli/internal/cmd/import"
 	"github.com/rudderlabs/rudder-iac/cli/internal/cmd/project/apply"
 	"github.com/rudderlabs/rudder-iac/cli/internal/cmd/project/destroy"
 	"github.com/rudderlabs/rudder-iac/cli/internal/cmd/project/validate"
@@ -67,8 +68,9 @@ func init() {
 	rootCmd.AddCommand(debugCmd)
 	rootCmd.AddCommand(trackingplan.NewCmdTrackingPlan())
 	rootCmd.AddCommand(telemetryCmd.NewCmdTelemetry())
-  rootCmd.AddCommand(workspace.NewCmdWorkspace())
-  
+	rootCmd.AddCommand(workspace.NewCmdWorkspace())
+	rootCmd.AddCommand(importcmd.NewCmdImport())
+
 	rootCmd.AddCommand(apply.NewCmdApply())
 	rootCmd.AddCommand(validate.NewCmdValidate())
 	rootCmd.AddCommand(destroy.NewCmdDestroy())

--- a/cli/internal/importutils/import.go
+++ b/cli/internal/importutils/import.go
@@ -1,0 +1,59 @@
+package importutils
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/rudderlabs/rudder-iac/cli/internal/project/specs"
+	"github.com/rudderlabs/rudder-iac/cli/internal/syncer/resources"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	CLIVersion = "rudder/v0.1"
+)
+
+type ImportData struct {
+	ResourceData *resources.ResourceData
+	Metadata     map[string]interface{}
+}
+
+type ImportProvider interface {
+	Import(ctx context.Context, resourceType string, args ImportArgs) ([]ImportData, error)
+}
+
+type ImportArgs struct {
+	RemoteID    string
+	LocalID     string
+	WorkspaceID string
+}
+
+func Import(ctx context.Context, resourceType string, resources []ImportData, location string) error {
+	for _, resourceData := range resources {
+		spec := &specs.Spec{
+			Version:  CLIVersion,
+			Kind:     resourceType,
+			Metadata: resourceData.Metadata,
+			Spec:     *resourceData.ResourceData,
+		}
+
+		name, ok := resourceData.Metadata["name"].(string)
+		if !ok {
+			return fmt.Errorf("name is required in metadata")
+		}
+		// write spec to file
+		specYAML, err := yaml.Marshal(spec)
+		if err != nil {
+			return err
+		}
+		specPath := filepath.Join(location, fmt.Sprintf("%s.yaml", name))
+		err = os.WriteFile(specPath, specYAML, 0644)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/cli/internal/providers/retl/handler.go
+++ b/cli/internal/providers/retl/handler.go
@@ -3,6 +3,7 @@ package retl
 import (
 	"context"
 
+	"github.com/rudderlabs/rudder-iac/cli/internal/importutils"
 	"github.com/rudderlabs/rudder-iac/cli/internal/project/specs"
 	"github.com/rudderlabs/rudder-iac/cli/internal/syncer/resources"
 )
@@ -44,4 +45,10 @@ type resourceHandler interface {
 	// The returned resources will be added to the resource graph for
 	// dependency resolution and state management.
 	List(ctx context.Context) ([]resources.ResourceData, error)
+
+	// Import imports a single remote resource with local ID mapping.
+	// This method fetches a remote resource by remoteID and prepares it for local import
+	// with the specified localID. The workspaceID is used for proper resource scoping.
+	// Returns the resource data with import metadata or an error if import fails.
+	Import(ctx context.Context, args importutils.ImportArgs) ([]importutils.ImportData, error)
 }

--- a/cli/internal/providers/retl/provider.go
+++ b/cli/internal/providers/retl/provider.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	retlClient "github.com/rudderlabs/rudder-iac/api/client/retl"
+	"github.com/rudderlabs/rudder-iac/cli/internal/importutils"
 	"github.com/rudderlabs/rudder-iac/cli/internal/lister"
 	"github.com/rudderlabs/rudder-iac/cli/internal/project/specs"
 	"github.com/rudderlabs/rudder-iac/cli/internal/providers/retl/sqlmodel"
@@ -181,4 +182,19 @@ func (p *Provider) List(ctx context.Context, resourceType string, filters lister
 		return nil, fmt.Errorf("no handler for resource type: %s", resourceType)
 	}
 	return handler.List(ctx)
+}
+
+// Import imports a single remote RETL resource with local ID mapping
+func (p *Provider) Import(ctx context.Context, resourceType string, args importutils.ImportArgs) ([]importutils.ImportData, error) {
+	// Only support SQL models for import in this phase
+	if resourceType != sqlmodel.ResourceType {
+		return nil, fmt.Errorf("import is only supported for SQL models, got: %s", resourceType)
+	}
+
+	handler, ok := p.handlers[resourceType]
+	if !ok {
+		return nil, fmt.Errorf("no handler for resource type: %s", resourceType)
+	}
+
+	return handler.Import(ctx, args)
 }

--- a/cli/internal/providers/retl/provider_test.go
+++ b/cli/internal/providers/retl/provider_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	retlClient "github.com/rudderlabs/rudder-iac/api/client/retl"
+	"github.com/rudderlabs/rudder-iac/cli/internal/importutils"
 	"github.com/rudderlabs/rudder-iac/cli/internal/project/specs"
 	"github.com/rudderlabs/rudder-iac/cli/internal/providers/retl"
 	"github.com/rudderlabs/rudder-iac/cli/internal/providers/retl/sqlmodel"
@@ -114,6 +115,22 @@ func newDefaultMockClient() *mockRETLStore {
 		},
 		deleteRetlSourceFunc: func(ctx context.Context, id string) error {
 			return nil
+		},
+		getRetlSourceFunc: func(ctx context.Context, id string) (*retlClient.RETLSource, error) {
+
+			if id == "remote-id-not-found" {
+				return nil, fmt.Errorf("retl source not found")
+			}
+
+			return &retlClient.RETLSource{
+				ID:                   "remote-id",
+				Name:                 "Imported Model",
+				SourceType:           retlClient.ModelSourceType,
+				SourceDefinitionName: "postgres",
+				AccountID:            "acc123",
+				IsEnabled:            true,
+				Config:               retlClient.RETLSQLModelConfig{Description: "desc", PrimaryKey: "id", Sql: "SELECT * FROM t"},
+			}, nil
 		},
 	}
 }
@@ -516,6 +533,50 @@ func TestProvider(t *testing.T) {
 				}
 			})
 		}
+	})
+
+	t.Run("Import", func(t *testing.T) {
+		t.Parallel()
+
+		t.Run("Success", func(t *testing.T) {
+			provider := retl.New(newDefaultMockClient())
+
+			args := importutils.ImportArgs{RemoteID: "remote-id", LocalID: "local-id", WorkspaceID: "ws-1"}
+			results, err := provider.Import(context.Background(), sqlmodel.ResourceType, args)
+			assert.NoError(t, err)
+			assert.Len(t, results, 1)
+			imported := results[0]
+			assert.Equal(t, "local-id", (*imported.ResourceData)[sqlmodel.IDKey])
+			assert.Equal(t, "Imported Model", (*imported.ResourceData)[sqlmodel.DisplayNameKey])
+			assert.Equal(t, "desc", (*imported.ResourceData)[sqlmodel.DescriptionKey])
+			assert.Equal(t, "id", (*imported.ResourceData)[sqlmodel.PrimaryKeyKey])
+			assert.Equal(t, "SELECT * FROM t", (*imported.ResourceData)[sqlmodel.SQLKey])
+			assert.Equal(t, "postgres", (*imported.ResourceData)[sqlmodel.SourceDefinitionKey])
+			assert.Equal(t, true, (*imported.ResourceData)[sqlmodel.EnabledKey])
+			assert.Equal(t, "acc123", (*imported.ResourceData)[sqlmodel.AccountIDKey])
+			assert.Equal(t, "local-id", imported.Metadata["name"])
+			assert.Equal(t, "ws-1", imported.Metadata["workspace"])
+		})
+
+		t.Run("Unsupported resource type", func(t *testing.T) {
+			mockClient := newDefaultMockClient()
+			provider := retl.New(mockClient)
+			args := importutils.ImportArgs{RemoteID: "remote-id", LocalID: "local-id", WorkspaceID: "ws-1"}
+			results, err := provider.Import(context.Background(), "unsupported-type", args)
+			assert.Error(t, err)
+			assert.Nil(t, results)
+			assert.Contains(t, err.Error(), "import is only supported for SQL models")
+		})
+
+		t.Run("Handler error", func(t *testing.T) {
+			mockClient := newDefaultMockClient()
+			provider := retl.New(mockClient)
+			args := importutils.ImportArgs{RemoteID: "remote-id-not-found", LocalID: "local-id", WorkspaceID: "ws-1"}
+			results, err := provider.Import(context.Background(), sqlmodel.ResourceType, args)
+			assert.Error(t, err)
+			assert.Nil(t, results)
+			assert.Contains(t, err.Error(), "getting RETL source for import")
+		})
 	})
 }
 

--- a/cli/internal/providers/retl/sqlmodel/handler_test.go
+++ b/cli/internal/providers/retl/sqlmodel/handler_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	retlClient "github.com/rudderlabs/rudder-iac/api/client/retl"
+	"github.com/rudderlabs/rudder-iac/cli/internal/importutils"
 	"github.com/rudderlabs/rudder-iac/cli/internal/project/specs"
 	"github.com/rudderlabs/rudder-iac/cli/internal/providers/retl/sqlmodel"
 	"github.com/rudderlabs/rudder-iac/cli/internal/syncer/resources"
@@ -30,6 +31,7 @@ type mockRETLClient struct {
 	createRetlSourceFunc func(ctx context.Context, req *retlClient.RETLSourceCreateRequest) (*retlClient.RETLSource, error)
 	updateRetlSourceFunc func(ctx context.Context, sourceID string, req *retlClient.RETLSourceUpdateRequest) (*retlClient.RETLSource, error)
 	listRetlSourcesFunc  func(ctx context.Context) (*retlClient.RETLSources, error)
+	getRetlSourceFunc    func(ctx context.Context, sourceID string) (*retlClient.RETLSource, error) // <-- add this
 }
 
 func (m *mockRETLClient) CreateRetlSource(ctx context.Context, req *retlClient.RETLSourceCreateRequest) (*retlClient.RETLSource, error) {
@@ -51,6 +53,9 @@ func (m *mockRETLClient) CreateRetlSource(ctx context.Context, req *retlClient.R
 }
 
 func (m *mockRETLClient) GetRetlSource(ctx context.Context, sourceID string) (*retlClient.RETLSource, error) {
+	if m.getRetlSourceFunc != nil {
+		return m.getRetlSourceFunc(ctx, sourceID)
+	}
 	return &retlClient.RETLSource{
 		ID:                   sourceID,
 		Name:                 "Test Model",
@@ -1043,5 +1048,82 @@ func TestSQLModelHandler(t *testing.T) {
 				}
 			})
 		}
+	})
+
+	t.Run("Import", func(t *testing.T) {
+		t.Parallel()
+
+		t.Run("Success", func(t *testing.T) {
+			mockClient := &mockRETLClient{}
+			handler := sqlmodel.NewHandler(mockClient)
+
+			// In Import tests, set mockClient.getRetlSourceFunc instead of mockClient.GetRetlSource
+			mockClient.getRetlSourceFunc = func(ctx context.Context, sourceID string) (*retlClient.RETLSource, error) {
+				return &retlClient.RETLSource{
+					ID:                   "remote-id",
+					Name:                 "Imported Model",
+					Config:               retlClient.RETLSQLModelConfig{Description: "desc", PrimaryKey: "id", Sql: "SELECT * FROM t"},
+					SourceType:           retlClient.ModelSourceType,
+					SourceDefinitionName: "postgres",
+					AccountID:            "acc123",
+					IsEnabled:            true,
+				}, nil
+			}
+
+			args := importutils.ImportArgs{
+				RemoteID:    "remote-id",
+				LocalID:     "local-id",
+				WorkspaceID: "ws-1",
+			}
+			results, err := handler.Import(context.Background(), args)
+			assert.NoError(t, err)
+			assert.Len(t, results, 1)
+			imported := results[0]
+			assert.Equal(t, "local-id", (*imported.ResourceData)[sqlmodel.IDKey])
+			assert.Equal(t, "Imported Model", (*imported.ResourceData)[sqlmodel.DisplayNameKey])
+			assert.Equal(t, "desc", (*imported.ResourceData)[sqlmodel.DescriptionKey])
+			assert.Equal(t, "id", (*imported.ResourceData)[sqlmodel.PrimaryKeyKey])
+			assert.Equal(t, "SELECT * FROM t", (*imported.ResourceData)[sqlmodel.SQLKey])
+			assert.Equal(t, "postgres", (*imported.ResourceData)[sqlmodel.SourceDefinitionKey])
+			assert.Equal(t, true, (*imported.ResourceData)[sqlmodel.EnabledKey])
+			assert.Equal(t, "acc123", (*imported.ResourceData)[sqlmodel.AccountIDKey])
+			assert.Equal(t, "local-id", imported.Metadata["name"])
+			assert.Equal(t, "ws-1", imported.Metadata["workspace"])
+		})
+
+		t.Run("Non-SQL-model type", func(t *testing.T) {
+			mockClient := &mockRETLClient{}
+			handler := sqlmodel.NewHandler(mockClient)
+
+			// Non-SQL-model type
+			mockClient.getRetlSourceFunc = func(ctx context.Context, sourceID string) (*retlClient.RETLSource, error) {
+				return &retlClient.RETLSource{
+					ID:         "remote-id",
+					SourceType: "not-model",
+				}, nil
+			}
+
+			args := importutils.ImportArgs{RemoteID: "remote-id", LocalID: "local-id", WorkspaceID: "ws-1"}
+			results, err := handler.Import(context.Background(), args)
+			assert.Error(t, err)
+			assert.Nil(t, results)
+			assert.Contains(t, err.Error(), "is not a SQL model")
+		})
+
+		t.Run("API error", func(t *testing.T) {
+			mockClient := &mockRETLClient{}
+			handler := sqlmodel.NewHandler(mockClient)
+
+			// API error
+			mockClient.getRetlSourceFunc = func(ctx context.Context, sourceID string) (*retlClient.RETLSource, error) {
+				return nil, fmt.Errorf("api error")
+			}
+
+			args := importutils.ImportArgs{RemoteID: "remote-id", LocalID: "local-id", WorkspaceID: "ws-1"}
+			results, err := handler.Import(context.Background(), args)
+			assert.Error(t, err)
+			assert.Nil(t, results)
+			assert.Contains(t, err.Error(), "getting RETL source for import")
+		})
 	})
 }

--- a/cli/internal/providers/retl/sqlmodel/model.go
+++ b/cli/internal/providers/retl/sqlmodel/model.go
@@ -18,6 +18,7 @@ const (
 	SourceDefinitionKey = "source_definition"
 	EnabledKey          = "enabled"
 	SQLKey              = "sql"
+	FileKey             = "file"
 	IDKey               = "id"
 	SourceTypeKey       = "source_type"
 	CreatedAtKey        = "createdAt"


### PR DESCRIPTION
This commit introduces a new command to import remote RETL SQL models into local configuration. The command allows users to specify local and remote IDs, workspace ID, and optional SQL file locations. It includes validation for required flags and integrates with the existing RETL provider to fetch and save the model data. Additionally, the implementation includes necessary utility functions for handling the import process and writing SQL files if specified.

## Description of the change

> Description here

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
