### PR TITLE
fix: make additionalProperties as optional to allow for backward compatible state

### DIFF
--- a/cli/internal/providers/datacatalog/state/trackingplan.go
+++ b/cli/internal/providers/datacatalog/state/trackingplan.go
@@ -335,7 +335,7 @@ func (args *TrackingPlanPropertyArgs) FromResourceData(propMap map[string]interf
 	args.LocalID = MustString(propMap, "localId")
 	args.Required = MustBool(propMap, "required")
 	args.ID = String(propMap, "id", "")
-	args.AdditionalProperties = MustBool(propMap, "additionalProperties")
+	args.AdditionalProperties = Bool(propMap, "additionalProperties", false)
 
 	// Handle nested properties recursively
 	nestedProps := NormalizeToSliceMap(propMap, "properties")


### PR DESCRIPTION
## Description of the change

Make the `additionalProperties` for nested properties in trackingplan property args as optional

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
