### PR TITLE
feat: implement event-stream-source provider

### DIFF
--- a/cli/internal/app/dependencies.go
+++ b/cli/internal/app/dependencies.go
@@ -5,11 +5,13 @@ import (
 
 	"github.com/rudderlabs/rudder-iac/api/client"
 	"github.com/rudderlabs/rudder-iac/api/client/catalog"
+	esClient "github.com/rudderlabs/rudder-iac/api/client/event-stream"
 	retlClient "github.com/rudderlabs/rudder-iac/api/client/retl"
 	"github.com/rudderlabs/rudder-iac/cli/internal/config"
 	"github.com/rudderlabs/rudder-iac/cli/internal/project"
 	"github.com/rudderlabs/rudder-iac/cli/internal/providers"
 	"github.com/rudderlabs/rudder-iac/cli/internal/providers/datacatalog"
+	esProvider "github.com/rudderlabs/rudder-iac/cli/internal/providers/event-stream"
 	"github.com/rudderlabs/rudder-iac/cli/internal/providers/retl"
 	"github.com/rudderlabs/rudder-iac/cli/internal/providers/workspace"
 )
@@ -21,6 +23,7 @@ var (
 type Providers struct {
 	DataCatalog project.Provider
 	RETL        project.Provider
+	EventStream project.Provider
 	Workspace   *workspace.Provider
 }
 
@@ -61,7 +64,7 @@ func NewDeps() (Deps, error) {
 
 	p := setupProviders(c)
 
-	cp, err := providers.NewCompositeProvider(p.DataCatalog, p.RETL)
+	cp, err := providers.NewCompositeProvider(p.DataCatalog, p.RETL, p.EventStream)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize composite provider: %w", err)
 	}
@@ -85,11 +88,13 @@ func setupClient(version string) (*client.Client, error) {
 func setupProviders(c *client.Client) *Providers {
 	dcp := datacatalog.New(catalog.NewRudderDataCatalog(c))
 	retlp := retl.New(retlClient.NewRudderRETLStore(c))
+	esp := esProvider.New(esClient.NewRudderEventStreamStore(c))
 	wsp := workspace.New(c)
 
 	return &Providers{
 		DataCatalog: dcp,
 		RETL:        retlp,
+		EventStream: esp,
 		Workspace:   wsp,
 	}
 }

--- a/cli/internal/providers/event-stream/provider.go
+++ b/cli/internal/providers/event-stream/provider.go
@@ -1,0 +1,180 @@
+package eventstream
+
+import (
+	"context"
+	"fmt"
+
+	esClient "github.com/rudderlabs/rudder-iac/api/client/event-stream"
+	"github.com/rudderlabs/rudder-iac/cli/internal/project/specs"
+	sourceHandler "github.com/rudderlabs/rudder-iac/cli/internal/providers/event-stream/source"
+	"github.com/rudderlabs/rudder-iac/cli/internal/syncer/resources"
+	"github.com/rudderlabs/rudder-iac/cli/internal/syncer/state"
+)
+
+type handler interface {
+	LoadSpec(path string, s *specs.Spec) error
+	Validate() error
+	GetResources() ([]*resources.Resource, error)
+	LoadState(ctx context.Context) (*state.State, error)
+	Create(ctx context.Context, ID string, data resources.ResourceData) (*resources.ResourceData, error)
+	Update(ctx context.Context, ID string, data resources.ResourceData, state resources.ResourceData) (*resources.ResourceData, error)
+	Delete(ctx context.Context, ID string, state resources.ResourceData) error
+	Import(ctx context.Context, ID string, data resources.ResourceData, remoteId string) (*resources.ResourceData, error)
+	LoadResourcesFromRemote(ctx context.Context) (*resources.ResourceCollection, error)
+	LoadStateFromResources(ctx context.Context, collection *resources.ResourceCollection) (*state.State, error)
+}
+
+type Provider struct {
+	kindToType map[string]string
+	handlers   map[string]handler
+}
+
+func New(client esClient.EventStreamStore) *Provider {
+	p := &Provider{
+		kindToType: map[string]string{
+			"event-stream-source": sourceHandler.ResourceType,
+		},
+		handlers: make(map[string]handler),
+	}
+	p.handlers[sourceHandler.ResourceType] = sourceHandler.NewHandler(client)
+	return p
+}
+
+func (p *Provider) GetSupportedKinds() []string {
+	kinds := make([]string, 0, len(p.kindToType))
+	for kind := range p.kindToType {
+		kinds = append(kinds, kind)
+	}
+	return kinds
+}
+
+func (p *Provider) GetSupportedTypes() []string {
+	types := make([]string, 0, len(p.kindToType))
+	for _, t := range p.kindToType {
+		types = append(types, t)
+	}
+	return types
+}
+
+func (p *Provider) LoadSpec(path string, s *specs.Spec) error {
+	resourceType, ok := p.kindToType[s.Kind]
+	if !ok {
+		return fmt.Errorf("unsupported kind: %s", s.Kind)
+	}
+	handler, ok := p.handlers[resourceType]
+	if !ok {
+		return fmt.Errorf("no handler for resource type: %s", resourceType)
+	}
+	return handler.LoadSpec(path, s)
+}
+
+func (p *Provider) Validate() error {
+	for resourceType, handler := range p.handlers {
+		if err := handler.Validate(); err != nil {
+			return fmt.Errorf("validating %s: %w", resourceType, err)
+		}
+	}
+	return nil
+}
+
+func (p *Provider) GetResourceGraph() (*resources.Graph, error) {
+	graph := resources.NewGraph()
+	for resourceType, handler := range p.handlers {
+		resources, err := handler.GetResources()
+		if err != nil {
+			return nil, fmt.Errorf("getting resources for %s: %w", resourceType, err)
+		}
+		for _, resource := range resources {
+			graph.AddResource(resource)
+		}
+	}
+	return graph, nil
+}
+
+func (p *Provider) LoadState(ctx context.Context) (*state.State, error) {
+	result := state.EmptyState()
+	for _, handler := range p.handlers {
+		state, err := handler.LoadState(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("loading state for %s: %w", handler, err)
+		}
+		result, err = result.Merge(state)
+		if err != nil {
+			return nil, fmt.Errorf("merging state for %s: %w", handler, err)
+		}
+	}
+	return result, nil
+}
+
+func (p *Provider) LoadResourcesFromRemote(ctx context.Context) (*resources.ResourceCollection, error) {
+	collection := resources.NewResourceCollection()
+	for resourceType, handler := range p.handlers {
+		c, err := handler.LoadResourcesFromRemote(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("loading %s: %w", resourceType, err)
+		}
+		collection, err = collection.Merge(c)
+		if err != nil {
+			return nil, fmt.Errorf("merging collection for %s: %w", resourceType, err)
+		}
+	}
+	return collection, nil
+}
+
+func (p *Provider) LoadStateFromResources(ctx context.Context, collection *resources.ResourceCollection) (*state.State, error) {
+	s := state.EmptyState()
+	for resourceType, handler := range p.handlers {
+		providerState, err := handler.LoadStateFromResources(ctx, collection)
+		if err != nil {
+			return nil, fmt.Errorf("loading state from provider handler %s: %w", resourceType, err)
+		}
+		s, err = s.Merge(providerState)
+		if err != nil {
+			return nil, fmt.Errorf("merging provider states: %w", err)
+		}
+	}
+	return s, nil
+}
+
+func (p *Provider) PutResourceState(ctx context.Context, URN string, s *state.ResourceState) error {
+	// Not required with the stateless CLI approach
+	return nil
+}
+
+func (p *Provider) DeleteResourceState(ctx context.Context, st *state.ResourceState) error {
+	// Not required with the stateless CLI approach
+	return nil
+}
+
+func (p *Provider) Create(ctx context.Context, ID string, resourceType string, data resources.ResourceData) (*resources.ResourceData, error) {
+	handler, ok := p.handlers[resourceType]
+	if !ok {
+		return nil, fmt.Errorf("no handler for resource type: %s", resourceType)
+	}
+	return handler.Create(ctx, ID, data)
+}
+
+func (p *Provider) Update(ctx context.Context, ID string, resourceType string, data resources.ResourceData, state resources.ResourceData) (*resources.ResourceData, error) {
+	handler, ok := p.handlers[resourceType]
+	if !ok {
+		return nil, fmt.Errorf("no handler for resource type: %s", resourceType)
+	}
+
+	return handler.Update(ctx, ID, data, state)
+}
+
+func (p *Provider) Delete(ctx context.Context, ID string, resourceType string, state resources.ResourceData) error {
+	handler, ok := p.handlers[resourceType]
+	if !ok {
+		return fmt.Errorf("no handler for resource type: %s", resourceType)
+	}
+	return handler.Delete(ctx, ID, state)
+}
+
+func (p *Provider) Import(ctx context.Context, ID string, resourceType string, data resources.ResourceData, workspaceId, remoteId string) (*resources.ResourceData, error) {
+	handler, ok := p.handlers[resourceType]
+	if !ok {
+		return nil, fmt.Errorf("no handler for resource type: %s", resourceType)
+	}
+	return handler.Import(ctx, ID, data, remoteId)
+}

--- a/cli/internal/providers/event-stream/provider_test.go
+++ b/cli/internal/providers/event-stream/provider_test.go
@@ -1,0 +1,420 @@
+package eventstream_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	sourceClient "github.com/rudderlabs/rudder-iac/api/client/event-stream/source"
+	"github.com/rudderlabs/rudder-iac/cli/internal/project/specs"
+	eventstream "github.com/rudderlabs/rudder-iac/cli/internal/providers/event-stream"
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/event-stream/source"
+	"github.com/rudderlabs/rudder-iac/cli/internal/syncer/resources"
+	"github.com/rudderlabs/rudder-iac/cli/internal/syncer/state"
+)
+
+func TestProvider(t *testing.T) {
+	t.Run("GetSupportedKinds", func(t *testing.T) {
+		provider := eventstream.New(source.NewMockSourceClient())
+		kinds := provider.GetSupportedKinds()
+		assert.Contains(t, kinds, "event-stream-source")
+		assert.Len(t, kinds, 1)
+	})
+
+	t.Run("GetSupportedTypes", func(t *testing.T) {
+		provider := eventstream.New(source.NewMockSourceClient())
+		types := provider.GetSupportedTypes()
+		assert.Contains(t, types, source.ResourceType)
+		assert.Len(t, types, 1)
+	})
+
+	t.Run("LoadSpec", func(t *testing.T) {
+		t.Run("UnsupportedKind", func(t *testing.T) {
+			provider := eventstream.New(source.NewMockSourceClient())
+			err := provider.LoadSpec("", &specs.Spec{Kind: "unsupported"})
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "unsupported kind")
+		})
+
+		t.Run("ValidKind", func(t *testing.T) {
+			provider := eventstream.New(source.NewMockSourceClient())
+			err := provider.LoadSpec("test.yaml", &specs.Spec{
+				Kind: "event-stream-source",
+				Spec: map[string]interface{}{
+					"id":                "test-source",
+					"name":              "Test Source",
+					"source_definition": "Javascript",
+					"enabled":           true,
+				},
+			})
+			assert.NoError(t, err)
+		})
+
+		t.Run("InvalidSpec", func(t *testing.T) {
+			provider := eventstream.New(source.NewMockSourceClient())
+			err := provider.LoadSpec("test.yaml", &specs.Spec{
+				Kind: "event-stream-source",
+				Spec: map[string]interface{}{
+					"id":      123, // should be string
+					"enabled": "invalid",
+				},
+			})
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "'id' expected type 'string'")
+		})
+	})
+
+	t.Run("Validate", func(t *testing.T) {
+		testCases := []struct {
+			name          string
+			specs         []*specs.Spec
+			expectedError bool
+			errorMessage  string
+		}{
+			{
+				name: "Valid sources",
+				specs: []*specs.Spec{
+					{
+						Version: "rudder/v0.1",
+						Kind:    "event-stream-source",
+						Spec: map[string]interface{}{
+							"id":                "test-source-1",
+							"name":              "Test Source 1",
+							"source_definition": "Javascript",
+							"enabled":           true,
+						},
+					},
+				},
+				expectedError: false,
+			},
+			{
+				name: "Invalid source - missing required fields",
+				specs: []*specs.Spec{
+					{
+						Version: "rudder/v0.1",
+						Kind:    "event-stream-source",
+						Spec: map[string]interface{}{
+							"id":      "test-source",
+							"enabled": true,
+						},
+					},
+				},
+				expectedError: true,
+				errorMessage:  "name is required",
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				provider := eventstream.New(source.NewMockSourceClient())
+
+				// Load all specs
+				for _, spec := range tc.specs {
+					err := provider.LoadSpec("", spec)
+					require.NoError(t, err, "LoadSpec should not fail")
+				}
+
+				// Validate all specs
+				err := provider.Validate()
+				if tc.expectedError {
+					assert.Error(t, err)
+					if tc.errorMessage != "" {
+						assert.Contains(t, err.Error(), tc.errorMessage)
+					}
+				} else {
+					assert.NoError(t, err)
+				}
+			})
+		}
+	})
+
+	t.Run("GetResourceGraph", func(t *testing.T) {
+		provider := eventstream.New(source.NewMockSourceClient())
+
+		err := provider.LoadSpec("test1.yaml", &specs.Spec{
+			Kind: "event-stream-source",
+			Spec: map[string]interface{}{
+				"id":                "test-source-1",
+				"name":              "Test Source 1",
+				"source_definition": "Javascript",
+				"enabled":           true,
+			},
+		})
+		require.NoError(t, err)
+
+		err = provider.LoadSpec("test2.yaml", &specs.Spec{
+			Kind: "event-stream-source",
+			Spec: map[string]interface{}{
+				"id":                "test-source-2",
+				"name":              "Test Source 2",
+				"source_definition": "Python",
+				"enabled":           false,
+			},
+		})
+		require.NoError(t, err)
+
+		graph, err := provider.GetResourceGraph()
+		require.NoError(t, err)
+
+		// Verify both resources are in the graph
+		resources := graph.Resources()
+		assert.Len(t, resources, 2)
+
+		// Verify resource IDs
+		resourceIDs := make([]string, 0, len(resources))
+		for _, r := range resources {
+			resourceIDs = append(resourceIDs, r.ID())
+		}
+		assert.Contains(t, resourceIDs, "test-source-1")
+		assert.Contains(t, resourceIDs, "test-source-2")
+	})
+
+	t.Run("LoadState", func(t *testing.T) {
+		mockClient := source.NewMockSourceClient()
+		provider := eventstream.New(mockClient)
+
+		ctx := context.Background()
+		mockClient.SetGetSourcesFunc(func(ctx context.Context) ([]sourceClient.EventStreamSource, error) {
+			return []sourceClient.EventStreamSource{
+				{
+					ID:         "remote123",
+					ExternalID: "external-123",
+					Name:       "Test Source 1",
+					Type:       "Javascript",
+					Enabled:    true,
+				},
+				{
+					ID:         "remote456",
+					ExternalID: "external-456",
+					Name:       "Test Source 2",
+					Type:       "Python",
+					Enabled:    false,
+				},
+			}, nil
+		})
+
+		s, err := provider.LoadState(ctx)
+		require.NoError(t, err)
+
+		// Check that both resources are loaded
+		assert.Len(t, s.Resources, 2)
+
+		// Check first resource
+		urn1 := resources.URN("external-123", source.ResourceType)
+		rs1 := s.GetResource(urn1)
+		require.NotNil(t, rs1)
+		assert.Equal(t, &state.ResourceState{
+			ID:   "external-123",
+			Type: source.ResourceType,
+			Input: resources.ResourceData{
+				"name":              "Test Source 1",
+				"enabled":           true,
+				"source_definition": "Javascript",
+			},
+			Output: resources.ResourceData{
+				"id": "remote123",
+			},
+		}, rs1)
+
+		rs2 := s.GetResource("event-stream-source:external-456")
+		assert.Equal(t, &state.ResourceState{
+			ID:   "external-456",
+			Type: source.ResourceType,
+			Input: resources.ResourceData{
+				"name":              "Test Source 2",
+				"enabled":           false,
+				"source_definition": "Python",
+			},
+			Output: resources.ResourceData{
+				"id": "remote456",
+			},
+		}, rs2)
+	})
+
+	t.Run("CRUD Operations", func(t *testing.T) {
+		t.Run("Create", func(t *testing.T) {
+			provider := eventstream.New(source.NewMockSourceClient())
+			ctx := context.Background()
+
+			createData := resources.ResourceData{
+				"name":              "Test Source",
+				"enabled":           true,
+				"source_definition": "Javascript",
+			}
+
+			result, err := provider.Create(ctx, "test-source", source.ResourceType, createData)
+			require.NoError(t, err)
+			require.Equal(t, &resources.ResourceData{
+				"name":              "Test Source",
+				"enabled":           true,
+				"source_definition": "Javascript",
+			}, result)
+		})
+
+		t.Run("Update", func(t *testing.T) {
+			provider := eventstream.New(source.NewMockSourceClient())
+			ctx := context.Background()
+
+			updateData := resources.ResourceData{
+				"name":    "Updated Source",
+				"enabled": false,
+			}
+
+			stateData := resources.ResourceData{
+				"id": "test-source-id",
+			}
+
+			result, err := provider.Update(ctx, "test-source", source.ResourceType, updateData, stateData)
+			require.NoError(t, err)
+			assert.Equal(t, &resources.ResourceData{
+				"name":              "Updated Source",
+				"enabled":           false,
+				"source_definition": "Javascript",
+			}, result)
+		})
+
+		t.Run("Delete", func(t *testing.T) {
+			provider := eventstream.New(source.NewMockSourceClient())
+			ctx := context.Background()
+			stateData := resources.ResourceData{
+				"id": "test-source-id",
+			}
+			err := provider.Delete(ctx, "test-source", source.ResourceType, stateData)
+			require.NoError(t, err)
+		})
+	})
+
+	t.Run("Import", func(t *testing.T) {
+		provider := eventstream.New(source.NewMockSourceClient())
+		ctx := context.Background()
+		_, err := provider.Import(ctx, "test-source", source.ResourceType, nil, "workspace-123", "remote-123")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "importing event stream source is not supported")
+	})
+
+	t.Run("LoadResourcesFromRemote", func(t *testing.T) {
+		mockClient := source.NewMockSourceClient()
+		provider := eventstream.New(mockClient)
+
+		ctx := context.Background()
+		mockClient.SetGetSourcesFunc(func(ctx context.Context) ([]sourceClient.EventStreamSource, error) {
+			return []sourceClient.EventStreamSource{
+				{
+					ID:         "remote123",
+					ExternalID: "external-123",
+					Name:       "Test Source 1",
+					Type:       "Javascript",
+					Enabled:    true,
+				},
+				{
+					ID:         "remote456",
+					ExternalID: "external-456",
+					Name:       "Test Source 2",
+					Type:       "Python",
+					Enabled:    false,
+				},
+			}, nil
+		})
+
+		collection, err := provider.LoadResourcesFromRemote(ctx)
+		require.NoError(t, err)
+
+		esResources := collection.GetAll(source.ResourceType)
+		require.Len(t, esResources, 2)
+
+		assert.Equal(t, map[string]*resources.RemoteResource{
+			"remote123": {
+				ID:         "remote123",
+				ExternalID: "external-123",
+				Data: sourceClient.EventStreamSource{
+					ID:         "remote123",
+					ExternalID: "external-123",
+					Name:       "Test Source 1",
+					Type:       "Javascript",
+					Enabled:    true,
+				},
+			},
+			"remote456": {
+				ID:         "remote456",
+				ExternalID: "external-456",
+				Data: sourceClient.EventStreamSource{
+					ID:         "remote456",
+					ExternalID: "external-456",
+					Name:       "Test Source 2",
+					Type:       "Python",
+					Enabled:    false,
+				},
+			},
+		}, esResources)
+	})
+
+	t.Run("LoadStateFromResources", func(t *testing.T) {
+		mockClient := source.NewMockSourceClient()
+		provider := eventstream.New(mockClient)
+
+		ctx := context.Background()
+
+		// Create a ResourceCollection with test data
+		collection := resources.NewResourceCollection()
+		resourceMap := map[string]*resources.RemoteResource{
+			"remote123": {
+				ID:         "remote123",
+				ExternalID: "external-123",
+				Data: sourceClient.EventStreamSource{
+					ID:         "remote123",
+					ExternalID: "external-123",
+					Name:       "Test Source 1",
+					Type:       "Javascript",
+					Enabled:    true,
+				},
+			},
+			"remote456": {
+				ID:         "remote456",
+				ExternalID: "external-456",
+				Data: sourceClient.EventStreamSource{
+					ID:         "remote456",
+					ExternalID: "external-456",
+					Name:       "Test Source 2",
+					Type:       "Python",
+					Enabled:    false,
+				},
+			},
+		}
+		collection.Set(source.ResourceType, resourceMap)
+
+		loadedState, err := provider.LoadStateFromResources(ctx, collection)
+		require.NoError(t, err)
+
+		assert.Len(t, loadedState.Resources, 2)
+
+		// Check first resource
+		assert.Equal(t, map[string]*state.ResourceState{
+			"event-stream-source:external-123": {
+				ID:   "external-123",
+				Type: "event-stream-source",
+				Input: resources.ResourceData{
+					"name":              "Test Source 1",
+					"enabled":           true,
+					"source_definition": "Javascript",
+				},
+				Output: resources.ResourceData{
+					"id": "remote123",
+				},
+			},
+			"event-stream-source:external-456": {
+				ID:   "external-456",
+				Type: "event-stream-source",
+				Input: resources.ResourceData{
+					"name":              "Test Source 2",
+					"enabled":           false,
+					"source_definition": "Python",
+				},
+				Output: resources.ResourceData{
+					"id": "remote456",
+				},
+			},
+		}, loadedState.Resources)
+	})
+}

--- a/cli/internal/providers/event-stream/source/handler.go
+++ b/cli/internal/providers/event-stream/source/handler.go
@@ -1,0 +1,190 @@
+package source
+
+import (
+	"context"
+	"fmt"
+	"slices"
+
+	"github.com/go-viper/mapstructure/v2"
+	sourceClient "github.com/rudderlabs/rudder-iac/api/client/event-stream/source"
+	"github.com/rudderlabs/rudder-iac/cli/internal/project/specs"
+	"github.com/rudderlabs/rudder-iac/cli/internal/syncer/resources"
+	"github.com/rudderlabs/rudder-iac/cli/internal/syncer/state"
+)
+
+type Handler struct {
+	resources map[string]*sourceSpec
+	client    sourceClient.SourceStore
+}
+
+func NewHandler(client sourceClient.SourceStore) *Handler {
+	return &Handler{resources: make(map[string]*sourceSpec), client: client}
+}
+
+func (h *Handler) LoadSpec(_ string, s *specs.Spec) error {
+	source := &sourceSpec{}
+	if err := mapstructure.Decode(s.Spec, source); err != nil {
+		return fmt.Errorf("decoding spec: %w", err)
+	}
+	if _, exists := h.resources[source.LocalId]; exists {
+		return fmt.Errorf("event stream source with id %s already exists", source.LocalId)
+	}
+	h.resources[source.LocalId] = source
+	return nil
+}
+
+func validateSource(source *sourceSpec) error {
+	if source.LocalId == "" {
+		return fmt.Errorf("id is required")
+	}
+	if source.Name == "" {
+		return fmt.Errorf("name is required")
+	}
+	if source.SourceDefinition == "" {
+		return fmt.Errorf("source_definition is required")
+	}
+	if !slices.Contains(sourceDefinitions, source.SourceDefinition) {
+		return fmt.Errorf("source_definition '%s' is invalid, must be one of: %v", source.SourceDefinition, sourceDefinitions)
+	}
+	return nil
+}
+
+func (h *Handler) Validate() error {
+	for _, source := range h.resources {
+		if err := validateSource(source); err != nil {
+			return fmt.Errorf("validating event stream source spec: %w", err)
+		}
+	}
+	return nil
+}
+
+func (h *Handler) GetResources() ([]*resources.Resource, error) {
+	result := make([]*resources.Resource, 0, len(h.resources))
+	for _, s := range h.resources {
+		data := resources.ResourceData{
+			NameKey:             s.Name,
+			EnabledKey:          s.Enabled,
+			SourceDefinitionKey: s.SourceDefinition,
+		}
+		r := resources.NewResource(s.LocalId, ResourceType, data, []string{})
+		result = append(result, r)
+	}
+	return result, nil
+}
+
+func (h *Handler) Create(ctx context.Context, id string, data resources.ResourceData) (*resources.ResourceData, error) {
+	createRequest := &sourceClient.CreateSourceRequest{
+		ExternalID: id,
+		Name:       data[NameKey].(string),
+		Type:       data[SourceDefinitionKey].(string),
+		Enabled:    data[EnabledKey].(bool),
+	}
+	resp, err := h.client.Create(ctx, createRequest)
+	if err != nil {
+		return nil, fmt.Errorf("creating event stream source: %w", err)
+	}
+	return mapRemoteToResourceData(resp), nil
+}
+
+func (h *Handler) Update(ctx context.Context, id string, data resources.ResourceData, state resources.ResourceData) (*resources.ResourceData, error) {
+	if state[SourceDefinitionKey] != data[SourceDefinitionKey] {
+		return nil, fmt.Errorf("source_definition cannot be changed")
+	}
+	remoteID, ok := state[IDKey].(string)
+	if !ok {
+		return nil, fmt.Errorf("missing id in resource data")
+	}
+	updateRequest := &sourceClient.UpdateSourceRequest{
+		Name:    data[NameKey].(string),
+		Enabled: data[EnabledKey].(bool),
+	}
+	resp, err := h.client.Update(ctx, remoteID, updateRequest)
+	if err != nil {
+		return nil, fmt.Errorf("updating event stream source: %w", err)
+	}
+	return mapRemoteToResourceData(resp), nil
+}
+
+func (h *Handler) LoadState(ctx context.Context) (*state.State, error) {
+	sources, err := h.client.GetSources(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("getting event stream sources: %w", err)
+	}
+	st := state.EmptyState()
+	for _, source := range sources {
+		if source.ExternalID != "" {
+			st.AddResource(mapRemoteToState(source))
+		}
+	}
+	return st, nil
+}
+
+func (h *Handler) LoadResourcesFromRemote(ctx context.Context) (*resources.ResourceCollection, error) {
+	collection := resources.NewResourceCollection()
+	sources, err := h.client.GetSources(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("getting event stream sources: %w", err)
+	}
+	resourceMap := make(map[string]*resources.RemoteResource)
+	for _, source := range sources {
+		resourceMap[source.ID] = &resources.RemoteResource{
+			ID:         source.ID,
+			ExternalID: source.ExternalID,
+			Data:       source,
+		}
+	}
+	collection.Set(ResourceType, resourceMap)
+	return collection, nil
+}
+
+func (p *Handler) LoadStateFromResources(ctx context.Context, collection *resources.ResourceCollection) (*state.State, error) {
+	s := state.EmptyState()
+	esResources := collection.GetAll(ResourceType)
+	for _, esResource := range esResources {
+		source, ok := esResource.Data.(sourceClient.EventStreamSource)
+		if !ok {
+			return nil, fmt.Errorf("unable to cast resource to event stream source")
+		}
+		if source.ExternalID != "" {
+			resourceState := mapRemoteToState(source)
+			urn := resources.URN(esResource.ExternalID, ResourceType)
+			s.Resources[urn] = resourceState
+		}
+	}
+	return s, nil
+}
+
+func (h *Handler) Delete(ctx context.Context, id string, state resources.ResourceData) error {
+	remoteID, ok := state[IDKey].(string)
+	if !ok {
+		return fmt.Errorf("missing id in resource data")
+	}
+	err := h.client.Delete(ctx, remoteID)
+	if err != nil {
+		return fmt.Errorf("deleting event stream source: %w", err)
+	}
+	return nil
+}
+
+func (h *Handler) Import(_ context.Context, _ string, data resources.ResourceData, _ string) (*resources.ResourceData, error) {
+	return nil, fmt.Errorf("importing event stream source is not supported")
+}
+
+func mapRemoteToState(source sourceClient.EventStreamSource) *state.ResourceState {
+	return &state.ResourceState{
+		Type: ResourceType,
+		ID:   source.ExternalID,
+		Input: *mapRemoteToResourceData(&source),
+		Output: resources.ResourceData{
+			IDKey: source.ID,
+		},
+	}
+}
+
+func mapRemoteToResourceData(source *sourceClient.EventStreamSource) *resources.ResourceData {
+	return &resources.ResourceData{
+		NameKey:             source.Name,
+		EnabledKey:          source.Enabled,
+		SourceDefinitionKey: source.Type,
+	}
+}

--- a/cli/internal/providers/event-stream/source/handler_test.go
+++ b/cli/internal/providers/event-stream/source/handler_test.go
@@ -1,0 +1,477 @@
+package source_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	sourceClient "github.com/rudderlabs/rudder-iac/api/client/event-stream/source"
+	"github.com/rudderlabs/rudder-iac/cli/internal/project/specs"
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/event-stream/source"
+	"github.com/rudderlabs/rudder-iac/cli/internal/syncer/resources"
+	"github.com/rudderlabs/rudder-iac/cli/internal/syncer/state"
+)
+
+func TestEventStreamSourceHandler(t *testing.T) {
+	t.Run("LoadSpec", func(t *testing.T) {
+		t.Run("error with invalid type", func(t *testing.T) {
+			mockClient := source.NewMockSourceClient()
+			handler := source.NewHandler(mockClient)
+
+			spec := &specs.Spec{
+				Version: "rudder/v0.1",
+				Kind:    "event-stream-source",
+				Spec: map[string]interface{}{
+					"id":                123,
+					"name":              "Test Source",
+					"source_definition": "Javascript",
+					"enabled":           true,
+				},
+			}
+			err := handler.LoadSpec("", spec)
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "'id' expected type 'string'")
+		})
+
+		t.Run("error with duplicate id", func(t *testing.T) {
+			mockClient := source.NewMockSourceClient()
+			handler := source.NewHandler(mockClient)
+
+			spec := &specs.Spec{
+				Version: "rudder/v0.1",
+				Kind:    "event-stream-source",
+				Spec: map[string]interface{}{
+					"id":                "test-source",
+					"name":              "Test Source",
+					"source_definition": "Javascript",
+					"enabled":           true,
+				},
+			}
+
+			err := handler.LoadSpec("", spec)
+			require.NoError(t, err)
+
+			err = handler.LoadSpec("", spec)
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "event stream source with id test-source already exists")
+		})
+	})
+
+	t.Run("Validate", func(t *testing.T) {
+		testCases := []struct {
+			name          string
+			specs         []*specs.Spec
+			expectedError bool
+			errorMessage  string
+		}{
+			{
+				name: "Valid sources",
+				specs: []*specs.Spec{
+					{
+						Version: "rudder/v0.1",
+						Kind:    "event-stream-source",
+						Spec: map[string]interface{}{
+							"id":                "test-source-1",
+							"name":              "Test Source 1",
+							"source_definition": "Javascript",
+							"enabled":           true,
+						},
+					},
+					{
+						Version: "rudder/v0.1",
+						Kind:    "event-stream-source",
+						Spec: map[string]interface{}{
+							"id":                "test-source-2",
+							"name":              "Test Source 2",
+							"source_definition": "Python",
+							"enabled":           false,
+						},
+					},
+				},
+				expectedError: false,
+			},
+			{
+				name: "Missing id",
+				specs: []*specs.Spec{
+					{
+						Version: "rudder/v0.1",
+						Kind:    "event-stream-source",
+						Spec: map[string]interface{}{
+							"name":              "Test Source",
+							"source_definition": "Javascript",
+							"enabled":           true,
+						},
+					},
+				},
+				expectedError: true,
+				errorMessage:  "id is required",
+			},
+			{
+				name: "Missing name",
+				specs: []*specs.Spec{
+					{
+						Version: "rudder/v0.1",
+						Kind:    "event-stream-source",
+						Spec: map[string]interface{}{
+							"id":                "test-source",
+							"source_definition": "Javascript",
+							"enabled":           true,
+						},
+					},
+				},
+				expectedError: true,
+				errorMessage:  "name is required",
+			},
+			{
+				name: "Missing source_definition",
+				specs: []*specs.Spec{
+					{
+						Version: "rudder/v0.1",
+						Kind:    "event-stream-source",
+						Spec: map[string]interface{}{
+							"id":      "test-source",
+							"name":    "Test Source",
+							"enabled": true,
+						},
+					},
+				},
+				expectedError: true,
+				errorMessage:  "source_definition is required",
+			},
+			{
+				name: "Invalid source_definition",
+				specs: []*specs.Spec{
+					{
+						Version: "rudder/v0.1",
+						Kind:    "event-stream-source",
+						Spec: map[string]interface{}{
+							"id":                "test-source",
+							"name":              "Test Source",
+							"source_definition": "InvalidSDK",
+							"enabled":           true,
+						},
+					},
+				},
+				expectedError: true,
+				errorMessage:  "source_definition 'InvalidSDK' is invalid",
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				mockClient := source.NewMockSourceClient()
+				handler := source.NewHandler(mockClient)
+
+				for _, spec := range tc.specs {
+					err := handler.LoadSpec("", spec)
+					require.NoError(t, err)
+				}
+
+				err := handler.Validate()
+
+				if tc.expectedError {
+					assert.Error(t, err)
+					if tc.errorMessage != "" {
+						assert.Contains(t, err.Error(), tc.errorMessage)
+					}
+				} else {
+					assert.NoError(t, err)
+				}
+			})
+		}
+	})
+
+	t.Run("GetResources", func(t *testing.T) {
+		mockClient := source.NewMockSourceClient()
+		handler := source.NewHandler(mockClient)
+
+		spec := &specs.Spec{
+			Version: "rudder/v0.1",
+			Kind:    "event-stream-source",
+			Spec: map[string]interface{}{
+				"id":                "test-source-1",
+				"name":              "Test Source 1",
+				"source_definition": "Javascript",
+				"enabled":           true,
+			},
+		}
+
+		err := handler.LoadSpec("", spec)
+		require.NoError(t, err)
+
+		res, err := handler.GetResources()
+		assert.NoError(t, err)
+		assert.Len(t, res, 1)
+
+		assert.Equal(t, "test-source-1", res[0].ID())
+		assert.Equal(t, source.ResourceType, res[0].Type())
+		assert.Equal(t, resources.ResourceData{
+			"name":              "Test Source 1",
+			"enabled":           true,
+			"source_definition": "Javascript",
+		}, res[0].Data())
+		assert.Empty(t, res[0].Dependencies())
+	})
+
+	t.Run("Create", func(t *testing.T) {
+		mockClient := source.NewMockSourceClient()
+		handler := source.NewHandler(mockClient)
+
+		data := resources.ResourceData{
+			"name":              "Test Source",
+			"enabled":           true,
+			"source_definition": "Javascript",
+		}
+
+		result, err := handler.Create(context.Background(), "test-source", data)
+
+		assert.NoError(t, err)
+		assert.True(t, mockClient.CreateCalled())
+		assert.Equal(t, &resources.ResourceData{
+			"name":              "Test Source",
+			"enabled":           true,
+			"source_definition": "Javascript",
+		}, result)
+	})
+
+	t.Run("Update", func(t *testing.T) {
+		t.Run("Success", func(t *testing.T) {
+			mockClient := source.NewMockSourceClient()
+			handler := source.NewHandler(mockClient)
+
+			data := resources.ResourceData{
+				"name":              "Updated Source",
+				"enabled":           false,
+				"source_definition": "Javascript",
+			}
+			state := resources.ResourceData{
+				"id":                "remote123",
+				"name":              "Original Source",
+				"enabled":           true,
+				"source_definition": "Javascript",
+			}
+
+			result, err := handler.Update(context.Background(), "test-source", data, state)
+
+			assert.NoError(t, err)
+			assert.True(t, mockClient.UpdateCalled())
+			assert.Equal(t, &resources.ResourceData{
+				"name":              "Updated Source",
+				"enabled":           false,
+				"source_definition": "Javascript",
+			}, result)
+		})
+
+		t.Run("Source definition cannot be changed", func(t *testing.T) {
+			mockClient := source.NewMockSourceClient()
+			handler := source.NewHandler(mockClient)
+
+			data := resources.ResourceData{
+				"source_definition": "Python",
+			}
+			state := resources.ResourceData{
+				"id":                "remote123",
+				"name":              "Original Source",
+				"enabled":           true,
+				"source_definition": "Javascript",
+			}
+
+			_, err := handler.Update(context.Background(), "test-source", data, state)
+
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "source_definition cannot be changed")
+			assert.False(t, mockClient.UpdateCalled())
+		})
+	})
+
+	t.Run("Delete", func(t *testing.T) {
+		mockClient := source.NewMockSourceClient()
+		handler := source.NewHandler(mockClient)
+
+		state := resources.ResourceData{
+			"id": "remote123",
+		}
+
+		err := handler.Delete(context.Background(), "test-source", state)
+
+		assert.NoError(t, err)
+		assert.True(t, mockClient.DeleteCalled())
+	})
+
+	t.Run("LoadState", func(t *testing.T) {
+		mockClient := source.NewMockSourceClient()
+		mockClient.SetGetSourcesFunc(func(ctx context.Context) ([]sourceClient.EventStreamSource, error) {
+			return []sourceClient.EventStreamSource{
+				{
+					ID:         "remote123",
+					ExternalID: "external-123",
+					Name:       "Test Source 1",
+					Type:       "Javascript",
+					Enabled:    true,
+				},
+				{
+					ID:         "remote456",
+					ExternalID: "external-456",
+					Name:       "Test Source 2",
+					Type:       "Python",
+					Enabled:    false,
+				},
+				{
+					ID:         "remote789",
+					ExternalID: "", // This should be skipped
+					Name:       "Test Source 3",
+					Type:       "Go",
+					Enabled:    true,
+				},
+			}, nil
+		})
+		handler := source.NewHandler(mockClient)
+
+		st, err := handler.LoadState(context.Background())
+
+		assert.NoError(t, err)
+		assert.True(t, mockClient.GetSourcesCalled())
+
+		// Should have 2 resources (one with empty ExternalID is skipped)
+		assert.Len(t, st.Resources, 2)
+
+		resource1 := st.GetResource("event-stream-source:external-123")
+		assert.Equal(t, &state.ResourceState{
+			ID:   "external-123",
+			Type: "event-stream-source",
+			Input: resources.ResourceData{
+				"name":              "Test Source 1",
+				"enabled":           true,
+				"source_definition": "Javascript",
+			},
+			Output: resources.ResourceData{
+				"id": "remote123",
+			},
+		}, resource1)
+
+		resource2 := st.GetResource("event-stream-source:external-456")
+		assert.Equal(t, &state.ResourceState{
+			ID:   "external-456",
+			Type: "event-stream-source",
+			Input: resources.ResourceData{
+				"name":              "Test Source 2",
+				"enabled":           false,
+				"source_definition": "Python",
+			},
+			Output: resources.ResourceData{
+				"id": "remote456",
+			},
+		}, resource2)
+	})
+
+	t.Run("LoadResourcesFromRemote", func(t *testing.T) {
+		mockClient := source.NewMockSourceClient()
+		mockClient.SetGetSourcesFunc(func(ctx context.Context) ([]sourceClient.EventStreamSource, error) {
+			return []sourceClient.EventStreamSource{
+				{
+					ID:         "remote123",
+					ExternalID: "external-123",
+					Name:       "Test Source 1",
+					Type:       "Javascript",
+					Enabled:    true,
+				},
+				{
+					ID:         "remote456",
+					ExternalID: "external-456",
+					Name:       "Test Source 2",
+					Type:       "Python",
+					Enabled:    false,
+				},
+			}, nil
+		})
+		handler := source.NewHandler(mockClient)
+
+		collection, err := handler.LoadResourcesFromRemote(context.Background())
+
+		assert.NoError(t, err)
+		assert.True(t, mockClient.GetSourcesCalled())
+
+		esResources := collection.GetAll(source.ResourceType)
+		assert.Len(t, esResources, 2)
+
+		assert.Equal(t, map[string]*resources.RemoteResource{
+			"remote123": {
+				ID:         "remote123",
+				ExternalID: "external-123",
+				Data: sourceClient.EventStreamSource{
+					ID:         "remote123",
+					ExternalID: "external-123",
+					Name:       "Test Source 1",
+					Type:       "Javascript",
+					Enabled:    true,
+				},
+			},
+			"remote456": {
+				ID:         "remote456",
+				ExternalID: "external-456",
+				Data: sourceClient.EventStreamSource{
+					ID:         "remote456",
+					ExternalID: "external-456",
+					Name:       "Test Source 2",
+					Type:       "Python",
+					Enabled:    false,
+				},
+			},
+		}, esResources)
+	})
+
+	t.Run("LoadStateFromResources", func(t *testing.T) {
+		handler := source.NewHandler(nil)
+
+		// Create a resource collection with event stream sources
+		collection := resources.NewResourceCollection()
+		resourceMap := map[string]*resources.RemoteResource{
+			"remote123": {
+				ID:         "remote123",
+				ExternalID: "external-123",
+				Data: sourceClient.EventStreamSource{
+					ID:         "remote123",
+					ExternalID: "external-123",
+					Name:       "Test Source 1",
+					Type:       "Javascript",
+					Enabled:    true,
+				},
+			},
+			"remote456": {
+				ID:         "remote456",
+				ExternalID: "external-456",
+				Data: sourceClient.EventStreamSource{
+					ID:         "remote456",
+					ExternalID: "",
+					Name:       "Test Source 2",
+					Type:       "Python",
+					Enabled:    false,
+				},
+			},
+		}
+		collection.Set(source.ResourceType, resourceMap)
+
+		st, err := handler.LoadStateFromResources(context.Background(), collection)
+
+		assert.NoError(t, err)
+		assert.NotNil(t, st)
+
+		assert.Len(t, st.Resources, 1)
+		assert.Equal(t, map[string]*state.ResourceState{
+			"event-stream-source:external-123": {
+				ID:   "external-123",
+				Type: "event-stream-source",
+				Input: resources.ResourceData{
+					"name":              "Test Source 1",
+					"enabled":           true,
+					"source_definition": "Javascript",
+				},
+				Output: resources.ResourceData{
+					"id": "remote123",
+				},
+			},
+		}, st.Resources)
+	})
+}

--- a/cli/internal/providers/event-stream/source/mock_client.go
+++ b/cli/internal/providers/event-stream/source/mock_client.go
@@ -1,0 +1,73 @@
+package source
+
+import (
+	"context"
+
+	sourceClient "github.com/rudderlabs/rudder-iac/api/client/event-stream/source"
+)
+
+type MockSourceClient struct {
+	createCalled     bool
+	updateCalled     bool
+	deleteCalled     bool
+	getSourcesCalled bool
+	getSourcesFunc   func(ctx context.Context) ([]sourceClient.EventStreamSource, error)
+}
+
+func (m *MockSourceClient) Create(ctx context.Context, req *sourceClient.CreateSourceRequest) (*sourceClient.EventStreamSource, error) {
+	m.createCalled = true
+	return &sourceClient.EventStreamSource{
+		ExternalID:  req.ExternalID,
+		Name:        req.Name,
+		Type:        req.Type,
+		Enabled:     req.Enabled,
+	}, nil
+}
+
+func (m *MockSourceClient) Update(ctx context.Context, sourceID string, req *sourceClient.UpdateSourceRequest) (*sourceClient.EventStreamSource, error) {
+	m.updateCalled = true
+	return &sourceClient.EventStreamSource{
+		ID:          sourceID,
+		ExternalID:  "external-123",
+		Name:        req.Name,
+		Type:        "Javascript",
+		Enabled:     req.Enabled,
+	}, nil
+}
+
+func (m *MockSourceClient) Delete(ctx context.Context, sourceID string) error {
+	m.deleteCalled = true
+	return nil
+}
+
+func (m *MockSourceClient) GetSources(ctx context.Context) ([]sourceClient.EventStreamSource, error) {
+	m.getSourcesCalled = true
+	if m.getSourcesFunc != nil {
+		return m.getSourcesFunc(ctx)
+	}
+	return []sourceClient.EventStreamSource{}, nil
+}
+
+func NewMockSourceClient() *MockSourceClient {
+	return &MockSourceClient{}
+}
+
+func (m *MockSourceClient) SetGetSourcesFunc(f func(ctx context.Context) ([]sourceClient.EventStreamSource, error)) {
+	m.getSourcesFunc = f
+}
+
+func (m *MockSourceClient) CreateCalled() bool {
+	return m.createCalled
+}
+
+func (m *MockSourceClient) UpdateCalled() bool {
+	return m.updateCalled
+}
+
+func (m *MockSourceClient) DeleteCalled() bool {
+	return m.deleteCalled
+}
+
+func (m *MockSourceClient) GetSourcesCalled() bool {
+	return m.getSourcesCalled
+}

--- a/cli/internal/providers/event-stream/source/model.go
+++ b/cli/internal/providers/event-stream/source/model.go
@@ -1,0 +1,35 @@
+package source
+
+const (
+	ResourceType = "event-stream-source"
+
+	IDKey               = "id" // remote id
+	NameKey          = "name"
+	EnabledKey          = "enabled"
+	SourceDefinitionKey = "source_definition"
+)
+
+var sourceDefinitions = []string{
+	"Java",	
+	"DotNet",
+	"PHP",
+	"Flutter",
+	"Cordova",
+	"Rust",
+	"ReactNative",
+	"Python",
+	"iOS",
+	"Android",
+	"Javascript",
+	"Go",
+	"Node",
+	"Ruby",
+	"Unity",
+}
+
+type sourceSpec struct {
+	LocalId      string `mapstructure:"id"`
+	Name    string `mapstructure:"name"`
+	SourceDefinition string `mapstructure:"source_definition"`
+	Enabled bool   `mapstructure:"enabled"`
+}


### PR DESCRIPTION
**Summary**

This PR implements a new event-stream provider for the rudder-iac CLI, enabling management of event stream sources through YAML specifications.

**Key Changes**

  🆕 New Provider Implementation

  - Event Stream Provider (cli/internal/providers/event-stream/provider.go): Core provider for all event stream related resources
  - Source Handler (cli/internal/providers/event-stream/source/handler.go): Specialized handler for managing event stream sources 
  - Model Definitions (cli/internal/providers/event-stream/source/model.go): Type definitions and constants for event stream source specifications

  🔧 Integration

  - Dependencies Integration (cli/internal/app/dependencies.go): Registered the new event stream provider with
   the composite provider system
  - Added event stream client integration and provider initialization