### PR TITLE
fix: remove unnecessary UnmarshalJSON when handling variantcase and updated the match value validation

### DIFF
--- a/cli/internal/providers/datacatalog/localcatalog/variants.go
+++ b/cli/internal/providers/datacatalog/localcatalog/variants.go
@@ -1,10 +1,5 @@
 package localcatalog
 
-import (
-	"encoding/json"
-	"math"
-)
-
 // Variants represents a slice of conditional variants for local YAML configuration parsing.
 // It provides the foundational data structure for conditional validation of properties
 type Variants []Variant
@@ -26,37 +21,4 @@ type VariantCase struct {
 type PropertyReference struct {
 	Ref      string `json:"$ref"`
 	Required bool   `json:"required"`
-}
-
-func (vc *VariantCase) UnmarshalJSON(b []byte) error {
-	type alias struct {
-		DisplayName string              `json:"display_name"`
-		Match       []any               `json:"match"`
-		Description string              `json:"description"`
-		Properties  []PropertyReference `json:"properties"`
-	}
-	var tmp alias
-	if err := json.Unmarshal(b, &tmp); err != nil {
-		return err
-	}
-
-	normalized := make([]any, len(tmp.Match))
-	for i, v := range tmp.Match {
-		switch n := v.(type) {
-		case float64:
-			if n == math.Trunc(n) {
-				normalized[i] = int(n)
-			} else {
-				normalized[i] = n
-			}
-		default:
-			normalized[i] = v
-		}
-	}
-
-	vc.DisplayName = tmp.DisplayName
-	vc.Match = normalized
-	vc.Description = tmp.Description
-	vc.Properties = tmp.Properties
-	return nil
 }

--- a/cli/internal/providers/datacatalog/validate/required_keys.go
+++ b/cli/internal/providers/datacatalog/validate/required_keys.go
@@ -2,6 +2,7 @@ package validate
 
 import (
 	"fmt"
+	"math"
 	"regexp"
 	"slices"
 	"strings"
@@ -529,10 +530,16 @@ func (rk *RequiredKeysValidator) validateVariantsRequiredKeys(variants catalog.V
 			}
 
 			for k, matchValue := range variantCase.Match {
-				switch matchValue.(type) {
-				case string, bool,
-					int, int8, int16, int32, int64,
-					uint, uint8, uint16, uint32, uint64:
+				switch matchValue := matchValue.(type) {
+				case string, bool, int:
+				case float64:
+					if matchValue != math.Trunc(matchValue) {
+						errors = append(errors, ValidationError{
+							error:     fmt.Errorf("match value at index %d must be an integer", k),
+							Reference: caseReference,
+						})
+					}
+
 				default:
 					errors = append(errors, ValidationError{
 						error:     fmt.Errorf("match value at index %d must be string, bool or integer type (got: %T)", k, matchValue),

--- a/cli/internal/providers/datacatalog/validate/required_keys_test.go
+++ b/cli/internal/providers/datacatalog/validate/required_keys_test.go
@@ -756,7 +756,7 @@ func TestVariantsValidation(t *testing.T) {
 										Cases: []catalog.VariantCase{
 											{
 												DisplayName: "Admin User",
-												Match:       []any{123, true, "admin"},
+												Match:       []any{123, 123.0, true, "admin"},
 												Properties: []catalog.PropertyReference{
 													{Ref: "#/properties/test-group/admin_level", Required: true},
 												},


### PR DESCRIPTION
## Description of the change

Unmarshalling the variantcase in a custom way, made sure that the integer value can be properly handled in the match. The consequence of that handling was, we started to get unintentional diffs even when there was no change in the catalog.

The main reason was the type of match value we applied was `int` due to custom unmarshal JSON while the value read from the state is still `float64` which is default type of reading numbers by Go. This generates unnecessary diffs everytime without any changes.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
