### PR TITLE
chore: add autocompletion for the rudder-cli commands and flags

### DIFF
--- a/cli/internal/cmd/completion.go
+++ b/cli/internal/cmd/completion.go
@@ -1,0 +1,66 @@
+package cmd
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var completionCmd = &cobra.Command{
+	Use:   "completion [bash|zsh|fish|powershell]",
+	Short: "Generate completion script",
+	Long: `To load completions:
+
+Bash:
+
+  $ source <(rudder-cli completion bash)
+
+  # To load completions for each session, execute once:
+  # Linux:
+  $ rudder-cli completion bash > /etc/bash_completion.d/rudder-cli
+  # macOS:
+  $ rudder-cli completion bash > /usr/local/etc/bash_completion.d/rudder-cli
+
+Zsh:
+
+  # If shell completion is not already enabled in your environment,
+  # you will need to enable it.  You can execute the following once:
+
+  $ echo "autoload -U compinit; compinit" >> ~/.zshrc
+
+  # To load completions for each session, execute once:
+  $ rudder-cli completion zsh > "${fpath[1]}/_rudder-cli"
+
+  # You will need to start a new shell for this setup to take effect.
+
+Fish:
+
+  $ rudder-cli completion fish | source
+
+  # To load completions for each session, execute once:
+  $ rudder-cli completion fish > ~/.config/fish/completions/rudder-cli.fish
+
+PowerShell:
+
+  PS> rudder-cli completion powershell | Out-String | Invoke-Expression
+
+  # To load completions for every new session, run:
+  PS> rudder-cli completion powershell > rudder-cli.ps1
+  # and source this file from your PowerShell profile.
+`,
+	DisableFlagsInUseLine: true,
+	ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
+	Args:                  cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
+	Run: func(cmd *cobra.Command, args []string) {
+		switch args[0] {
+		case "bash":
+			cmd.Root().GenBashCompletion(os.Stdout)
+		case "zsh":
+			cmd.Root().GenZshCompletion(os.Stdout)
+		case "fish":
+			cmd.Root().GenFishCompletion(os.Stdout, true)
+		case "powershell":
+			cmd.Root().GenPowerShellCompletionWithDesc(os.Stdout)
+		}
+	},
+}

--- a/cli/internal/cmd/root.go
+++ b/cli/internal/cmd/root.go
@@ -66,6 +66,7 @@ func init() {
 	// Add subcommands to the root command
 	rootCmd.AddCommand(authCmd)
 	rootCmd.AddCommand(debugCmd)
+	rootCmd.AddCommand(completionCmd)
 	rootCmd.AddCommand(trackingplan.NewCmdTrackingPlan())
 	rootCmd.AddCommand(telemetryCmd.NewCmdTelemetry())
 	rootCmd.AddCommand(workspace.NewCmdWorkspace())


### PR DESCRIPTION
**Description**:

Since the number of commands are increasing with the CLI each with their own set of subcommands and flags, it's becoming hard to keep track of all of them. This PR adds to create autocompletions for the CLI and add them to your shell autocomplete capability.

It adds new commands like:
```
$ rudder-cli completion bash >  /usr/local/etc/bash_completion.d/rudder-cli
$ rudder-cli completion zsh > "${fpath[1]}/_rudder-cli"
```

Attaching screenshots for how the autocomplete works.

<img width="770" height="380" alt="Screenshot 2025-08-30 at 10 24 06 PM" src="https://github.com/user-attachments/assets/0b1317fb-14d7-4266-aaf2-2a829540755c" />

<img width="771" height="122" alt="Screenshot 2025-08-30 at 10 24 22 PM" src="https://github.com/user-attachments/assets/ccefcd84-1a77-45d8-8324-9a2dc8bde470" />

<img width="770" height="194" alt="Screenshot 2025-08-30 at 10 24 36 PM" src="https://github.com/user-attachments/assets/9955577c-518b-4bd5-b19d-90a21af4a5ee" />

<img width="770" height="108" alt="Screenshot 2025-08-30 at 10 25 00 PM" src="https://github.com/user-attachments/assets/072be2e1-4089-46d3-ab90-144751d87d73" />
