### PR TITLE
feat: add import workspace command to the cli

### DIFF
--- a/cli/internal/cmd/import/import.go
+++ b/cli/internal/cmd/import/import.go
@@ -12,7 +12,6 @@ func NewCmdImport() *cobra.Command {
 	}
 
 	cmd.AddCommand(NewCmdRetlSource())
-	cmd.AddCommand(NewWorkspaceImport())
 
 	return cmd
 }


### PR DESCRIPTION
## Description of the change

This change adds a new command to import workspaces in the cli. As of now the command as a `Pre-Step` simply `Loads` the project which internally reads the configuration YAML files and validates the project.

The `RunE` command doesn't contain any implementation as this is just scaffolding of the change.

## Command Structure

```
./rudder-cli import workspace --location ./catalog
```


## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

Fixes DAW-2122

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 