### PR TITLE
feat: add conconcurrency flag to apply and destroy commands

### DIFF
--- a/cli/internal/cmd/project/apply/apply.go
+++ b/cli/internal/cmd/project/apply/apply.go
@@ -7,6 +7,7 @@ import (
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/rudderlabs/rudder-iac/cli/internal/app"
 	"github.com/rudderlabs/rudder-iac/cli/internal/cmd/telemetry"
+	"github.com/rudderlabs/rudder-iac/cli/internal/config"
 	"github.com/rudderlabs/rudder-iac/cli/internal/logger"
 	"github.com/rudderlabs/rudder-iac/cli/internal/project"
 	"github.com/rudderlabs/rudder-iac/cli/internal/syncer"
@@ -22,12 +23,13 @@ var (
 
 func NewCmdApply() *cobra.Command {
 	var (
-		deps     app.Deps
-		p        project.Project
-		err      error
-		location string
-		dryRun   bool
-		confirm  bool
+		deps        app.Deps
+		p           project.Project
+		err         error
+		location    string
+		dryRun      bool
+		confirm     bool
+		concurrency int
 	)
 
 	cmd := &cobra.Command{
@@ -47,6 +49,11 @@ func NewCmdApply() *cobra.Command {
 			deps, err = app.NewDeps()
 			if err != nil {
 				return fmt.Errorf("initialising dependencies: %w", err)
+			}
+
+			// Validate concurrency flag usage
+			if cmd.Flags().Changed("concurrency") && !config.GetConfig().ExperimentalFlags.ConcurrentSyncs {
+				return fmt.Errorf("concurrency flag is only allowed when ConcurrentSyncs experimental feature is enabled")
 			}
 
 			p = project.New(location, deps.CompositeProvider())
@@ -87,8 +94,9 @@ func NewCmdApply() *cobra.Command {
 				context.Background(),
 				graph,
 				syncer.SyncOptions{
-					DryRun:  dryRun,
-					Confirm: confirm,
+					DryRun:      dryRun,
+					Confirm:     confirm,
+					Concurrency: concurrency,
 				})
 
 			if err != nil {
@@ -108,5 +116,6 @@ func NewCmdApply() *cobra.Command {
 	cmd.Flags().StringVarP(&location, "location", "l", ".", "Path to the directory containing the project files or a specific file")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Only show the changes without applying them")
 	cmd.Flags().BoolVar(&confirm, "confirm", true, "Confirm changes before applying them")
+	cmd.Flags().IntVar(&concurrency, "concurrency", 30, "Number of concurrent operations to run (only allowed when ConcurrentSyncs experimental feature is enabled)")
 	return cmd
 }


### PR DESCRIPTION
**Summary**

  - Added --concurrency flag to both apply and destroy commands with a default valueof 30
  - Flag is gated behind the `ConcurrentSyncs` experimental feature for explicit usage
  - Users can see the flag in help output but can only override the default when the experimental feature is enabled

  **Changes Made**

  Apply Command (internal/cmd/project/apply/apply.go):
  - Added concurrency variable and flag registration
  - Added validation to prevent explicit usage when ConcurrentSyncs is disabled
  - Updated SyncOptions to pass concurrency value to the syncer

  Destroy Command (internal/cmd/project/destroy/destroy.go):
  - Added concurrency variable and flag registration
  - Added validation to prevent explicit usage when ConcurrentSyncs is disabled
  - Updated SyncOptions to pass concurrency value to the syncer