### PR TITLE
feat: create typer cobra command

### DIFF
--- a/cli/internal/cmd/root.go
+++ b/cli/internal/cmd/root.go
@@ -14,6 +14,7 @@ import (
 	"github.com/rudderlabs/rudder-iac/cli/internal/cmd/project/validate"
 	telemetryCmd "github.com/rudderlabs/rudder-iac/cli/internal/cmd/telemetry"
 	"github.com/rudderlabs/rudder-iac/cli/internal/cmd/trackingplan"
+	"github.com/rudderlabs/rudder-iac/cli/internal/cmd/typer"
 	"github.com/rudderlabs/rudder-iac/cli/internal/cmd/workspace"
 	"github.com/rudderlabs/rudder-iac/cli/internal/config"
 	"github.com/rudderlabs/rudder-iac/cli/internal/logger"
@@ -68,6 +69,7 @@ func init() {
 	rootCmd.AddCommand(debugCmd)
 	rootCmd.AddCommand(trackingplan.NewCmdTrackingPlan())
 	rootCmd.AddCommand(telemetryCmd.NewCmdTelemetry())
+	rootCmd.AddCommand(typer.NewCmdTyper())
 	rootCmd.AddCommand(workspace.NewCmdWorkspace())
 	rootCmd.AddCommand(importcmd.NewCmdImport())
 

--- a/cli/internal/cmd/typer/typer.go
+++ b/cli/internal/cmd/typer/typer.go
@@ -1,0 +1,95 @@
+package typer
+
+import (
+	"fmt"
+
+	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/rudderlabs/rudder-iac/cli/internal/cmd/telemetry"
+	"github.com/rudderlabs/rudder-iac/cli/internal/logger"
+	"github.com/spf13/cobra"
+)
+
+var (
+	log = logger.New("typer.cmd")
+)
+
+func NewCmdTyper() *cobra.Command {
+	var (
+		err            error
+		trackingPlanID string
+		platform       string
+		outputPath     string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "typer",
+		Short: "Generate platform-specific RudderAnalytics bindings from tracking plans",
+		Long: heredoc.Doc(`
+			RudderTyper generates strongly-typed RudderAnalytics bindings from your tracking plans.
+			It reads tracking plan configurations and generates platform-specific code for type-safe event tracking.
+		`),
+		Example: heredoc.Doc(`
+			$ rudder-cli typer --tracking-plan-id tp_123 --platform kotlin --output ./generated
+			$ rudder-cli typer --tracking-plan-id tp_123 --platform kotlin --output ./src/main/kotlin
+		`),
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			// Validate required flags
+			if trackingPlanID == "" {
+				return fmt.Errorf("tracking plan ID is required (use --tracking-plan-id flag)")
+			}
+			if platform == "" {
+				return fmt.Errorf("platform is required (use --platform flag)")
+			}
+			if outputPath == "" {
+				return fmt.Errorf("output path is required (use --output flag)")
+			}
+
+			// Mock: initialize orchestrator
+			log.Debug("mock: initialize orchestrator")
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			log.Debug("typer generation",
+				"trackingPlanID", trackingPlanID,
+				"platform", platform,
+				"outputPath", outputPath)
+
+			defer func() {
+				telemetry.TrackCommand("typer", err, []telemetry.KV{
+					{K: "trackingPlanID", V: trackingPlanID},
+					{K: "platform", V: platform},
+					{K: "outputPath", V: outputPath},
+				}...)
+			}()
+
+			// Provide user feedback
+			fmt.Printf("🔧 Generating %s bindings for tracking plan: %s\n", platform, trackingPlanID)
+			fmt.Println("📥 Fetching tracking plan data...")
+
+			log.Debug("mock: would fetch tracking plan from provider", "id", trackingPlanID)
+
+			fmt.Printf("⚡ Generating %s code...\n", platform)
+			log.Debug("mock: would generate code for platform", "platform", platform)
+
+			fmt.Printf("📁 Writing files to %s...\n", outputPath)
+			log.Debug("mock: would write files to output directory", "path", outputPath)
+
+			fmt.Printf("✅ Successfully generated %s bindings in %s\n", platform, outputPath)
+			log.Debug("mock implementation complete - real orchestrator will be added in PR 2")
+
+			return nil
+		},
+	}
+
+	// Add required flags
+	cmd.Flags().StringVarP(&trackingPlanID, "tracking-plan-id", "t", "", "Tracking plan ID to generate bindings for (required)")
+	cmd.Flags().StringVarP(&platform, "platform", "p", "", "Target platform for code generation (required)")
+	cmd.Flags().StringVarP(&outputPath, "output", "o", "", "Output directory path for generated files (required)")
+
+	// Mark required flags
+	cmd.MarkFlagRequired("tracking-plan-id")
+	cmd.MarkFlagRequired("platform")
+	cmd.MarkFlagRequired("output")
+
+	return cmd
+}

--- a/cli/internal/cmd/typer/typer_test.go
+++ b/cli/internal/cmd/typer/typer_test.go
@@ -1,0 +1,159 @@
+package typer
+
+import (
+	"testing"
+)
+
+func TestNewCmdTyper(t *testing.T) {
+	t.Run("Command Properties", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name     string
+			property string
+			want     string
+			notEmpty bool
+		}{
+			{"command use", "Use", "typer", false},
+			{"command short description", "Short", "", true},
+			{"command long description", "Long", "", true},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				cmd := NewCmdTyper()
+				if cmd == nil {
+					t.Fatal("NewCmdTyper() returned nil")
+				}
+
+				var got string
+				switch tt.property {
+				case "Use":
+					got = cmd.Use
+				case "Short":
+					got = cmd.Short
+				case "Long":
+					got = cmd.Long
+				}
+
+				if tt.notEmpty {
+					if got == "" {
+						t.Errorf("Expected %s to not be empty", tt.property)
+					}
+				} else {
+					if got != tt.want {
+						t.Errorf("Expected %s to be '%s', got '%s'", tt.property, tt.want, got)
+					}
+				}
+			})
+		}
+	})
+
+	t.Run("Flag Existence", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name        string
+			flagName    string
+			shortFlag   string
+			shouldExist bool
+			isRequired  bool
+		}{
+			{"tracking-plan-id flag", "tracking-plan-id", "t", true, true},
+			{"platform flag", "platform", "p", true, true},
+			{"output flag", "output", "o", true, true},
+			{"non-existent flag", "invalid-flag", "", false, false},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				cmd := NewCmdTyper()
+				flag := cmd.Flags().Lookup(tt.flagName)
+				exists := flag != nil
+
+				if exists != tt.shouldExist {
+					t.Errorf("Flag %s existence = %v, want %v", tt.flagName, exists, tt.shouldExist)
+					return
+				}
+
+				if tt.shouldExist && tt.shortFlag != "" {
+					if flag.Shorthand != tt.shortFlag {
+						t.Errorf("Flag %s shorthand = %s, want %s", tt.flagName, flag.Shorthand, tt.shortFlag)
+					}
+				}
+			})
+		}
+	})
+
+	t.Run("Flag Validation", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name           string
+			trackingPlanID string
+			platform       string
+			outputPath     string
+			expectError    bool
+			wantError      string
+		}{
+			{
+				name:           "all flags provided",
+				trackingPlanID: "tp_123",
+				platform:       "kotlin",
+				outputPath:     "./output",
+				expectError:    false,
+			},
+			{
+				name:           "missing tracking-plan-id",
+				trackingPlanID: "",
+				platform:       "kotlin",
+				outputPath:     "./output",
+				expectError:    true,
+				wantError:      "tracking plan ID is required (use --tracking-plan-id flag)",
+			},
+			{
+				name:           "missing platform",
+				trackingPlanID: "tp_123",
+				platform:       "",
+				outputPath:     "./output",
+				expectError:    true,
+				wantError:      "platform is required (use --platform flag)",
+			},
+			{
+				name:           "missing output path",
+				trackingPlanID: "tp_123",
+				platform:       "kotlin",
+				outputPath:     "",
+				expectError:    true,
+				wantError:      "output path is required (use --output flag)",
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				cmd := NewCmdTyper()
+
+				// Set flags
+				cmd.Flags().Set("tracking-plan-id", tt.trackingPlanID)
+				cmd.Flags().Set("platform", tt.platform)
+				cmd.Flags().Set("output", tt.outputPath)
+
+				err := cmd.PreRunE(cmd, []string{})
+
+				if tt.expectError {
+					if err == nil {
+						t.Error("Expected error but got none")
+						return
+					}
+					if tt.wantError != "" && err.Error() != tt.wantError {
+						t.Errorf("Expected error '%s', got '%s'", tt.wantError, err.Error())
+					}
+				} else {
+					if err != nil {
+						t.Errorf("Expected no error but got: %v", err)
+					}
+				}
+			})
+		}
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.5
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/go-viper/mapstructure/v2 v2.2.1
+	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/kyokomi/emoji/v2 v2.2.13
 	github.com/rudderlabs/analytics-go/v4 v4.2.1
@@ -36,7 +37,6 @@ require (
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
 	github.com/fatih/color v1.14.1 // indirect
 	github.com/fsnotify/fsnotify v1.8.0 // indirect
-	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -43,8 +43,6 @@ github.com/fsnotify/fsnotify v1.8.0 h1:dAwr6QBTBZIkG8roQaJjGof0pp0EeF+tNV7YBP3F/
 github.com/fsnotify/fsnotify v1.8.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/go-viper/mapstructure/v2 v2.2.1 h1:ZAaOCxANMuZx5RCeg0mBdEZk7DZasvvZIxtHqx8aGss=
 github.com/go-viper/mapstructure/v2 v2.2.1/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
-github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
-github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=


### PR DESCRIPTION
# What
Adds a new rudder-cli typer Cobra command to generate platform-specific RudderAnalytics bindings from a tracking plan.
# Why
Provide a first-class CLI entrypoint for RudderTyper so users can generate strongly-typed analytics code from their tracking plans.
# How
- Implements typer command with required flags:
  - --tracking-plan-id, -t: ID of the tracking plan
  - --platform, -p: target platform (currently kotlin)
  - --output, -o: output directory for generated files
- Validates required flags in PreRunE with clear error messages.
- Emits concise console output; detailed execution is available via debug logger.
- Captures telemetry of executions and key options.
- Registers the command in the root command.

# How to test locally
Build and run:
```
rudder-cli typer --tracking-plan-id tp_123 --platform kotlin --output ./generated
```
Expect a short console message and generated files written to the provided output path when orchestrator support is present.