### PR TITLE
feat: use new event stream sources APIs

### DIFF
--- a/api/client/event-stream/source/source.go
+++ b/api/client/event-stream/source/source.go
@@ -9,7 +9,7 @@ import (
 	"github.com/rudderlabs/rudder-iac/api/client"
 )
 
-const prefix = "/v2/sources"
+const prefix = "/v2/event-stream-sources"
 
 type SourceStore interface {
 	Create(ctx context.Context, source *CreateSourceRequest) (*EventStreamSource, error)
@@ -38,11 +38,11 @@ func (r *rudderSourceStore) Create(ctx context.Context, source *CreateSourceRequ
 	if err != nil {
 		return nil, fmt.Errorf("creating event stream source: %w", err)
 	}
-	var result sourceResponse
+	var result EventStreamSource
 	if err := json.Unmarshal(resp, &result); err != nil {
 		return nil, fmt.Errorf("unmarshalling create source response: %w", err)
 	}
-	return &result.Source, nil
+	return &result, nil
 }
 
 func (r *rudderSourceStore) Update(ctx context.Context, sourceId string, source *UpdateSourceRequest) (*EventStreamSource, error) {
@@ -56,11 +56,11 @@ func (r *rudderSourceStore) Update(ctx context.Context, sourceId string, source 
 		return nil, fmt.Errorf("updating event stream source: %w", err)
 	}
 
-	var result sourceResponse
+	var result EventStreamSource
 	if err := json.Unmarshal(resp, &result); err != nil {
 		return nil, fmt.Errorf("unmarshalling update source response: %w", err)
 	}
-	return &result.Source, nil
+	return &result, nil
 }
 
 func (r *rudderSourceStore) Delete(ctx context.Context, sourceId string) error {
@@ -73,7 +73,7 @@ func (r *rudderSourceStore) Delete(ctx context.Context, sourceId string) error {
 }
 
 func (r *rudderSourceStore) GetSources(ctx context.Context) ([]EventStreamSource, error) {
-	data, err := r.client.Do(ctx, "GET", prefix, nil)
+	data, err := r.client.Do(ctx, "GET", "/v2/sources", nil)
 	if err != nil {
 		return nil, fmt.Errorf("sending read state request: %w", err)
 	}

--- a/api/client/event-stream/source/source_test.go
+++ b/api/client/event-stream/source/source_test.go
@@ -16,17 +16,15 @@ func TestCreateSource(t *testing.T) {
 	httpClient := testutils.NewMockHTTPClient(t, testutils.Call{
 		Validate: func(req *http.Request) bool {
 			expected := `{"externalId":"ext-123","name":"Test Source","type":"webhook","enabled":true}`
-			return testutils.ValidateRequest(t, req, "POST", "/v2/sources", expected)
+			return testutils.ValidateRequest(t, req, "POST", "/v2/event-stream-sources", expected)
 		},
 		ResponseStatus: 200,
 		ResponseBody: `{
-			"source": {
-				"id": "src-123",
-				"externalId": "ext-123",
-				"name": "Test Source",
-				"type": "webhook",
-				"enabled": true
-			}
+			"id": "src-123",
+			"externalId": "ext-123",
+			"name": "Test Source",
+			"type": "webhook",
+			"enabled": true
 		}`,
 	})
 
@@ -46,11 +44,11 @@ func TestCreateSource(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, &esSource.EventStreamSource{
-		ID:          "src-123",
-		ExternalID:  "ext-123",
-		Name:        "Test Source",
-		Type:        "webhook",
-		Enabled:     true,
+		ID:         "src-123",
+		ExternalID: "ext-123",
+		Name:       "Test Source",
+		Type:       "webhook",
+		Enabled:    true,
 	}, created)
 	httpClient.AssertNumberOfCalls()
 }
@@ -59,17 +57,15 @@ func TestUpdateSource(t *testing.T) {
 	httpClient := testutils.NewMockHTTPClient(t, testutils.Call{
 		Validate: func(req *http.Request) bool {
 			expected := `{"name":"Updated Source"}`
-			return testutils.ValidateRequest(t, req, "PUT", "/v2/sources/src-123", expected)
+			return testutils.ValidateRequest(t, req, "PUT", "/v2/event-stream-sources/src-123", expected)
 		},
 		ResponseStatus: 200,
 		ResponseBody: `{
-			"source": {
-				"id": "src-123",
-				"externalId": "ext-123",
-				"name": "Updated Source",
-				"type": "webhook",
-				"enabled": true
-			}
+			"id": "src-123",
+			"externalId": "ext-123",
+			"name": "Updated Source",
+			"type": "webhook",
+			"enabled": true
 		}`,
 	})
 
@@ -86,11 +82,11 @@ func TestUpdateSource(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, &esSource.EventStreamSource{
-		ID:          "src-123",
-		ExternalID:  "ext-123",
-		Name:        "Updated Source",
-		Type:        "webhook",
-		Enabled:     true,
+		ID:         "src-123",
+		ExternalID: "ext-123",
+		Name:       "Updated Source",
+		Type:       "webhook",
+		Enabled:    true,
 	}, updated)
 
 	httpClient.AssertNumberOfCalls()
@@ -99,7 +95,7 @@ func TestUpdateSource(t *testing.T) {
 func TestDeleteSource(t *testing.T) {
 	httpClient := testutils.NewMockHTTPClient(t, testutils.Call{
 		Validate: func(req *http.Request) bool {
-			return testutils.ValidateRequest(t, req, "DELETE", "/v2/sources/src-123", "")
+			return testutils.ValidateRequest(t, req, "DELETE", "/v2/event-stream-sources/src-123", "")
 		},
 		ResponseStatus: 204,
 	})
@@ -150,18 +146,18 @@ func TestGetSources(t *testing.T) {
 
 	assert.Equal(t, []esSource.EventStreamSource{
 		{
-			ID:          "src-123",
-			ExternalID:  "ext-123",
-			Name:        "Source 1",
-			Type:        "webhook",
-			Enabled:     true,
+			ID:         "src-123",
+			ExternalID: "ext-123",
+			Name:       "Source 1",
+			Type:       "webhook",
+			Enabled:    true,
 		},
 		{
-			ID:          "src-456",
-			ExternalID:  "ext-456",
-			Name:        "Source 2",
-			Type:        "api",
-			Enabled:     false,
+			ID:         "src-456",
+			ExternalID: "ext-456",
+			Name:       "Source 2",
+			Type:       "api",
+			Enabled:    false,
 		},
 	}, sources)
 }

--- a/api/client/event-stream/source/types.go
+++ b/api/client/event-stream/source/types.go
@@ -12,10 +12,6 @@ type UpdateSourceRequest struct {
 	Enabled bool   `json:"enabled,omitempty"`
 }
 
-type sourceResponse struct {
-	Source EventStreamSource `json:"source"`
-}
-
 type EventStreamSource struct {
 	ID          string `json:"id"`
 	ExternalID  string `json:"externalId"`

--- a/cli/internal/providers/event-stream/provider_test.go
+++ b/cli/internal/providers/event-stream/provider_test.go
@@ -45,7 +45,7 @@ func TestProvider(t *testing.T) {
 				Spec: map[string]interface{}{
 					"id":                "test-source",
 					"name":              "Test Source",
-					"source_definition": "Javascript",
+					"type": "javascript",
 					"enabled":           true,
 				},
 			})
@@ -82,7 +82,7 @@ func TestProvider(t *testing.T) {
 						Spec: map[string]interface{}{
 							"id":                "test-source-1",
 							"name":              "Test Source 1",
-							"source_definition": "Javascript",
+							"type": "javascript",
 							"enabled":           true,
 						},
 					},
@@ -138,7 +138,7 @@ func TestProvider(t *testing.T) {
 			Spec: map[string]interface{}{
 				"id":                "test-source-1",
 				"name":              "Test Source 1",
-				"source_definition": "Javascript",
+				"type": "javascript",
 				"enabled":           true,
 			},
 		})
@@ -149,7 +149,7 @@ func TestProvider(t *testing.T) {
 			Spec: map[string]interface{}{
 				"id":                "test-source-2",
 				"name":              "Test Source 2",
-				"source_definition": "Python",
+				"type": "python",
 				"enabled":           false,
 			},
 		})
@@ -182,14 +182,14 @@ func TestProvider(t *testing.T) {
 					ID:         "remote123",
 					ExternalID: "external-123",
 					Name:       "Test Source 1",
-					Type:       "Javascript",
+					Type:       "javascript",
 					Enabled:    true,
 				},
 				{
 					ID:         "remote456",
 					ExternalID: "external-456",
 					Name:       "Test Source 2",
-					Type:       "Python",
+					Type:       "python",
 					Enabled:    false,
 				},
 			}, nil
@@ -211,7 +211,7 @@ func TestProvider(t *testing.T) {
 			Input: resources.ResourceData{
 				"name":              "Test Source 1",
 				"enabled":           true,
-				"source_definition": "Javascript",
+				"type": "javascript",
 			},
 			Output: resources.ResourceData{
 				"id": "remote123",
@@ -225,7 +225,7 @@ func TestProvider(t *testing.T) {
 			Input: resources.ResourceData{
 				"name":              "Test Source 2",
 				"enabled":           false,
-				"source_definition": "Python",
+				"type": "python",
 			},
 			Output: resources.ResourceData{
 				"id": "remote456",
@@ -241,7 +241,7 @@ func TestProvider(t *testing.T) {
 			createData := resources.ResourceData{
 				"name":              "Test Source",
 				"enabled":           true,
-				"source_definition": "Javascript",
+				"type": "javascript",
 			}
 
 			result, err := provider.Create(ctx, "test-source", source.ResourceType, createData)
@@ -249,7 +249,7 @@ func TestProvider(t *testing.T) {
 			require.Equal(t, &resources.ResourceData{
 				"name":              "Test Source",
 				"enabled":           true,
-				"source_definition": "Javascript",
+				"type": "javascript",
 			}, result)
 		})
 
@@ -271,7 +271,7 @@ func TestProvider(t *testing.T) {
 			assert.Equal(t, &resources.ResourceData{
 				"name":              "Updated Source",
 				"enabled":           false,
-				"source_definition": "Javascript",
+				"type": "javascript",
 			}, result)
 		})
 
@@ -305,7 +305,7 @@ func TestProvider(t *testing.T) {
 					ID:         "remote123",
 					ExternalID: "external-123",
 					Name:       "Test Source 1",
-					Type:       "Javascript",
+					Type:       "javascript",
 					Enabled:    true,
 				},
 				{
@@ -332,7 +332,7 @@ func TestProvider(t *testing.T) {
 					ID:         "remote123",
 					ExternalID: "external-123",
 					Name:       "Test Source 1",
-					Type:       "Javascript",
+					Type:       "javascript",
 					Enabled:    true,
 				},
 			},
@@ -366,7 +366,7 @@ func TestProvider(t *testing.T) {
 					ID:         "remote123",
 					ExternalID: "external-123",
 					Name:       "Test Source 1",
-					Type:       "Javascript",
+					Type:       "javascript",
 					Enabled:    true,
 				},
 			},
@@ -377,7 +377,7 @@ func TestProvider(t *testing.T) {
 					ID:         "remote456",
 					ExternalID: "external-456",
 					Name:       "Test Source 2",
-					Type:       "Python",
+					Type:       "python",
 					Enabled:    false,
 				},
 			},
@@ -397,7 +397,7 @@ func TestProvider(t *testing.T) {
 				Input: resources.ResourceData{
 					"name":              "Test Source 1",
 					"enabled":           true,
-					"source_definition": "Javascript",
+					"type": "javascript",
 				},
 				Output: resources.ResourceData{
 					"id": "remote123",
@@ -409,7 +409,7 @@ func TestProvider(t *testing.T) {
 				Input: resources.ResourceData{
 					"name":              "Test Source 2",
 					"enabled":           false,
-					"source_definition": "Python",
+					"type": "python",
 				},
 				Output: resources.ResourceData{
 					"id": "remote456",

--- a/cli/internal/providers/event-stream/source/handler.go
+++ b/cli/internal/providers/event-stream/source/handler.go
@@ -41,10 +41,10 @@ func validateSource(source *sourceSpec) error {
 		return fmt.Errorf("name is required")
 	}
 	if source.SourceDefinition == "" {
-		return fmt.Errorf("source_definition is required")
+		return fmt.Errorf("type is required")
 	}
 	if !slices.Contains(sourceDefinitions, source.SourceDefinition) {
-		return fmt.Errorf("source_definition '%s' is invalid, must be one of: %v", source.SourceDefinition, sourceDefinitions)
+		return fmt.Errorf("type '%s' is invalid, must be one of: %v", source.SourceDefinition, sourceDefinitions)
 	}
 	return nil
 }
@@ -88,7 +88,7 @@ func (h *Handler) Create(ctx context.Context, id string, data resources.Resource
 
 func (h *Handler) Update(ctx context.Context, id string, data resources.ResourceData, state resources.ResourceData) (*resources.ResourceData, error) {
 	if state[SourceDefinitionKey] != data[SourceDefinitionKey] {
-		return nil, fmt.Errorf("source_definition cannot be changed")
+		return nil, fmt.Errorf("type cannot be changed")
 	}
 	remoteID, ok := state[IDKey].(string)
 	if !ok {

--- a/cli/internal/providers/event-stream/source/handler_test.go
+++ b/cli/internal/providers/event-stream/source/handler_test.go
@@ -26,7 +26,7 @@ func TestEventStreamSourceHandler(t *testing.T) {
 				Spec: map[string]interface{}{
 					"id":                123,
 					"name":              "Test Source",
-					"source_definition": "Javascript",
+					"type": "javascript",
 					"enabled":           true,
 				},
 			}
@@ -45,7 +45,7 @@ func TestEventStreamSourceHandler(t *testing.T) {
 				Spec: map[string]interface{}{
 					"id":                "test-source",
 					"name":              "Test Source",
-					"source_definition": "Javascript",
+					"type": "javascript",
 					"enabled":           true,
 				},
 			}
@@ -75,7 +75,7 @@ func TestEventStreamSourceHandler(t *testing.T) {
 						Spec: map[string]interface{}{
 							"id":                "test-source-1",
 							"name":              "Test Source 1",
-							"source_definition": "Javascript",
+							"type": "javascript",
 							"enabled":           true,
 						},
 					},
@@ -85,7 +85,7 @@ func TestEventStreamSourceHandler(t *testing.T) {
 						Spec: map[string]interface{}{
 							"id":                "test-source-2",
 							"name":              "Test Source 2",
-							"source_definition": "Python",
+							"type": "python",
 							"enabled":           false,
 						},
 					},
@@ -100,7 +100,7 @@ func TestEventStreamSourceHandler(t *testing.T) {
 						Kind:    "event-stream-source",
 						Spec: map[string]interface{}{
 							"name":              "Test Source",
-							"source_definition": "Javascript",
+							"type": "javascript",
 							"enabled":           true,
 						},
 					},
@@ -116,7 +116,7 @@ func TestEventStreamSourceHandler(t *testing.T) {
 						Kind:    "event-stream-source",
 						Spec: map[string]interface{}{
 							"id":                "test-source",
-							"source_definition": "Javascript",
+							"type": "javascript",
 							"enabled":           true,
 						},
 					},
@@ -125,7 +125,7 @@ func TestEventStreamSourceHandler(t *testing.T) {
 				errorMessage:  "name is required",
 			},
 			{
-				name: "Missing source_definition",
+				name: "Missing type",
 				specs: []*specs.Spec{
 					{
 						Version: "rudder/v0.1",
@@ -138,10 +138,10 @@ func TestEventStreamSourceHandler(t *testing.T) {
 					},
 				},
 				expectedError: true,
-				errorMessage:  "source_definition is required",
+				errorMessage:  "type is required",
 			},
 			{
-				name: "Invalid source_definition",
+				name: "Invalid type",
 				specs: []*specs.Spec{
 					{
 						Version: "rudder/v0.1",
@@ -149,13 +149,13 @@ func TestEventStreamSourceHandler(t *testing.T) {
 						Spec: map[string]interface{}{
 							"id":                "test-source",
 							"name":              "Test Source",
-							"source_definition": "InvalidSDK",
+							"type": "InvalidSDK",
 							"enabled":           true,
 						},
 					},
 				},
 				expectedError: true,
-				errorMessage:  "source_definition 'InvalidSDK' is invalid",
+				errorMessage:  "type 'InvalidSDK' is invalid",
 			},
 		}
 
@@ -193,7 +193,7 @@ func TestEventStreamSourceHandler(t *testing.T) {
 			Spec: map[string]interface{}{
 				"id":                "test-source-1",
 				"name":              "Test Source 1",
-				"source_definition": "Javascript",
+				"type": "javascript",
 				"enabled":           true,
 			},
 		}
@@ -210,7 +210,7 @@ func TestEventStreamSourceHandler(t *testing.T) {
 		assert.Equal(t, resources.ResourceData{
 			"name":              "Test Source 1",
 			"enabled":           true,
-			"source_definition": "Javascript",
+			"type": "javascript",
 		}, res[0].Data())
 		assert.Empty(t, res[0].Dependencies())
 	})
@@ -222,7 +222,7 @@ func TestEventStreamSourceHandler(t *testing.T) {
 		data := resources.ResourceData{
 			"name":              "Test Source",
 			"enabled":           true,
-			"source_definition": "Javascript",
+			"type": "javascript",
 		}
 
 		result, err := handler.Create(context.Background(), "test-source", data)
@@ -232,7 +232,7 @@ func TestEventStreamSourceHandler(t *testing.T) {
 		assert.Equal(t, &resources.ResourceData{
 			"name":              "Test Source",
 			"enabled":           true,
-			"source_definition": "Javascript",
+			"type": "javascript",
 		}, result)
 	})
 
@@ -244,13 +244,13 @@ func TestEventStreamSourceHandler(t *testing.T) {
 			data := resources.ResourceData{
 				"name":              "Updated Source",
 				"enabled":           false,
-				"source_definition": "Javascript",
+				"type": "javascript",
 			}
 			state := resources.ResourceData{
 				"id":                "remote123",
 				"name":              "Original Source",
 				"enabled":           true,
-				"source_definition": "Javascript",
+				"type": "javascript",
 			}
 
 			result, err := handler.Update(context.Background(), "test-source", data, state)
@@ -260,7 +260,7 @@ func TestEventStreamSourceHandler(t *testing.T) {
 			assert.Equal(t, &resources.ResourceData{
 				"name":              "Updated Source",
 				"enabled":           false,
-				"source_definition": "Javascript",
+				"type": "javascript",
 			}, result)
 		})
 
@@ -269,19 +269,19 @@ func TestEventStreamSourceHandler(t *testing.T) {
 			handler := source.NewHandler(mockClient)
 
 			data := resources.ResourceData{
-				"source_definition": "Python",
+				"type": "python",
 			}
 			state := resources.ResourceData{
 				"id":                "remote123",
 				"name":              "Original Source",
 				"enabled":           true,
-				"source_definition": "Javascript",
+				"type": "javascript",
 			}
 
 			_, err := handler.Update(context.Background(), "test-source", data, state)
 
 			assert.Error(t, err)
-			assert.Contains(t, err.Error(), "source_definition cannot be changed")
+			assert.Contains(t, err.Error(), "type cannot be changed")
 			assert.False(t, mockClient.UpdateCalled())
 		})
 	})
@@ -308,21 +308,21 @@ func TestEventStreamSourceHandler(t *testing.T) {
 					ID:         "remote123",
 					ExternalID: "external-123",
 					Name:       "Test Source 1",
-					Type:       "Javascript",
+					Type:       "javascript",
 					Enabled:    true,
 				},
 				{
 					ID:         "remote456",
 					ExternalID: "external-456",
 					Name:       "Test Source 2",
-					Type:       "Python",
+					Type:       "python",
 					Enabled:    false,
 				},
 				{
 					ID:         "remote789",
 					ExternalID: "", // This should be skipped
 					Name:       "Test Source 3",
-					Type:       "Go",
+					Type:       "go",
 					Enabled:    true,
 				},
 			}, nil
@@ -344,7 +344,7 @@ func TestEventStreamSourceHandler(t *testing.T) {
 			Input: resources.ResourceData{
 				"name":              "Test Source 1",
 				"enabled":           true,
-				"source_definition": "Javascript",
+				"type": "javascript",
 			},
 			Output: resources.ResourceData{
 				"id": "remote123",
@@ -358,7 +358,7 @@ func TestEventStreamSourceHandler(t *testing.T) {
 			Input: resources.ResourceData{
 				"name":              "Test Source 2",
 				"enabled":           false,
-				"source_definition": "Python",
+				"type": "python",
 			},
 			Output: resources.ResourceData{
 				"id": "remote456",
@@ -374,14 +374,14 @@ func TestEventStreamSourceHandler(t *testing.T) {
 					ID:         "remote123",
 					ExternalID: "external-123",
 					Name:       "Test Source 1",
-					Type:       "Javascript",
+					Type:       "javascript",
 					Enabled:    true,
 				},
 				{
 					ID:         "remote456",
 					ExternalID: "external-456",
 					Name:       "Test Source 2",
-					Type:       "Python",
+					Type:       "python",
 					Enabled:    false,
 				},
 			}, nil
@@ -404,7 +404,7 @@ func TestEventStreamSourceHandler(t *testing.T) {
 					ID:         "remote123",
 					ExternalID: "external-123",
 					Name:       "Test Source 1",
-					Type:       "Javascript",
+					Type:       "javascript",
 					Enabled:    true,
 				},
 			},
@@ -415,7 +415,7 @@ func TestEventStreamSourceHandler(t *testing.T) {
 					ID:         "remote456",
 					ExternalID: "external-456",
 					Name:       "Test Source 2",
-					Type:       "Python",
+					Type:       "python",
 					Enabled:    false,
 				},
 			},
@@ -435,7 +435,7 @@ func TestEventStreamSourceHandler(t *testing.T) {
 					ID:         "remote123",
 					ExternalID: "external-123",
 					Name:       "Test Source 1",
-					Type:       "Javascript",
+					Type:       "javascript",
 					Enabled:    true,
 				},
 			},
@@ -446,7 +446,7 @@ func TestEventStreamSourceHandler(t *testing.T) {
 					ID:         "remote456",
 					ExternalID: "",
 					Name:       "Test Source 2",
-					Type:       "Python",
+					Type:       "python",
 					Enabled:    false,
 				},
 			},
@@ -466,7 +466,7 @@ func TestEventStreamSourceHandler(t *testing.T) {
 				Input: resources.ResourceData{
 					"name":              "Test Source 1",
 					"enabled":           true,
-					"source_definition": "Javascript",
+					"type": "javascript",
 				},
 				Output: resources.ResourceData{
 					"id": "remote123",

--- a/cli/internal/providers/event-stream/source/mock_client.go
+++ b/cli/internal/providers/event-stream/source/mock_client.go
@@ -34,7 +34,7 @@ func (m *MockSourceClient) Update(ctx context.Context, sourceID string, req *sou
 		ID:         sourceID,
 		ExternalID: "external-123",
 		Name:       req.Name,
-		Type:       "Javascript",
+		Type:       "javascript",
 		Enabled:    req.Enabled,
 	}, nil
 }

--- a/cli/internal/providers/event-stream/source/model.go
+++ b/cli/internal/providers/event-stream/source/model.go
@@ -4,32 +4,32 @@ const (
 	ResourceType = "event-stream-source"
 
 	IDKey               = "id" // remote id
-	NameKey          = "name"
+	NameKey             = "name"
 	EnabledKey          = "enabled"
-	SourceDefinitionKey = "source_definition"
+	SourceDefinitionKey = "type"
 )
 
 var sourceDefinitions = []string{
-	"Java",	
-	"DotNet",
-	"PHP",
-	"Flutter",
-	"Cordova",
-	"Rust",
-	"ReactNative",
-	"Python",
-	"iOS",
-	"Android",
-	"Javascript",
-	"Go",
-	"Node",
-	"Ruby",
-	"Unity",
+	"java",
+	"dotnet",
+	"php",
+	"flutter",
+	"cordova",
+	"rust",
+	"react_native",
+	"python",
+	"ios",
+	"android",
+	"javascript",
+	"go",
+	"node",
+	"ruby",
+	"unity",
 }
 
 type sourceSpec struct {
-	LocalId      string `mapstructure:"id"`
-	Name    string `mapstructure:"name"`
-	SourceDefinition string `mapstructure:"source_definition"`
-	Enabled bool   `mapstructure:"enabled"`
+	LocalId          string `mapstructure:"id"`
+	Name             string `mapstructure:"name"`
+	SourceDefinition string `mapstructure:"type"`
+	Enabled          bool   `mapstructure:"enabled"`
 }


### PR DESCRIPTION
This PR updates the event stream sources implementation to use the new API endpoints and response format.

**Changes**

  - API Endpoint: Changed from /v2/sources to /v2/event-stream-sources for create, update, and delete operations
  - Field Naming: Updated source_definition field to type with lowercase values (e.g., Javascript → javascript, ReactNative →
  react_native)

**Technical Details**

  - Updated all client methods (Create, Update, Delete) to work with the new response format
  - Updated test cases to reflect the new API endpoints and response structure
  - All source definition values are now lowercase and use snake_case where applicable