### PR TITLE
feat(typer): support for json schema based plan provider

### DIFF
--- a/api/client/catalog/trackingplans.go
+++ b/api/client/catalog/trackingplans.go
@@ -163,6 +163,7 @@ type TrackingPlanStore interface {
 	DeleteTrackingPlan(ctx context.Context, id string) error
 	DeleteTrackingPlanEvent(ctx context.Context, trackingPlanId string, eventId string) error
 	GetTrackingPlan(ctx context.Context, id string) (*TrackingPlanWithIdentifiers, error)
+	GetTrackingPlanWithSchemas(ctx context.Context, id string) (*TrackingPlanWithSchemas, error)
 	GetTrackingPlanEventSchema(ctx context.Context, id string, eventId string) (*TrackingPlanEventSchema, error)
 	GetTrackingPlanEventWithIdentifiers(ctx context.Context, id, eventId string) (*TrackingPlanEventPropertyIdentifiers, error)
 	UpdateTrackingPlanEvent(ctx context.Context, id string, input EventIdentifierDetail) (*TrackingPlan, error)
@@ -278,6 +279,44 @@ func (c *RudderDataCatalog) GetTrackingPlan(ctx context.Context, id string) (*Tr
 	trackingPlan.Events = make([]TrackingPlanEventPropertyIdentifiers, len(events.Data))
 	for i, event := range events.Data {
 		schema, err := c.GetTrackingPlanEventWithIdentifiers(ctx, id, event.ID)
+		if err != nil {
+			return nil, fmt.Errorf("fetching event schema: %s on tracking plan: %s: %w", event.ID, id, err)
+		}
+		trackingPlan.Events[i] = *schema
+	}
+
+	return &trackingPlan, nil
+}
+
+func (c *RudderDataCatalog) GetTrackingPlanWithSchemas(ctx context.Context, id string) (*TrackingPlanWithSchemas, error) {
+	resp, err := c.client.Do(ctx, "GET", fmt.Sprintf("v2/catalog/tracking-plans/%s", id), nil)
+	if err != nil {
+		return nil, fmt.Errorf("executing http request to fetch tracking plan: %w", err)
+	}
+
+	trackingPlan := TrackingPlanWithSchemas{}
+	if err := json.NewDecoder(bytes.NewReader(resp)).Decode(&trackingPlan); err != nil {
+		return nil, fmt.Errorf("decoding tracking plan response: %w", err)
+	}
+
+	var events struct {
+		Data []struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+
+	eventsResp, err := c.client.Do(ctx, "GET", fmt.Sprintf("v2/catalog/tracking-plans/%s/events", id), nil)
+	if err != nil {
+		return nil, fmt.Errorf("executing http request to fetch events on tracking plan: %w", err)
+	}
+
+	if err := json.NewDecoder(bytes.NewReader(eventsResp)).Decode(&events); err != nil {
+		return nil, fmt.Errorf("decoding events response: %w, response: %s", err, string(eventsResp))
+	}
+
+	trackingPlan.Events = make([]TrackingPlanEventSchema, len(events.Data))
+	for i, event := range events.Data {
+		schema, err := c.GetTrackingPlanEventSchema(ctx, id, event.ID)
 		if err != nil {
 			return nil, fmt.Errorf("fetching event schema: %s on tracking plan: %s: %w", event.ID, id, err)
 		}

--- a/cli/internal/providers/datacatalog/empty_catalog.go
+++ b/cli/internal/providers/datacatalog/empty_catalog.go
@@ -72,6 +72,10 @@ func (m *EmptyCatalog) GetTrackingPlan(ctx context.Context, id string) (*catalog
 	return nil, nil
 }
 
+func (m *EmptyCatalog) GetTrackingPlanWithSchemas(ctx context.Context, id string) (*catalog.TrackingPlanWithSchemas, error) {
+	return nil, nil
+}
+
 func (m *EmptyCatalog) GetTrackingPlanEventSchema(ctx context.Context, id string, eventId string) (*catalog.TrackingPlanEventSchema, error) {
 	return nil, nil
 }

--- a/cli/internal/providers/datacatalog/trackingplan_test.go
+++ b/cli/internal/providers/datacatalog/trackingplan_test.go
@@ -50,6 +50,10 @@ func (m *MockTrackingPlanCatalog) GetTrackingPlan(ctx context.Context, id string
 	return m.tpWithIdentifiers, m.err
 }
 
+func (m *MockTrackingPlanCatalog) GetTrackingPlanWithSchemas(ctx context.Context, id string) (*catalog.TrackingPlanWithSchemas, error) {
+	return m.tpWithSchema, m.err
+}
+
 func (m *MockTrackingPlanCatalog) GetTrackingPlanEventSchema(ctx context.Context, id string, eventId string) (*catalog.TrackingPlanEventSchema, error) {
 	return m.tpes, m.err
 }

--- a/cli/internal/typer/generator/platforms/kotlin/naming.go
+++ b/cli/internal/typer/generator/platforms/kotlin/naming.go
@@ -143,9 +143,9 @@ func getOrRegisterEventDataClassName(rule *plan.EventRule, nameRegistry *core.Na
 
 	var suffix string
 	switch rule.Section {
-	case plan.EventRuleSectionProperties:
+	case plan.IdentitySectionProperties:
 		suffix = "Properties"
-	case plan.EventRuleSectionTraits:
+	case plan.IdentitySectionTraits:
 		suffix = "Traits"
 	default:
 		return "", fmt.Errorf("unsupported event rule section: %s", rule.Section)

--- a/cli/internal/typer/generator/platforms/kotlin/rudderanalytics.go
+++ b/cli/internal/typer/generator/platforms/kotlin/rudderanalytics.go
@@ -8,11 +8,11 @@ import (
 )
 
 // sectionToParamName converts an EventRuleSection to the appropriate parameter name
-func sectionToParamName(section plan.EventRuleSection) (string, error) {
+func sectionToParamName(section plan.IdentitySection) (string, error) {
 	switch section {
-	case plan.EventRuleSectionProperties:
+	case plan.IdentitySectionProperties:
 		return "properties", nil
-	case plan.EventRuleSectionTraits:
+	case plan.IdentitySectionTraits:
 		return "traits", nil
 	default:
 		return "", fmt.Errorf("unknown event rule section: %s", section)

--- a/cli/internal/typer/plan/helpers.go
+++ b/cli/internal/typer/plan/helpers.go
@@ -47,14 +47,16 @@ func (tp *TrackingPlan) ExtractAllProperties() map[string]*Property {
 // The customTypes map is modified in place to accumulate results
 func extractCustomTypesFromSchema(schema *ObjectSchema, customTypes map[string]*CustomType) {
 	for _, propSchema := range schema.Properties {
-		if propSchema.Property.IsCustomType() {
-			customType := propSchema.Property.CustomType()
-			if customType != nil {
-				customTypes[customType.Name] = customType
+		for _, t := range propSchema.Property.Type {
+			if IsCustomType(t) {
+				customType := AsCustomType(t)
+				if customType != nil {
+					customTypes[customType.Name] = customType
 
-				// Recursively process referenced by object custom types
-				if customType.Schema != nil {
-					extractCustomTypesFromSchema(customType.Schema, customTypes)
+					// Recursively process referenced by object custom types
+					if customType.Schema != nil {
+						extractCustomTypesFromSchema(customType.Schema, customTypes)
+					}
 				}
 			}
 		}

--- a/cli/internal/typer/plan/plan.go
+++ b/cli/internal/typer/plan/plan.go
@@ -1,5 +1,9 @@
 package plan
 
+import (
+	"fmt"
+)
+
 /*
  * Event related types
  */
@@ -22,6 +26,24 @@ type Event struct {
 	Description string    `json:"description,omitempty"`
 }
 
+// ParseEventType converts a string to an EventType, returning an error for unknown types
+func ParseEventType(s string) (EventType, error) {
+	switch s {
+	case string(EventTypeTrack):
+		return EventTypeTrack, nil
+	case string(EventTypeIdentify):
+		return EventTypeIdentify, nil
+	case string(EventTypePage):
+		return EventTypePage, nil
+	case string(EventTypeScreen):
+		return EventTypeScreen, nil
+	case string(EventTypeGroup):
+		return EventTypeGroup, nil
+	default:
+		return "", fmt.Errorf("invalid event type: %s", s)
+	}
+}
+
 /*
  * Property related types
  */
@@ -31,11 +53,11 @@ type PrimitiveType string
 
 const (
 	PrimitiveTypeString  PrimitiveType = "string"
+	PrimitiveTypeInteger PrimitiveType = "integer"
 	PrimitiveTypeNumber  PrimitiveType = "number"
 	PrimitiveTypeBoolean PrimitiveType = "boolean"
 	PrimitiveTypeArray   PrimitiveType = "array"
 	PrimitiveTypeObject  PrimitiveType = "object"
-	PrimitiveTypeDate    PrimitiveType = "date"
 )
 
 // PropertyType represents either a primitive type or a custom type
@@ -51,32 +73,56 @@ type PropertyConfig struct {
 type Property struct {
 	Name        string          `json:"name"`
 	Description string          `json:"description"`
-	Type        PropertyType    `json:"type"`
+	Type        []PropertyType  `json:"type"`
 	Config      *PropertyConfig `json:"config,omitempty"`
 }
 
-func (p *Property) IsPrimitive() bool {
-	_, ok := p.Type.(PrimitiveType)
+// IsPrimitiveType checks if the PropertyType is a PrimitiveType
+func IsPrimitiveType(t PropertyType) bool {
+	_, ok := t.(PrimitiveType)
 	return ok
 }
 
-func (p Property) IsCustomType() bool {
-	_, ok := p.Type.(CustomType)
-	return ok
-}
-
-func (p *Property) CustomType() *CustomType {
-	if customType, ok := p.Type.(CustomType); ok {
-		return &customType
+// AsPrimitiveType converts a PropertyType to a PrimitiveType pointer if possible, else returns nil
+func AsPrimitiveType(t PropertyType) *PrimitiveType {
+	if primitiveType, ok := t.(PrimitiveType); ok {
+		return &primitiveType
 	}
 	return nil
 }
 
-func (p *Property) PrimitiveType() PrimitiveType {
-	if primitiveType, ok := p.Type.(PrimitiveType); ok {
-		return primitiveType
+// ParsePrimitiveType converts a string to a PrimitiveType, returning an error for unknown types
+func ParsePrimitiveType(s string) (PrimitiveType, error) {
+	switch s {
+	case string(PrimitiveTypeString):
+		return PrimitiveTypeString, nil
+	case string(PrimitiveTypeInteger):
+		return PrimitiveTypeInteger, nil
+	case string(PrimitiveTypeNumber):
+		return PrimitiveTypeNumber, nil
+	case string(PrimitiveTypeBoolean):
+		return PrimitiveTypeBoolean, nil
+	case string(PrimitiveTypeArray):
+		return PrimitiveTypeArray, nil
+	case string(PrimitiveTypeObject):
+		return PrimitiveTypeObject, nil
+	default:
+		return "", fmt.Errorf("invalid primitive type: %s", s)
 	}
-	return ""
+}
+
+// IsCustomType checks if the PropertyType is a CustomType
+func IsCustomType(t PropertyType) bool {
+	_, ok := t.(CustomType)
+	return ok
+}
+
+// AsCustomType converts a PropertyType to a CustomType pointer if possible, else returns nil
+func AsCustomType(t PropertyType) *CustomType {
+	if customType, ok := t.(CustomType); ok {
+		return &customType
+	}
+	return nil
 }
 
 /*
@@ -100,19 +146,31 @@ func (c *CustomType) IsPrimitive() bool {
  * Event Rule related types
  */
 
-// EventRuleSection represents the section of an event rule
-type EventRuleSection string
+// IdentitySection represents the section of an event rule
+type IdentitySection string
 
 const (
-	EventRuleSectionProperties EventRuleSection = "properties"
-	EventRuleSectionTraits     EventRuleSection = "traits"
+	IdentitySectionProperties IdentitySection = "properties"
+	IdentitySectionTraits     IdentitySection = "traits"
 )
+
+// ParseIdentitySection converts a string to an IdentitySection, returning an error for unknown sections
+func ParseIdentitySection(s string) (IdentitySection, error) {
+	switch s {
+	case string(IdentitySectionProperties):
+		return IdentitySectionProperties, nil
+	case string(IdentitySectionTraits):
+		return IdentitySectionTraits, nil
+	default:
+		return "", fmt.Errorf("invalid identity section: %s", s)
+	}
+}
 
 // EventRule represents a rule for an event
 type EventRule struct {
-	Event   Event            `json:"event"`
-	Section EventRuleSection `json:"section"`
-	Schema  ObjectSchema     `json:"schema"`
+	Event   Event           `json:"event"`
+	Section IdentitySection `json:"section"`
+	Schema  ObjectSchema    `json:"schema"`
 }
 
 /*

--- a/cli/internal/typer/plan/providers/jsonschema.go
+++ b/cli/internal/typer/plan/providers/jsonschema.go
@@ -1,0 +1,209 @@
+package providers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/rudderlabs/rudder-iac/api/client/catalog"
+	"github.com/rudderlabs/rudder-iac/cli/internal/typer/plan"
+)
+
+type JSONSchemaPlanProvider struct {
+	trackingPlanID string
+	client         catalog.TrackingPlanStore
+}
+
+func NewJSONSchemaPlanProvider(trackingPlanID string, client catalog.TrackingPlanStore) *JSONSchemaPlanProvider {
+	return &JSONSchemaPlanProvider{
+		trackingPlanID: trackingPlanID,
+		client:         client,
+	}
+}
+
+func (p *JSONSchemaPlanProvider) GetTrackingPlan(ctx context.Context) (*plan.TrackingPlan, error) {
+	apitp, err := p.client.GetTrackingPlanWithSchemas(ctx, p.trackingPlanID)
+	if err != nil {
+		return nil, err
+	}
+
+	rules := make([]plan.EventRule, 0, len(apitp.Events))
+	for _, ev := range apitp.Events {
+		rule, err := parseEventSchema(&ev)
+		if err != nil {
+			return nil, err
+		}
+		rules = append(rules, *rule)
+	}
+
+	tp := &plan.TrackingPlan{
+		Name:  apitp.Name,
+		Rules: rules,
+	}
+
+	// Pretty print the tracking plan for debugging
+	b, err := json.MarshalIndent(tp, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	fmt.Println(string(b))
+
+	return tp, nil
+}
+
+func parseEventSchema(ev *catalog.TrackingPlanEventSchema) (*plan.EventRule, error) {
+	evType, err := plan.ParseEventType(ev.EventType)
+	if err != nil {
+		return nil, err
+	}
+
+	event := plan.Event{
+		Name:        ev.Name,
+		Description: ev.Description,
+		EventType:   evType,
+	}
+
+	section, err := plan.ParseIdentitySection(ev.IdentitySection)
+	if err != nil {
+		return nil, err
+	}
+
+	schemaProperties, ok := ev.Rules.Properties[ev.IdentitySection]
+	if !ok {
+		return nil, fmt.Errorf("identity section '%s' not found in properties", ev.IdentitySection)
+	}
+
+	schemaPropertiesMap, ok := schemaProperties.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("properties for identity section '%s' must be an object", ev.IdentitySection)
+	}
+
+	schema, err := parseJSONSchemaObject(schemaPropertiesMap)
+	if err != nil {
+		return nil, err
+	}
+
+	rule := plan.EventRule{
+		Event:   event,
+		Section: section,
+		Schema:  *schema,
+	}
+
+	return &rule, nil
+}
+
+func parseJSONSchemaObject(object map[string]any) (*plan.ObjectSchema, error) {
+	objSchema := &plan.ObjectSchema{
+		Properties: make(map[string]plan.PropertySchema),
+	}
+
+	requiredSet := make(map[string]bool)
+	required, ok := object["required"]
+	if ok {
+		slice, ok := required.([]interface{})
+		if !ok {
+			return nil, fmt.Errorf("'required' field must be an array of strings, it is instead %T", required)
+		}
+		// Create a set of required property names for quick lookup
+		for _, req := range slice {
+			if reqStr, ok := req.(string); ok {
+				requiredSet[reqStr] = true
+			}
+		}
+	}
+
+	properties, ok := object["properties"].(map[string]any)
+	if !ok {
+		return nil, nil
+	}
+
+	for propName, propDef := range properties {
+		propSchema, err := parsePropertySchema(propName, propDef, requiredSet[propName])
+		if err != nil {
+			return nil, fmt.Errorf("parsing property '%s': %w", propName, err)
+		}
+
+		if propSchema != nil {
+			objSchema.Properties[propName] = *propSchema
+		}
+	}
+
+	return objSchema, nil
+}
+
+func parsePropertySchema(name string, propDef any, required bool) (*plan.PropertySchema, error) {
+	propMap, ok := propDef.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("property definition must be an object, got %T", propDef)
+	}
+
+	// Parse type
+	typeVal, exists := propMap["type"]
+	if !exists {
+		typeVal = "object"
+	}
+
+	typeStr, ok := typeVal.(string)
+	if !ok {
+		typeArr, ok := typeVal.([]any)
+		if !ok || len(typeArr) == 0 {
+			return nil, fmt.Errorf("property 'type' must be a string or non-empty array of strings, got %T", typeVal)
+		}
+		typeStr, ok = typeArr[0].(string)
+		if !ok {
+			return nil, fmt.Errorf("property 'type' array must contain strings, got %T", typeArr[0])
+		}
+	}
+
+	propType, err := plan.ParsePrimitiveType(typeStr)
+	if err != nil {
+		return nil, fmt.Errorf("parsing property type '%s': %w", typeStr, err)
+	}
+
+	// Create property
+	property := plan.Property{
+		Name: name,
+		Type: []plan.PropertyType{propType},
+	}
+
+	// Parse description if present
+	if desc, exists := propMap["description"]; exists {
+		if descStr, ok := desc.(string); ok {
+			property.Description = descStr
+		}
+	}
+
+	// Parse enum config if present
+	if enumVal, exists := propMap["enum"]; exists {
+		if enumSlice, ok := enumVal.([]any); ok {
+			var enumStrings []string
+			for _, e := range enumSlice {
+				if eStr, ok := e.(string); ok {
+					enumStrings = append(enumStrings, eStr)
+				}
+			}
+			if len(enumStrings) > 0 {
+				property.Config = &plan.PropertyConfig{
+					Enum: enumStrings,
+				}
+			}
+		}
+	}
+
+	// Create property schema
+	propSchema := &plan.PropertySchema{
+		Property: property,
+		Required: required,
+	}
+
+	// Handle nested objects
+	if typeStr == "object" {
+		nestedObj, err := parseJSONSchemaObject(propMap)
+		if err != nil {
+			return nil, fmt.Errorf("parsing nested object for property '%s': %w", name, err)
+		}
+		propSchema.Schema = nestedObj
+	}
+
+	return propSchema, nil
+}

--- a/cli/internal/typer/plan/providers/jsonschema_test.go
+++ b/cli/internal/typer/plan/providers/jsonschema_test.go
@@ -1,0 +1,525 @@
+package providers_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/rudderlabs/rudder-iac/api/client/catalog"
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/datacatalog"
+	"github.com/rudderlabs/rudder-iac/cli/internal/typer/plan"
+	"github.com/rudderlabs/rudder-iac/cli/internal/typer/plan/providers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockTrackingPlanStore implements catalog.TrackingPlanStore for testing
+type mockTrackingPlanStore struct {
+	*datacatalog.EmptyCatalog
+	trackingPlanWithSchemas *catalog.TrackingPlanWithSchemas
+	err                     error
+}
+
+func (m *mockTrackingPlanStore) GetTrackingPlanWithSchemas(ctx context.Context, id string) (*catalog.TrackingPlanWithSchemas, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.trackingPlanWithSchemas, nil
+}
+
+// Helper function to parse JSON rules into map[string]interface{}
+func parseRulesJSON(rulesJSON string) map[string]interface{} {
+	var rules map[string]interface{}
+	if err := json.Unmarshal([]byte(rulesJSON), &rules); err != nil {
+		panic("failed to parse rules JSON: " + err.Error())
+	}
+	return rules
+}
+
+func TestJSONSchemaPlanProvider_GetTrackingPlan(t *testing.T) {
+	tests := []struct {
+		name             string
+		mockResponse     *catalog.TrackingPlanWithSchemas
+		expectedPlan     *plan.TrackingPlan
+		expectedError    bool
+		expectedErrorMsg string
+	}{
+		{
+			name: "successful parsing with all property types",
+			mockResponse: &catalog.TrackingPlanWithSchemas{
+				ID:           "tp_123",
+				Name:         "Test Tracking Plan",
+				CreationType: "manual",
+				Version:      1,
+				WorkspaceID:  "1ZFgGc4ZM7S0vJq3MPLHkMhJZxK",
+				CreatedAt:    time.Now(),
+				UpdatedAt:    time.Now(),
+				Events: []catalog.TrackingPlanEventSchema{
+					{
+						ID:              "ev_3338E4WgCctF2oUyL5gnJnqntjl",
+						Name:            "Test",
+						Description:     "",
+						EventType:       "track",
+						CategoryId:      nil,
+						WorkspaceId:     "1ZFgGc4ZM7S0vJq3MPLHkMhJZxK",
+						CreatedBy:       "1ZFgEE5fDiU9nioWcvYFCuunWpf",
+						UpdatedBy:       nil,
+						CreatedAt:       time.Now(),
+						UpdatedAt:       time.Now(),
+						IdentitySection: "properties",
+						Rules: struct {
+							Schema     string                 `json:"$schema"`
+							Type       string                 `json:"type"`
+							Properties map[string]interface{} `json:"properties"`
+						}{
+							Schema: "https://json-schema.org/draft/2019-09/schema",
+							Type:   "object",
+							Properties: parseRulesJSON(`{
+								"properties": {
+									"type": "object",
+									"properties": {
+										"someObject": {
+											"type": ["object"],
+											"additionalProperties": true,
+											"properties": {
+												"someInteger": {
+													"type": ["integer"]
+												},
+												"someNumber": {
+													"type": ["number"]
+												},
+												"someString": {
+													"type": ["string"]
+												}
+											},
+											"required": []
+										},
+										"someInteger": {
+											"type": ["integer"]
+										},
+										"someNumber": {
+											"type": ["number"]
+										},
+										"someString": {
+											"type": ["string"]
+										},
+										"someArrayOfStrings": {
+											"type": ["array"],
+											"items": {
+												"type": ["string"]
+											}
+										},
+										"someStringWithEnums": {
+											"type": ["string"],
+											"enum": ["one", "two", "three"]
+										},
+										"someStringOrBoolean": {
+											"type": ["boolean", "string"],
+											"pattern": "^\\d{4}-[01]\\d-[0-3]\\dT[0-2](?:\\d:[0-5]){2}\\d(?:\\.\\d+)?Z?$"
+										}
+									},
+									"required": [],
+									"unevaluatedProperties": false
+								}
+							}`),
+						},
+					},
+				},
+			},
+			expectedPlan: &plan.TrackingPlan{
+				Name: "Test Tracking Plan",
+				Rules: []plan.EventRule{
+					{
+						Event: plan.Event{
+							Name:        "Test",
+							Description: "",
+							EventType:   plan.EventTypeTrack,
+						},
+						Section: plan.IdentitySectionProperties,
+						Schema: plan.ObjectSchema{
+							Properties: map[string]plan.PropertySchema{
+								"someObject": {
+									Property: plan.Property{
+										Name: "someObject",
+										Type: []plan.PropertyType{plan.PrimitiveTypeObject},
+									},
+									Required: false,
+									Schema: &plan.ObjectSchema{
+										Properties: map[string]plan.PropertySchema{
+											"someInteger": {
+												Property: plan.Property{
+													Name: "someInteger",
+													Type: []plan.PropertyType{plan.PrimitiveTypeInteger},
+												},
+												Required: false,
+											},
+											"someNumber": {
+												Property: plan.Property{
+													Name: "someNumber",
+													Type: []plan.PropertyType{plan.PrimitiveTypeNumber},
+												},
+												Required: false,
+											},
+											"someString": {
+												Property: plan.Property{
+													Name: "someString",
+													Type: []plan.PropertyType{plan.PrimitiveTypeString},
+												},
+												Required: false,
+											},
+										},
+									},
+								},
+								"someInteger": {
+									Property: plan.Property{
+										Name: "someInteger",
+										Type: []plan.PropertyType{plan.PrimitiveTypeInteger},
+									},
+									Required: false,
+								},
+								"someNumber": {
+									Property: plan.Property{
+										Name: "someNumber",
+										Type: []plan.PropertyType{plan.PrimitiveTypeNumber},
+									},
+									Required: false,
+								},
+								"someString": {
+									Property: plan.Property{
+										Name: "someString",
+										Type: []plan.PropertyType{plan.PrimitiveTypeString},
+									},
+									Required: false,
+								},
+								"someArrayOfStrings": {
+									Property: plan.Property{
+										Name: "someArrayOfStrings",
+										Type: []plan.PropertyType{plan.PrimitiveTypeArray},
+									},
+									Required: false,
+								},
+								"someStringWithEnums": {
+									Property: plan.Property{
+										Name: "someStringWithEnums",
+										Type: []plan.PropertyType{plan.PrimitiveTypeString},
+										Config: &plan.PropertyConfig{
+											Enum: []string{"one", "two", "three"},
+										},
+									},
+									Required: false,
+								},
+								"someStringOrBoolean": {
+									Property: plan.Property{
+										Name: "someStringOrBoolean",
+										Type: []plan.PropertyType{plan.PrimitiveTypeBoolean},
+									},
+									Required: false,
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedError: false,
+		},
+		{
+			name: "required properties",
+			mockResponse: &catalog.TrackingPlanWithSchemas{
+				ID:           "tp_456",
+				Name:         "Required Props Plan",
+				CreationType: "manual",
+				Version:      1,
+				WorkspaceID:  "ws_123",
+				CreatedAt:    time.Now(),
+				UpdatedAt:    time.Now(),
+				Events: []catalog.TrackingPlanEventSchema{
+					{
+						ID:              "ev_456",
+						Name:            "User Signup",
+						Description:     "User registration event",
+						EventType:       "track",
+						IdentitySection: "properties",
+						Rules: struct {
+							Schema     string                 `json:"$schema"`
+							Type       string                 `json:"type"`
+							Properties map[string]interface{} `json:"properties"`
+						}{
+							Schema: "https://json-schema.org/draft/2019-09/schema",
+							Type:   "object",
+							Properties: parseRulesJSON(`{
+								"properties": {
+									"type": "object",
+									"properties": {
+										"email": {
+											"type": ["string"]
+										},
+										"username": {
+											"type": ["string"]
+										}
+									},
+									"required": ["email", "username"]
+								}
+							}`),
+						},
+					},
+				},
+			},
+			expectedPlan: &plan.TrackingPlan{
+				Name: "Required Props Plan",
+				Rules: []plan.EventRule{
+					{
+						Event: plan.Event{
+							Name:        "User Signup",
+							Description: "User registration event",
+							EventType:   plan.EventTypeTrack,
+						},
+						Section: plan.IdentitySectionProperties,
+						Schema: plan.ObjectSchema{
+							Properties: map[string]plan.PropertySchema{
+								"email": {
+									Property: plan.Property{
+										Name: "email",
+										Type: []plan.PropertyType{plan.PrimitiveTypeString},
+									},
+									Required: true,
+								},
+								"username": {
+									Property: plan.Property{
+										Name: "username",
+										Type: []plan.PropertyType{plan.PrimitiveTypeString},
+									},
+									Required: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedError: false,
+		},
+		{
+			name: "identify event with traits section",
+			mockResponse: &catalog.TrackingPlanWithSchemas{
+				ID:           "tp_789",
+				Name:         "Identify Plan",
+				CreationType: "manual",
+				Version:      1,
+				WorkspaceID:  "ws_123",
+				CreatedAt:    time.Now(),
+				UpdatedAt:    time.Now(),
+				Events: []catalog.TrackingPlanEventSchema{
+					{
+						ID:              "ev_789",
+						Name:            "User Identified",
+						Description:     "User identify event",
+						EventType:       "identify",
+						IdentitySection: "traits",
+						Rules: struct {
+							Schema     string                 `json:"$schema"`
+							Type       string                 `json:"type"`
+							Properties map[string]interface{} `json:"properties"`
+						}{
+							Schema: "https://json-schema.org/draft/2019-09/schema",
+							Type:   "object",
+							Properties: parseRulesJSON(`{
+								"traits": {
+									"type": "object",
+									"properties": {
+										"userId": {
+											"type": ["string"]
+										}
+									},
+									"required": ["userId"]
+								}
+							}`),
+						},
+					},
+				},
+			},
+			expectedPlan: &plan.TrackingPlan{
+				Name: "Identify Plan",
+				Rules: []plan.EventRule{
+					{
+						Event: plan.Event{
+							Name:        "User Identified",
+							Description: "User identify event",
+							EventType:   plan.EventTypeIdentify,
+						},
+						Section: plan.IdentitySectionTraits,
+						Schema: plan.ObjectSchema{
+							Properties: map[string]plan.PropertySchema{
+								"userId": {
+									Property: plan.Property{
+										Name: "userId",
+										Type: []plan.PropertyType{plan.PrimitiveTypeString},
+									},
+									Required: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedError: false,
+		},
+		{
+			name: "empty tracking plan",
+			mockResponse: &catalog.TrackingPlanWithSchemas{
+				ID:           "tp_empty",
+				Name:         "Empty Plan",
+				CreationType: "manual",
+				Version:      1,
+				WorkspaceID:  "ws_123",
+				CreatedAt:    time.Now(),
+				UpdatedAt:    time.Now(),
+				Events:       []catalog.TrackingPlanEventSchema{},
+			},
+			expectedPlan: &plan.TrackingPlan{
+				Name:  "Empty Plan",
+				Rules: []plan.EventRule{},
+			},
+			expectedError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := &mockTrackingPlanStore{
+				trackingPlanWithSchemas: tt.mockResponse,
+				err:                     nil,
+			}
+
+			provider := providers.NewJSONSchemaPlanProvider("test-plan-id", mockClient)
+			result, err := provider.GetTrackingPlan(context.Background())
+
+			if tt.expectedError {
+				require.Error(t, err)
+				if tt.expectedErrorMsg != "" {
+					assert.Contains(t, err.Error(), tt.expectedErrorMsg)
+				}
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, result)
+
+				// Compare tracking plan name
+				assert.Equal(t, tt.expectedPlan.Name, result.Name)
+
+				// Compare number of rules
+				assert.Len(t, result.Rules, len(tt.expectedPlan.Rules))
+
+				// Compare each rule
+				for i, expectedRule := range tt.expectedPlan.Rules {
+					actualRule := result.Rules[i]
+
+					// Compare event details
+					assert.Equal(t, expectedRule.Event.Name, actualRule.Event.Name)
+					assert.Equal(t, expectedRule.Event.Description, actualRule.Event.Description)
+					assert.Equal(t, expectedRule.Event.EventType, actualRule.Event.EventType)
+
+					// Compare section
+					assert.Equal(t, expectedRule.Section, actualRule.Section)
+
+					// Compare schema properties
+					assert.Len(t, actualRule.Schema.Properties, len(expectedRule.Schema.Properties))
+
+					for propName, expectedProp := range expectedRule.Schema.Properties {
+						actualProp, exists := actualRule.Schema.Properties[propName]
+						assert.True(t, exists, "Property %s should exist", propName)
+
+						assert.Equal(t, expectedProp.Property.Name, actualProp.Property.Name)
+						assert.Equal(t, expectedProp.Required, actualProp.Required)
+						assert.Equal(t, len(expectedProp.Property.Type), len(actualProp.Property.Type))
+
+						// Compare enum config if present
+						if expectedProp.Property.Config != nil && expectedProp.Property.Config.Enum != nil {
+							require.NotNil(t, actualProp.Property.Config)
+							assert.ElementsMatch(t, expectedProp.Property.Config.Enum, actualProp.Property.Config.Enum)
+						}
+
+						// Compare nested schema if present
+						if expectedProp.Schema != nil {
+							require.NotNil(t, actualProp.Schema, "Nested schema should exist for %s", propName)
+							assert.Len(t, actualProp.Schema.Properties, len(expectedProp.Schema.Properties))
+						}
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestJSONSchemaPlanProvider_ErrorCases(t *testing.T) {
+	mockInvalidRespone := func(eventType, identitySection, rulesJSON string) *catalog.TrackingPlanWithSchemas {
+		return &catalog.TrackingPlanWithSchemas{
+			ID:   "tp_123",
+			Name: "Test Plan",
+			Events: []catalog.TrackingPlanEventSchema{
+				{
+					ID:              "ev_123",
+					Name:            "Test Event",
+					EventType:       eventType,
+					IdentitySection: identitySection,
+					Rules: struct {
+						Schema     string                 `json:"$schema"`
+						Type       string                 `json:"type"`
+						Properties map[string]interface{} `json:"properties"`
+					}{
+						Schema:     "https://json-schema.org/draft/2019-09/schema",
+						Type:       "object",
+						Properties: parseRulesJSON(rulesJSON),
+					},
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name             string
+		mockResponse     *catalog.TrackingPlanWithSchemas
+		expectedErrorMsg string
+	}{
+		{
+			name: "invalid event type",
+			mockResponse: mockInvalidRespone("invalid_type", "properties", `{
+				"properties": {
+					"type": "object",
+					"properties": {},
+					"required": []
+				}
+			}`),
+			expectedErrorMsg: "invalid event type",
+		},
+		{
+			name: "invalid identity section",
+			mockResponse: mockInvalidRespone("track", "invalid_section", `{
+				"properties": {
+					"type": "object",
+					"properties": {},
+					"required": []
+				}
+			}`),
+			expectedErrorMsg: "invalid identity section",
+		},
+		{
+			name:             "missing identity section in properties",
+			mockResponse:     mockInvalidRespone("track", "properties", `{}`),
+			expectedErrorMsg: "identity section 'properties' not found in properties",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := &mockTrackingPlanStore{
+				trackingPlanWithSchemas: tt.mockResponse,
+				err:                     nil,
+			}
+
+			provider := providers.NewJSONSchemaPlanProvider("test-plan-id", mockClient)
+			_, err := provider.GetTrackingPlan(context.Background())
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.expectedErrorMsg)
+		})
+	}
+}

--- a/cli/internal/typer/plan/testutils/reference_plan.go
+++ b/cli/internal/typer/plan/testutils/reference_plan.go
@@ -53,31 +53,31 @@ func init() {
 	ReferenceProperties["email"] = &plan.Property{
 		Name:        "email",
 		Description: "User's email address",
-		Type:        *ReferenceCustomTypes["email"],
+		Type:        []plan.PropertyType{*ReferenceCustomTypes["email"]},
 	}
 
 	ReferenceProperties["first_name"] = &plan.Property{
 		Name:        "first_name",
 		Description: "User's first name",
-		Type:        plan.PrimitiveTypeString,
+		Type:        []plan.PropertyType{plan.PrimitiveTypeString},
 	}
 
 	ReferenceProperties["last_name"] = &plan.Property{
 		Name:        "last_name",
 		Description: "User's last name",
-		Type:        plan.PrimitiveTypeString,
+		Type:        []plan.PropertyType{plan.PrimitiveTypeString},
 	}
 
 	ReferenceProperties["age"] = &plan.Property{
 		Name:        "age",
 		Description: "User's age",
-		Type:        *ReferenceCustomTypes["age"],
+		Type:        []plan.PropertyType{*ReferenceCustomTypes["age"]},
 	}
 
 	ReferenceProperties["active"] = &plan.Property{
 		Name:        "active",
 		Description: "User active status",
-		Type:        *ReferenceCustomTypes["active"],
+		Type:        []plan.PropertyType{*ReferenceCustomTypes["active"]},
 	}
 
 	ReferenceCustomTypes["user_profile"] = &plan.CustomType{
@@ -106,7 +106,7 @@ func init() {
 	ReferenceProperties["profile"] = &plan.Property{
 		Name:        "profile",
 		Description: "User profile data",
-		Type:        *ReferenceCustomTypes["user_profile"],
+		Type:        []plan.PropertyType{*ReferenceCustomTypes["user_profile"]},
 	}
 }
 
@@ -117,7 +117,7 @@ func GetReferenceTrackingPlan() *plan.TrackingPlan {
 	// Track event - properties
 	rules = append(rules, plan.EventRule{
 		Event:   *ReferenceEvents["User Signed Up"],
-		Section: plan.EventRuleSectionProperties,
+		Section: plan.IdentitySectionProperties,
 		Schema: plan.ObjectSchema{
 			Properties: map[string]plan.PropertySchema{
 				"age": {
@@ -140,7 +140,7 @@ func GetReferenceTrackingPlan() *plan.TrackingPlan {
 	// Identify event - traits
 	rules = append(rules, plan.EventRule{
 		Event:   *ReferenceEvents["Identify"],
-		Section: plan.EventRuleSectionTraits,
+		Section: plan.IdentitySectionTraits,
 		Schema: plan.ObjectSchema{
 			Properties: map[string]plan.PropertySchema{
 				"email": {
@@ -159,7 +159,7 @@ func GetReferenceTrackingPlan() *plan.TrackingPlan {
 	// Page event - properties
 	rules = append(rules, plan.EventRule{
 		Event:   *ReferenceEvents["Page"],
-		Section: plan.EventRuleSectionProperties,
+		Section: plan.IdentitySectionProperties,
 		Schema: plan.ObjectSchema{
 			Properties: map[string]plan.PropertySchema{
 				"profile": {
@@ -174,7 +174,7 @@ func GetReferenceTrackingPlan() *plan.TrackingPlan {
 	// Screen event - properties
 	rules = append(rules, plan.EventRule{
 		Event:   *ReferenceEvents["Screen"],
-		Section: plan.EventRuleSectionProperties,
+		Section: plan.IdentitySectionProperties,
 		Schema: plan.ObjectSchema{
 			Properties: map[string]plan.PropertySchema{
 				"profile": {
@@ -189,7 +189,7 @@ func GetReferenceTrackingPlan() *plan.TrackingPlan {
 	// Group event - traits
 	rules = append(rules, plan.EventRule{
 		Event:   *ReferenceEvents["Group"],
-		Section: plan.EventRuleSectionTraits,
+		Section: plan.IdentitySectionTraits,
 		Schema: plan.ObjectSchema{
 			Properties: map[string]plan.PropertySchema{
 				"active": {

--- a/cli/internal/typer/ruddertyper_test.go
+++ b/cli/internal/typer/ruddertyper_test.go
@@ -24,7 +24,7 @@ func (m *mockPlanProvider) GetTrackingPlan(ctx context.Context) (*plan.TrackingP
 					Name:        "TestEvent",
 					Description: "Test event",
 				},
-				Section: plan.EventRuleSectionProperties,
+				Section: plan.IdentitySectionProperties,
 				Schema: plan.ObjectSchema{
 					Properties:           make(map[string]plan.PropertySchema),
 					AdditionalProperties: false,


### PR DESCRIPTION
This pull request introduces significant enhancements and refactoring to the tracking plan and typer codebase, primarily to support richer schema handling and improve type safety. The most important changes include adding support for retrieving tracking plans with full event schemas, refactoring property and event rule type handling, and implementing a new provider for parsing JSON Schema tracking plans.

**Tracking Plan API and Provider Enhancements:**

* Added `GetTrackingPlanWithSchemas` method to the `TrackingPlanStore` interface and implementations, allowing retrieval of tracking plans along with detailed event schemas. [[1]](diffhunk://#diff-ad4229e602da75f696c743da5dad11b9b9a64aaf028520db29bd10493d9a9adfR166) [[2]](diffhunk://#diff-ad4229e602da75f696c743da5dad11b9b9a64aaf028520db29bd10493d9a9adfR291-R328) [[3]](diffhunk://#diff-ae6f1c0dd37aadda5eddbb9f2cc1d7f774ebcd0f0428cff3c965119984f02f43R75-R78) [[4]](diffhunk://#diff-c667fea2b974dbe479e4b11784e04123bd9918cf5027c678af64c97a3a82c160R53-R56)
* Introduced `JSONSchemaPlanProvider` in `cli/internal/typer/plan/providers/jsonschema.go` to parse tracking plan schemas from JSON, including event rules and property schemas.

**Property Type Refactoring:**

* Changed the `Property.Type` field from a single type to a slice (`[]PropertyType`), enabling support for union types and multiple property types. Added utility functions for type checking and conversion (`IsPrimitiveType`, `IsCustomType`, `AsPrimitiveType`, `AsCustomType`, etc.).
* Updated all usages and helpers to handle the new property type structure, including extraction and initialization in test utilities. [[1]](diffhunk://#diff-9f4f19d81cc363f492a47a10d79e68406862ccfb0a318c51aad214f1e5cabbf2L50-R52) [[2]](diffhunk://#diff-9f4f19d81cc363f492a47a10d79e68406862ccfb0a318c51aad214f1e5cabbf2R64) [[3]](diffhunk://#diff-44c4144cd9022c2a98521b2d4330934a51b3c308167b4acf9b24b26c2c90eb07L56-R80) [[4]](diffhunk://#diff-44c4144cd9022c2a98521b2d4330934a51b3c308167b4acf9b24b26c2c90eb07L109-R109)

**Event Rule Section Refactoring:**

* Renamed `EventRuleSection` to `IdentitySection` for clarity and consistency, and updated all references and parsing logic accordingly. [[1]](diffhunk://#diff-29f0dfdebd2912b92dadb8a7c7896b427ce721317d8f9e010dd1361a764bfd76L103-R172) [[2]](diffhunk://#diff-c01ea9f3fbabe64b9c111fd6fcef7553b0566283d3f43fbbf6b84bdd1d2af41eL146-R148) [[3]](diffhunk://#diff-d4c305c34bf4429f51f403a9c785ae80821df6c4f4c6a9b4050d8dd1bcf0eafcL11-R15) [[4]](diffhunk://#diff-44c4144cd9022c2a98521b2d4330934a51b3c308167b4acf9b24b26c2c90eb07L120-R120) [[5]](diffhunk://#diff-44c4144cd9022c2a98521b2d4330934a51b3c308167b4acf9b24b26c2c90eb07L143-R143)

**Primitive Type Improvements:**

* Added support for the `integer` primitive type and removed `date` from the list of supported primitive types. Updated mapping logic for Kotlin type generation. [[1]](diffhunk://#diff-29f0dfdebd2912b92dadb8a7c7896b427ce721317d8f9e010dd1361a764bfd76R56-L38) [[2]](diffhunk://#diff-33aeb5a1e2fe2c6243a9d20f74400cb4e1a1a12ce6d3cba93e371608dde17d9aR295-L294)
* Improved property type parsing and error handling in Kotlin generator logic to support only single-type properties for now.

**Utility and Parsing Additions:**

* Added parsing functions for event types, primitive types, and identity sections to provide robust error handling and conversion from strings. [[1]](diffhunk://#diff-29f0dfdebd2912b92dadb8a7c7896b427ce721317d8f9e010dd1361a764bfd76R29-R46) [[2]](diffhunk://#diff-29f0dfdebd2912b92dadb8a7c7896b427ce721317d8f9e010dd1361a764bfd76L54-R125) [[3]](diffhunk://#diff-29f0dfdebd2912b92dadb8a7c7896b427ce721317d8f9e010dd1361a764bfd76L103-R172)

These changes collectively improve the flexibility and robustness of tracking plan handling, schema parsing, and code generation across the codebase.