### PR TITLE
feat: implement custom differ for custom types to prevent unnecessary updates

### DIFF
--- a/cli/internal/providers/datacatalog/state/customtype_test.go
+++ b/cli/internal/providers/datacatalog/state/customtype_test.go
@@ -158,3 +158,448 @@ func TestFromCatalogCustomType(t *testing.T) {
 	assert.Equal(t, "id", propRef2.Property)
 	assert.False(t, args.Properties[1].Required)
 }
+
+func TestCustomTypePropertyDiff(t *testing.T) {
+	tests := []struct {
+		name     string
+		prop1    *CustomTypeProperty
+		prop2    *CustomTypeProperty
+		expected bool
+	}{
+		{
+			name: "identical properties",
+			prop1: &CustomTypeProperty{
+				RefToID:  "ref1",
+				ID:       "id1",
+				Required: true,
+			},
+			prop2: &CustomTypeProperty{
+				RefToID:  "ref1",
+				ID:       "id1",
+				Required: true,
+			},
+			expected: false,
+		},
+		{
+			name: "different ID",
+			prop1: &CustomTypeProperty{
+				RefToID:  "ref1",
+				ID:       "id1",
+				Required: true,
+			},
+			prop2: &CustomTypeProperty{
+				RefToID:  "ref1",
+				ID:       "id2",
+				Required: true,
+			},
+			expected: true,
+		},
+		{
+			name: "different Required",
+			prop1: &CustomTypeProperty{
+				RefToID:  "ref1",
+				ID:       "id1",
+				Required: true,
+			},
+			prop2: &CustomTypeProperty{
+				RefToID:  "ref1",
+				ID:       "id1",
+				Required: false,
+			},
+			expected: true,
+		},
+		{
+			name: "different RefToID",
+			prop1: &CustomTypeProperty{
+				RefToID:  "ref1",
+				ID:       "id1",
+				Required: true,
+			},
+			prop2: &CustomTypeProperty{
+				RefToID:  "ref2",
+				ID:       "id1",
+				Required: true,
+			},
+			expected: true,
+		},
+		{
+			name: "complex RefToID objects",
+			prop1: &CustomTypeProperty{
+				RefToID: resources.PropertyRef{
+					URN:      "property:prop1",
+					Property: "id",
+				},
+				ID:       "id1",
+				Required: true,
+			},
+			prop2: &CustomTypeProperty{
+				RefToID: resources.PropertyRef{
+					URN:      "property:prop2",
+					Property: "id",
+				},
+				ID:       "id1",
+				Required: true,
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.prop1.Diff(tt.prop2)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestCustomTypeArgs_Diff(t *testing.T) {
+	baseArgs := &CustomTypeArgs{
+		LocalID:     "TestType",
+		Name:        "Test Type",
+		Description: "Test description",
+		Type:        "string",
+		Config: map[string]any{
+			"format": "email",
+			"length": 100,
+		},
+		Properties: []*CustomTypeProperty{
+			{
+				RefToID:  "ref1",
+				ID:       "prop1",
+				Required: true,
+			},
+		},
+		Variants: Variants{
+			{
+				Type:          "string",
+				Discriminator: "type",
+				Cases:         []VariantCase{},
+				Default:       []PropertyReference{},
+			},
+		},
+	}
+
+	tests := []struct {
+		name     string
+		args1    *CustomTypeArgs
+		args2    *CustomTypeArgs
+		expected bool
+	}{
+		{
+			name:     "identical args",
+			args1:    baseArgs,
+			args2:    baseArgs,
+			expected: false,
+		},
+		{
+			name:  "different LocalID",
+			args1: baseArgs,
+			args2: &CustomTypeArgs{
+				LocalID:     "DifferentType",
+				Name:        "Test Type",
+				Description: "Test description",
+				Type:        "string",
+				Config: map[string]any{
+					"format": "email",
+					"length": 100,
+				},
+				Properties: []*CustomTypeProperty{
+					{
+						RefToID:  "ref1",
+						ID:       "prop1",
+						Required: true,
+					},
+				},
+				Variants: Variants{
+					{
+						Type:          "string",
+						Discriminator: "type",
+						Cases:         []VariantCase{},
+						Default:       []PropertyReference{},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name:  "different Name",
+			args1: baseArgs,
+			args2: &CustomTypeArgs{
+				LocalID:     "TestType",
+				Name:        "Different Name",
+				Description: "Test description",
+				Type:        "string",
+				Config: map[string]any{
+					"format": "email",
+					"length": 100,
+				},
+				Properties: []*CustomTypeProperty{
+					{
+						RefToID:  "ref1",
+						ID:       "prop1",
+						Required: true,
+					},
+				},
+				Variants: Variants{
+					{
+						Type:          "string",
+						Discriminator: "type",
+						Cases:         []VariantCase{},
+						Default:       []PropertyReference{},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name:  "different Description",
+			args1: baseArgs,
+			args2: &CustomTypeArgs{
+				LocalID:     "TestType",
+				Name:        "Test Type",
+				Description: "Different description",
+				Type:        "string",
+				Config: map[string]any{
+					"format": "email",
+					"length": 100,
+				},
+				Properties: []*CustomTypeProperty{
+					{
+						RefToID:  "ref1",
+						ID:       "prop1",
+						Required: true,
+					},
+				},
+				Variants: Variants{
+					{
+						Type:          "string",
+						Discriminator: "type",
+						Cases:         []VariantCase{},
+						Default:       []PropertyReference{},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name:  "different Type",
+			args1: baseArgs,
+			args2: &CustomTypeArgs{
+				LocalID:     "TestType",
+				Name:        "Test Type",
+				Description: "Test description",
+				Type:        "number",
+				Config: map[string]any{
+					"format": "email",
+					"length": 100,
+				},
+				Properties: []*CustomTypeProperty{
+					{
+						RefToID:  "ref1",
+						ID:       "prop1",
+						Required: true,
+					},
+				},
+				Variants: Variants{
+					{
+						Type:          "string",
+						Discriminator: "type",
+						Cases:         []VariantCase{},
+						Default:       []PropertyReference{},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name:  "different Config",
+			args1: baseArgs,
+			args2: &CustomTypeArgs{
+				LocalID:     "TestType",
+				Name:        "Test Type",
+				Description: "Test description",
+				Type:        "string",
+				Config: map[string]any{
+					"format": "url",
+					"length": 200,
+				},
+				Properties: []*CustomTypeProperty{
+					{
+						RefToID:  "ref1",
+						ID:       "prop1",
+						Required: true,
+					},
+				},
+				Variants: Variants{
+					{
+						Type:          "string",
+						Discriminator: "type",
+						Cases:         []VariantCase{},
+						Default:       []PropertyReference{},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name:  "different Properties length",
+			args1: baseArgs,
+			args2: &CustomTypeArgs{
+				LocalID:     "TestType",
+				Name:        "Test Type",
+				Description: "Test description",
+				Type:        "string",
+				Config: map[string]any{
+					"format": "email",
+					"length": 100,
+				},
+				Properties: []*CustomTypeProperty{
+					{
+						RefToID:  "ref1",
+						ID:       "prop1",
+						Required: true,
+					},
+					{
+						RefToID:  "ref2",
+						ID:       "prop2",
+						Required: false,
+					},
+				},
+				Variants: Variants{
+					{
+						Type:          "string",
+						Discriminator: "type",
+						Cases:         []VariantCase{},
+						Default:       []PropertyReference{},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name:  "property not found",
+			args1: baseArgs,
+			args2: &CustomTypeArgs{
+				LocalID:     "TestType",
+				Name:        "Test Type",
+				Description: "Test description",
+				Type:        "string",
+				Config: map[string]any{
+					"format": "email",
+					"length": 100,
+				},
+				Properties: []*CustomTypeProperty{
+					{
+						RefToID:  "ref1",
+						ID:       "different_prop",
+						Required: true,
+					},
+				},
+				Variants: Variants{
+					{
+						Type:          "string",
+						Discriminator: "type",
+						Cases:         []VariantCase{},
+						Default:       []PropertyReference{},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name:  "property differs",
+			args1: baseArgs,
+			args2: &CustomTypeArgs{
+				LocalID:     "TestType",
+				Name:        "Test Type",
+				Description: "Test description",
+				Type:        "string",
+				Config: map[string]any{
+					"format": "email",
+					"length": 100,
+				},
+				Properties: []*CustomTypeProperty{
+					{
+						RefToID:  "ref1",
+						ID:       "prop1",
+						Required: false, // Different from baseArgs
+					},
+				},
+				Variants: Variants{
+					{
+						Type:          "string",
+						Discriminator: "type",
+						Cases:         []VariantCase{},
+						Default:       []PropertyReference{},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name:  "different Variants",
+			args1: baseArgs,
+			args2: &CustomTypeArgs{
+				LocalID:     "TestType",
+				Name:        "Test Type",
+				Description: "Test description",
+				Type:        "string",
+				Config: map[string]any{
+					"format": "email",
+					"length": 100,
+				},
+				Properties: []*CustomTypeProperty{
+					{
+						RefToID:  "ref1",
+						ID:       "prop1",
+						Required: true,
+					},
+				},
+				Variants: Variants{
+					{
+						Type:          "number",
+						Discriminator: "type",
+						Cases:         []VariantCase{},
+						Default:       []PropertyReference{},
+					},
+				},
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.args1.Diff(tt.args2)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestPropertyByID(t *testing.T) {
+	args := &CustomTypeArgs{
+		Properties: []*CustomTypeProperty{
+			{
+				ID:       "prop1",
+				RefToID:  "ref1",
+				Required: true,
+			},
+			{
+				ID:       "prop2",
+				RefToID:  "ref2",
+				Required: false,
+			},
+		},
+	}
+
+	// Test existing property
+	prop := args.PropertyByID("prop1")
+	assert.NotNil(t, prop)
+	assert.Equal(t, "prop1", prop.ID)
+	assert.Equal(t, "ref1", prop.RefToID)
+	assert.True(t, prop.Required)
+
+	// Test non-existing property
+	prop = args.PropertyByID("nonexistent")
+	assert.Nil(t, prop)
+}


### PR DESCRIPTION
## Description of the change

When adding variants onto the custom types model, we identified that the state differ started showing empty diffs on the custom types and trackingplans. Leave unchecked, they made API call to update the custom types with the same datapoint as it is. This unecessarily bumped the trackingplan versioning and hence creates hassle.

This PR implements a custom differ on the custom-types to prevent any unnecessary API updates.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
