### PR TITLE
chore: add new namer package to create a naming abstraction for externalId naming

### DIFF
--- a/cli/internal/namer/namer.go
+++ b/cli/internal/namer/namer.go
@@ -53,6 +53,8 @@ func (p *ExternalIdNamer) Name(input string) (string, error) {
 
 	baseName := p.strategy.Name(input)
 
+	// The reason we are generating id uniquely everytime we register name is
+	// as we just need to make sure that the name is unique within the scope.
 	registered, err := p.RegisterName(uuid.New().String(), p.scope, baseName)
 	if err != nil {
 		return "", fmt.Errorf("registering name: %s errored with: %w", baseName, err)

--- a/cli/internal/namer/namer_test.go
+++ b/cli/internal/namer/namer_test.go
@@ -70,6 +70,7 @@ func TestExternalIdNamer_Load(t *testing.T) {
 		wantErr bool
 		errMsg  string
 	}{
+		{"empty", []string{}, false, ""},
 		{"no duplicates", []string{"three", "four"}, false, ""},
 		{"with duplicates", []string{"one", "one"}, true, "loading name: one errored with: duplicate name exception"},
 		{"extra duplicates", []string{"test", "test", "test"}, true, "loading name: test errored with: duplicate name exception"},
@@ -98,11 +99,9 @@ func TestCollisionHandler(t *testing.T) {
 		existing []string
 		expected string
 	}{
-		{"no collision", "base", []string{"other"}, "base-1"},
 		{"simple collision", "base", []string{"base"}, "base-1"},
 		{"multiple collisions", "base", []string{"base", "base-1", "base-2"}, "base-3"},
 		{"edge empty", "", []string{}, "-1"},
-		{"existing includes candidates", "base", []string{"base-1", "base-2"}, "base-3"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Description of the change

### Overview
We are introducing a new abstraction to provide ability to name `externalId` uniquely during the import flow in the cli. This is done using a namer package based on the `*core.NameRegistry`.

The namer abstraction is as follows:
```
type Namer interface {
	Name(input string) (string, error)
	Load([]string) error
}
```

* `Load` function is used to prepopulate the namer with existing externalIds
* `Name` can then be called to get a unique name based on predefined strategy. In this case, we are using `KebabCase` as a default and predefined strategy to populate the names.

### Usage

```
n := NewExternalIdNamer(NewKebabCase())
n.Load([]string{"api-requested", "api-responded"})
n.Name("api-requested") // -> "api-requested-1"
```

### Concurrent Safe
The functionality to Load and Name is concurrent safe achieved through a `sync.Mutex`


## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

Fixes: **DAW-2125** https://linear.app/rudderstack/issue/DAW-2125/3-namer-interface

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 