### PR TITLE
chore: import apply changes introducing capturing of workspace information and using it in planning operations

### DIFF
--- a/api/client/catalog/properties.go
+++ b/api/client/catalog/properties.go
@@ -45,6 +45,7 @@ type PropertyStore interface {
 	DeleteProperty(ctx context.Context, id string) error
 	GetProperty(ctx context.Context, id string) (*Property, error)
 	GetProperties(ctx context.Context) ([]*Property, error)
+	SetPropertyExternalId(ctx context.Context, id string, externalId string) error
 }
 
 func (c *RudderDataCatalog) DeleteProperty(ctx context.Context, id string) error {
@@ -109,4 +110,22 @@ func (c *RudderDataCatalog) GetProperty(ctx context.Context, id string) (*Proper
 
 func (c *RudderDataCatalog) GetProperties(ctx context.Context) ([]*Property, error) {
 	return getAllResourcesWithPagination[*Property](ctx, c.client, "v2/catalog/properties")
+}
+
+func (c *RudderDataCatalog) SetPropertyExternalId(ctx context.Context, id string, externalId string) error {
+	payload := map[string]string{
+		"externalId": externalId,
+	}
+
+	byt, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshalling payload: %w", err)
+	}
+
+	_, err = c.client.Do(ctx, "PUT", fmt.Sprintf("v2/catalog/properties/%s/external-id", id), bytes.NewReader(byt))
+	if err != nil {
+		return fmt.Errorf("sending request: %w", err)
+	}
+
+	return nil
 }

--- a/api/client/client.go
+++ b/api/client/client.go
@@ -23,6 +23,7 @@ type Client struct {
 	Destinations *destinations
 	Connections  *connections
 	Accounts     *accounts
+	Workspaces   *workspaces
 }
 
 const BASE_URL = "https://api.rudderstack.com"
@@ -45,6 +46,7 @@ func New(accessToken string, options ...Option) (*Client, error) {
 	client.Destinations = &destinations{service: client.service("/v2/destinations")}
 	client.Connections = &connections{service: client.service("/v2/connections")}
 	client.Accounts = &accounts{service: client.service("/v2/accounts")}
+	client.Workspaces = &workspaces{client: client}
 
 	for _, o := range options {
 		if err := o(client); err != nil {

--- a/api/client/workspaces.go
+++ b/api/client/workspaces.go
@@ -1,0 +1,37 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+)
+
+type Workspace struct {
+	ID           string  `json:"id"`
+	Name         string  `json:"name"`
+	Environment  string  `json:"environment"`
+	Status       string  `json:"status"`
+	Region       string  `json:"region"`
+	DataPlaneURL *string `json:"dataPlaneURL,omitempty"`
+}
+
+type workspaces struct {
+	client *Client
+}
+
+type workspaceResponse struct {
+	Workspace *Workspace `json:"workspace"`
+}
+
+func (w *workspaces) GetByAuthToken(ctx context.Context) (*Workspace, error) {
+	res, err := w.client.Do(ctx, "GET", "/v2/workspace", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	response := &workspaceResponse{}
+	if err := json.Unmarshal(res, response); err != nil {
+		return nil, err
+	}
+
+	return response.Workspace, nil
+}

--- a/api/client/workspaces_test.go
+++ b/api/client/workspaces_test.go
@@ -1,0 +1,160 @@
+package client_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/rudderlabs/rudder-iac/api/client"
+	"github.com/rudderlabs/rudder-iac/api/internal/testutils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWorkspaces_GetByAuthToken_Success(t *testing.T) {
+	ctx := context.Background()
+
+	dataPlaneURL := "https://dataplane.example.com"
+	calls := []testutils.Call{
+		{
+			Validate: func(req *http.Request) bool {
+				return testutils.ValidateRequest(t, req, "GET", "https://api.rudderstack.com/v2/workspace", "")
+			},
+			ResponseStatus: 200,
+			ResponseBody: `{
+				"workspace": {
+					"id": "ws_123abc",
+					"name": "Production",
+					"environment": "PRODUCTION",
+					"status": "ACTIVE",
+					"region": "US",
+					"dataPlaneURL": "https://dataplane.example.com"
+				}
+			}`,
+		},
+	}
+
+	httpClient := testutils.NewMockHTTPClient(t, calls...)
+
+	c, err := client.New("some-access-token", client.WithHTTPClient(httpClient))
+	require.NoError(t, err)
+
+	workspace, err := c.Workspaces.GetByAuthToken(ctx)
+	require.NoError(t, err)
+	assert.NotNil(t, workspace)
+	assert.Equal(t, "ws_123abc", workspace.ID)
+	assert.Equal(t, "Production", workspace.Name)
+	assert.Equal(t, "PRODUCTION", workspace.Environment)
+	assert.Equal(t, "ACTIVE", workspace.Status)
+	assert.Equal(t, "US", workspace.Region)
+	assert.NotNil(t, workspace.DataPlaneURL)
+	assert.Equal(t, dataPlaneURL, *workspace.DataPlaneURL)
+
+	httpClient.AssertNumberOfCalls()
+}
+
+func TestWorkspaces_GetByAuthToken_NullDataPlaneURL(t *testing.T) {
+	ctx := context.Background()
+
+	calls := []testutils.Call{
+		{
+			Validate: func(req *http.Request) bool {
+				return testutils.ValidateRequest(t, req, "GET", "https://api.rudderstack.com/v2/workspace", "")
+			},
+			ResponseStatus: 200,
+			ResponseBody: `{
+				"workspace": {
+					"id": "ws_456def",
+					"name": "Development",
+					"environment": "DEVELOPMENT",
+					"status": "ACTIVE",
+					"region": "EU"
+				}
+			}`,
+		},
+	}
+
+	httpClient := testutils.NewMockHTTPClient(t, calls...)
+
+	c, err := client.New("some-access-token", client.WithHTTPClient(httpClient))
+	require.NoError(t, err)
+
+	workspace, err := c.Workspaces.GetByAuthToken(ctx)
+	require.NoError(t, err)
+	assert.NotNil(t, workspace)
+	assert.Equal(t, "ws_456def", workspace.ID)
+	assert.Equal(t, "Development", workspace.Name)
+	assert.Equal(t, "DEVELOPMENT", workspace.Environment)
+	assert.Equal(t, "ACTIVE", workspace.Status)
+	assert.Equal(t, "EU", workspace.Region)
+	assert.Nil(t, workspace.DataPlaneURL)
+
+	httpClient.AssertNumberOfCalls()
+}
+
+func TestWorkspaces_GetByAuthToken_Unauthorized(t *testing.T) {
+	ctx := context.Background()
+
+	calls := []testutils.Call{
+		{
+			Validate: func(req *http.Request) bool {
+				return testutils.ValidateRequest(t, req, "GET", "https://api.rudderstack.com/v2/workspace", "")
+			},
+			ResponseStatus: 401,
+			ResponseBody: `{
+				"error": "This endpoint requires a workspace-level access token",
+				"code": "UNAUTHORIZED"
+			}`,
+		},
+	}
+
+	httpClient := testutils.NewMockHTTPClient(t, calls...)
+
+	c, err := client.New("some-access-token", client.WithHTTPClient(httpClient))
+	require.NoError(t, err)
+
+	workspace, err := c.Workspaces.GetByAuthToken(ctx)
+	require.Error(t, err)
+	assert.Nil(t, workspace)
+
+	// Verify it's an APIError with correct status code
+	apiErr, ok := err.(*client.APIError)
+	assert.True(t, ok)
+	assert.Equal(t, 401, apiErr.HTTPStatusCode)
+	assert.Contains(t, apiErr.Message, "workspace-level access token")
+
+	httpClient.AssertNumberOfCalls()
+}
+
+func TestWorkspaces_GetByAuthToken_APIError(t *testing.T) {
+	ctx := context.Background()
+
+	calls := []testutils.Call{
+		{
+			Validate: func(req *http.Request) bool {
+				return testutils.ValidateRequest(t, req, "GET", "https://api.rudderstack.com/v2/workspace", "")
+			},
+			ResponseStatus: 500,
+			ResponseBody: `{
+				"error": "Internal server error",
+				"code": "INTERNAL_ERROR"
+			}`,
+		},
+	}
+
+	httpClient := testutils.NewMockHTTPClient(t, calls...)
+
+	c, err := client.New("some-access-token", client.WithHTTPClient(httpClient))
+	require.NoError(t, err)
+
+	workspace, err := c.Workspaces.GetByAuthToken(ctx)
+	require.Error(t, err)
+	assert.Nil(t, workspace)
+
+	// Verify it's an APIError
+	apiErr, ok := err.(*client.APIError)
+	assert.True(t, ok)
+	assert.Equal(t, 500, apiErr.HTTPStatusCode)
+
+	httpClient.AssertNumberOfCalls()
+}

--- a/cli/internal/cmd/project/apply/apply.go
+++ b/cli/internal/cmd/project/apply/apply.go
@@ -77,6 +77,11 @@ func NewCmdApply() *cobra.Command {
 				}...)
 			}()
 
+			workspace, err := deps.Client().Workspaces.GetByAuthToken(context.Background())
+			if err != nil {
+				return fmt.Errorf("fetching workspace information: %w", err)
+			}
+
 			// Get resource graph to understand dependencies
 			graph, err := p.GetResourceGraph()
 			if err != nil {
@@ -84,7 +89,7 @@ func NewCmdApply() *cobra.Command {
 			}
 
 			// Create syncer to handle the changes
-			s, err := syncer.New(deps.CompositeProvider())
+			s, err := syncer.New(deps.CompositeProvider(), workspace)
 			if err != nil {
 				return fmt.Errorf("creating syncer: %w", err)
 			}

--- a/cli/internal/cmd/project/destroy/destroy.go
+++ b/cli/internal/cmd/project/destroy/destroy.go
@@ -67,8 +67,12 @@ func NewCmdDestroy() *cobra.Command {
 				}...)
 			}()
 
-			// Create syncer to handle the deletion
-			s, err := syncer.New(deps.CompositeProvider())
+			workspace, err := deps.Client().Workspaces.GetByAuthToken(context.Background())
+			if err != nil {
+				return fmt.Errorf("fetching workspace information: %w", err)
+			}
+
+			s, err := syncer.New(deps.CompositeProvider(), workspace)
 			if err != nil {
 				return fmt.Errorf("creating syncer: %w", err)
 			}

--- a/cli/internal/cmd/project/destroy/destroy.go
+++ b/cli/internal/cmd/project/destroy/destroy.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/rudderlabs/rudder-iac/api/client"
 	"github.com/rudderlabs/rudder-iac/cli/internal/app"
 	"github.com/rudderlabs/rudder-iac/cli/internal/cmd/telemetry"
 	"github.com/rudderlabs/rudder-iac/cli/internal/config"
@@ -67,12 +68,7 @@ func NewCmdDestroy() *cobra.Command {
 				}...)
 			}()
 
-			workspace, err := deps.Client().Workspaces.GetByAuthToken(context.Background())
-			if err != nil {
-				return fmt.Errorf("fetching workspace information: %w", err)
-			}
-
-			s, err := syncer.New(deps.CompositeProvider(), workspace)
+			s, err := syncer.New(deps.CompositeProvider(), &client.Workspace{})
 			if err != nil {
 				return fmt.Errorf("creating syncer: %w", err)
 			}

--- a/cli/internal/cmd/trackingplan/apply/apply.go
+++ b/cli/internal/cmd/trackingplan/apply/apply.go
@@ -61,12 +61,17 @@ func NewCmdTPApply() *cobra.Command {
 				}...)
 			}()
 
+			workspace, err := deps.Client().Workspaces.GetByAuthToken(context.Background())
+			if err != nil {
+				return fmt.Errorf("fetching workspace information: %w", err)
+			}
+
 			graph, err := p.GetResourceGraph()
 			if err != nil {
 				return fmt.Errorf("getting resource graph: %w", err)
 			}
 
-			s, err := syncer.New(deps.Providers().DataCatalog)
+			s, err := syncer.New(deps.Providers().DataCatalog, workspace)
 			if err != nil {
 				return err
 			}

--- a/cli/internal/cmd/trackingplan/destroy/destroy.go
+++ b/cli/internal/cmd/trackingplan/destroy/destroy.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/rudderlabs/rudder-iac/api/client"
 	"github.com/rudderlabs/rudder-iac/cli/internal/app"
 	"github.com/rudderlabs/rudder-iac/cli/internal/cmd/telemetry"
 	"github.com/rudderlabs/rudder-iac/cli/internal/logger"
@@ -48,13 +49,7 @@ func NewCmdTPDestroy() *cobra.Command {
 				return fmt.Errorf("initialising dependencies: %w", err)
 			}
 
-			// Get workspace information
-			workspace, err := deps.Client().Workspaces.GetByAuthToken(context.Background())
-			if err != nil {
-				return fmt.Errorf("fetching workspace information: %w", err)
-			}
-
-			s, err := syncer.New(deps.Providers().DataCatalog, workspace)
+			s, err := syncer.New(deps.Providers().DataCatalog, &client.Workspace{})
 			if err != nil {
 				return err
 			}

--- a/cli/internal/cmd/trackingplan/destroy/destroy.go
+++ b/cli/internal/cmd/trackingplan/destroy/destroy.go
@@ -48,7 +48,13 @@ func NewCmdTPDestroy() *cobra.Command {
 				return fmt.Errorf("initialising dependencies: %w", err)
 			}
 
-			s, err := syncer.New(deps.Providers().DataCatalog)
+			// Get workspace information
+			workspace, err := deps.Client().Workspaces.GetByAuthToken(context.Background())
+			if err != nil {
+				return fmt.Errorf("fetching workspace information: %w", err)
+			}
+
+			s, err := syncer.New(deps.Providers().DataCatalog, workspace)
 			if err != nil {
 				return err
 			}

--- a/cli/internal/providers/datacatalog/catalog.go
+++ b/cli/internal/providers/datacatalog/catalog.go
@@ -22,6 +22,7 @@ type resourceProvider interface {
 	Create(ctx context.Context, ID string, data resources.ResourceData) (*resources.ResourceData, error)
 	Update(ctx context.Context, ID string, data resources.ResourceData, state resources.ResourceData) (*resources.ResourceData, error)
 	Delete(ctx context.Context, ID string, state resources.ResourceData) error
+	Import(ctx context.Context, ID string, data resources.ResourceData, remoteId string) (*resources.ResourceData, error)
 	LoadResourcesFromRemote(ctx context.Context) (*resources.ResourceCollection, error)
 	LoadStateFromResources(ctx context.Context, collection *resources.ResourceCollection) (*state.State, error)
 }
@@ -104,7 +105,11 @@ func (p *Provider) Delete(ctx context.Context, ID string, resourceType string, d
 }
 
 func (p *Provider) Import(ctx context.Context, ID string, resourceType string, data resources.ResourceData, workspaceId, remoteId string) (*resources.ResourceData, error) {
-	return nil, fmt.Errorf("import is not supported for %s", resourceType)
+	provider, ok := p.providerStore[resourceType]
+	if !ok {
+		return nil, fmt.Errorf("unknown resource type: %s", resourceType)
+	}
+	return provider.Import(ctx, ID, data, remoteId)
 }
 
 // LoadResourcesFromRemote loads all resources from remote catalog into a ResourceCollection

--- a/cli/internal/providers/datacatalog/category.go
+++ b/cli/internal/providers/datacatalog/category.go
@@ -95,6 +95,10 @@ func (p *CategoryProvider) Delete(ctx context.Context, ID string, data resources
 	return nil
 }
 
+func (p *CategoryProvider) Import(ctx context.Context, ID string, data resources.ResourceData, remoteId string) (*resources.ResourceData, error) {
+	return nil, fmt.Errorf("import is not supported for category resources")
+}
+
 // LoadResourcesFromRemote loads all categories from the remote catalog
 func (p *CategoryProvider) LoadResourcesFromRemote(ctx context.Context) (*resources.ResourceCollection, error) {
 	p.log.Debug("loading categories from remote catalog")

--- a/cli/internal/providers/datacatalog/customtype.go
+++ b/cli/internal/providers/datacatalog/customtype.go
@@ -164,6 +164,10 @@ func (p *CustomTypeProvider) Delete(ctx context.Context, ID string, data resourc
 	return nil
 }
 
+func (p *CustomTypeProvider) Import(ctx context.Context, ID string, data resources.ResourceData, remoteId string) (*resources.ResourceData, error) {
+	return nil, fmt.Errorf("import is not supported for custom type resources")
+}
+
 // LoadResourcesFromRemote loads all custom types from the remote catalog
 func (p *CustomTypeProvider) LoadResourcesFromRemote(ctx context.Context) (*resources.ResourceCollection, error) {
 	p.log.Debug("loading custom types from remote catalog")

--- a/cli/internal/providers/datacatalog/empty_catalog.go
+++ b/cli/internal/providers/datacatalog/empty_catalog.go
@@ -44,6 +44,10 @@ func (m *EmptyCatalog) GetProperty(ctx context.Context, id string) (*catalog.Pro
 	return nil, nil
 }
 
+func (m *EmptyCatalog) SetPropertyExternalId(ctx context.Context, id string, externalId string) error {
+	return nil
+}
+
 func (m *EmptyCatalog) CreateTrackingPlan(ctx context.Context, trackingPlanCreate catalog.TrackingPlanCreate) (*catalog.TrackingPlan, error) {
 	return nil, nil
 }

--- a/cli/internal/providers/datacatalog/event.go
+++ b/cli/internal/providers/datacatalog/event.go
@@ -130,6 +130,10 @@ func (p *EventProvider) Delete(ctx context.Context, ID string, state resources.R
 	return nil
 }
 
+func (p *EventProvider) Import(ctx context.Context, ID string, data resources.ResourceData, remoteId string) (*resources.ResourceData, error) {
+	return nil, fmt.Errorf("import is not supported for event resources")
+}
+
 // LoadResourcesFromRemote loads all events from the remote catalog
 func (p *EventProvider) LoadResourcesFromRemote(ctx context.Context) (*resources.ResourceCollection, error) {
 	p.log.Debug("loading events from remote catalog")

--- a/cli/internal/providers/datacatalog/state/property.go
+++ b/cli/internal/providers/datacatalog/state/property.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"fmt"
+	"reflect"
 	"strings"
 
 	"github.com/rudderlabs/rudder-iac/api/client/catalog"
@@ -14,6 +15,23 @@ type PropertyArgs struct {
 	Description string
 	Type        any
 	Config      map[string]interface{}
+}
+
+// DiffUpstream compares PropertyArgs with an upstream Property and returns true if they are different
+func (args *PropertyArgs) DiffUpstream(upstream *catalog.Property) bool {
+	if args.Name != upstream.Name {
+		return true
+	}
+
+	if args.Description != upstream.Description {
+		return true
+	}
+
+	if args.Type.(string) != upstream.Type {
+		return true
+	}
+
+	return !reflect.DeepEqual(args.Config, upstream.Config)
 }
 
 const PropertyResourceType = "property"

--- a/cli/internal/providers/datacatalog/state/property_test.go
+++ b/cli/internal/providers/datacatalog/state/property_test.go
@@ -3,6 +3,7 @@ package state_test
 import (
 	"testing"
 
+	"github.com/rudderlabs/rudder-iac/api/client/catalog"
 	"github.com/rudderlabs/rudder-iac/cli/internal/providers/datacatalog/localcatalog"
 	"github.com/rudderlabs/rudder-iac/cli/internal/providers/datacatalog/state"
 	"github.com/rudderlabs/rudder-iac/cli/internal/syncer/resources"
@@ -233,4 +234,124 @@ func TestPropertyState_ResourceData(t *testing.T) {
 		assert.Equal(t, propertyState, loopback)
 	})
 
+}
+
+func TestPropertyArgs_DiffUpstream(t *testing.T) {
+
+	t.Run("no diff", func(t *testing.T) {
+		t.Parallel()
+
+		args := &state.PropertyArgs{
+			Name:        "test-property",
+			Description: "A test property",
+			Type:        "string",
+			Config: map[string]interface{}{
+				"minLength": 5,
+				"maxLength": 10,
+			},
+		}
+
+		upstream := &catalog.Property{
+			Name:        "test-property",
+			Description: "A test property",
+			Type:        "string",
+			Config: map[string]interface{}{
+				"minLength": 5,
+				"maxLength": 10,
+			},
+		}
+
+		diffed := args.DiffUpstream(upstream)
+		assert.False(t, diffed)
+	})
+
+	t.Run("diff - name changed", func(t *testing.T) {
+		t.Parallel()
+
+		args := &state.PropertyArgs{
+			Name:        "test-property",
+			Description: "A test property",
+			Type:        "string",
+			Config:      map[string]interface{}{},
+		}
+
+		upstream := &catalog.Property{
+			Name:        "test-property-updated",
+			Description: "A test property",
+			Type:        "string",
+			Config:      map[string]interface{}{},
+		}
+
+		diffed := args.DiffUpstream(upstream)
+		assert.True(t, diffed)
+	})
+
+	t.Run("diff - description changed", func(t *testing.T) {
+		t.Parallel()
+
+		args := &state.PropertyArgs{
+			Name:        "test-property",
+			Description: "A test property",
+			Type:        "string",
+			Config:      map[string]interface{}{},
+		}
+
+		upstream := &catalog.Property{
+			Name:        "test-property",
+			Description: "Updated description",
+			Type:        "string",
+			Config:      map[string]interface{}{},
+		}
+
+		diffed := args.DiffUpstream(upstream)
+		assert.True(t, diffed)
+	})
+
+	t.Run("diff - type changed", func(t *testing.T) {
+		t.Parallel()
+
+		args := &state.PropertyArgs{
+			Name:        "test-property",
+			Description: "A test property",
+			Type:        "string",
+			Config:      map[string]interface{}{},
+		}
+
+		upstream := &catalog.Property{
+			Name:        "test-property",
+			Description: "A test property",
+			Type:        "number",
+			Config:      map[string]interface{}{},
+		}
+
+		diffed := args.DiffUpstream(upstream)
+		assert.True(t, diffed)
+	})
+
+	t.Run("diff - config changed", func(t *testing.T) {
+		t.Parallel()
+
+		args := &state.PropertyArgs{
+			Name:        "test-property",
+			Description: "A test property",
+			Type:        "string",
+			Config: map[string]interface{}{
+				"minLength": 5,
+				"maxLength": 10,
+			},
+		}
+
+		upstream := &catalog.Property{
+			Name:        "test-property",
+			Description: "A test property",
+			Type:        "string",
+			Config: map[string]interface{}{
+				"minLength": 5,
+				"maxLength": 20,
+			},
+		}
+
+		diffed := args.DiffUpstream(upstream)
+		assert.True(t, diffed)
+	})
 }

--- a/cli/internal/providers/datacatalog/trackingplan.go
+++ b/cli/internal/providers/datacatalog/trackingplan.go
@@ -214,6 +214,10 @@ func (p *TrackingPlanProvider) Delete(ctx context.Context, ID string, state reso
 	return nil
 }
 
+func (p *TrackingPlanProvider) Import(ctx context.Context, ID string, data resources.ResourceData, remoteId string) (*resources.ResourceData, error) {
+	return nil, fmt.Errorf("import is not supported for tracking plan resources")
+}
+
 // LoadResourcesFromRemote loads all tracking plans from the remote catalog
 func (p *TrackingPlanProvider) LoadResourcesFromRemote(ctx context.Context) (*resources.ResourceCollection, error) {
 	p.log.Debug("loading tracking plans from remote catalog - not yet implemented")

--- a/cli/internal/syncer/planner/planner.go
+++ b/cli/internal/syncer/planner/planner.go
@@ -10,6 +10,7 @@ import (
 )
 
 type Planner struct {
+	workspaceId string
 }
 
 type OperationType int
@@ -50,8 +51,10 @@ type Plan struct {
 	Operations []*Operation
 }
 
-func New() *Planner {
-	return &Planner{}
+func New(workspaceId string) *Planner {
+	return &Planner{
+		workspaceId: workspaceId,
+	}
 }
 
 func (p *Planner) Plan(source, target *resources.Graph) *Plan {
@@ -64,7 +67,9 @@ func (p *Planner) Plan(source, target *resources.Graph) *Plan {
 	for _, urn := range sortedNew {
 		resource, _ := target.GetResource(urn)
 		var opType OperationType = Create
-		if resource.ImportMetadata() != nil {
+
+		// Only import resources that are defined for the current workspace
+		if resource.ImportMetadata() != nil && resource.ImportMetadata().WorkspaceId == p.workspaceId {
 			opType = Import
 		}
 		plan.Operations = append(plan.Operations, &Operation{Type: opType, Resource: resource})

--- a/cli/internal/syncer/planner/planner.go
+++ b/cli/internal/syncer/planner/planner.go
@@ -69,7 +69,8 @@ func (p *Planner) Plan(source, target *resources.Graph) *Plan {
 		var opType OperationType = Create
 
 		// Only import resources that are defined for the current workspace
-		if resource.ImportMetadata() != nil && resource.ImportMetadata().WorkspaceId == p.workspaceId {
+		if resource.ImportMetadata() != nil &&
+			resource.ImportMetadata().WorkspaceId == p.workspaceId {
 			opType = Import
 		}
 		plan.Operations = append(plan.Operations, &Operation{Type: opType, Resource: resource})

--- a/cli/internal/syncer/planner/planner_test.go
+++ b/cli/internal/syncer/planner/planner_test.go
@@ -102,7 +102,7 @@ func TestPlanner_Plan(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := planner.New()
+			p := planner.New("test-workspace-id")
 			plan := p.Plan(tt.source, tt.target)
 			for i, op := range plan.Operations {
 				fmt.Printf("Operation %d: %d %s\n", i, op.Type, op.Resource.ID())

--- a/cli/internal/syncer/resources/resource.go
+++ b/cli/internal/syncer/resources/resource.go
@@ -36,6 +36,9 @@ func NewResource(id string, resourceType string, data ResourceData, dependencies
 		Dependencies: dependencies,
 	}
 	for _, opt := range opts {
+		if opt == nil {
+			continue
+		}
 		opt(r)
 	}
 	return &Resource{r: r}

--- a/cli/internal/syncer/syncer.go
+++ b/cli/internal/syncer/syncer.go
@@ -6,6 +6,7 @@ import (
 	"slices"
 	"sync"
 
+	"github.com/rudderlabs/rudder-iac/api/client"
 	"github.com/rudderlabs/rudder-iac/cli/internal/config"
 	dcstate "github.com/rudderlabs/rudder-iac/cli/internal/providers/datacatalog/state"
 	"github.com/rudderlabs/rudder-iac/cli/internal/syncer/differ"
@@ -17,6 +18,7 @@ import (
 
 type ProjectSyncer struct {
 	provider   SyncProvider
+	workspace  *client.Workspace
 	stateMutex sync.RWMutex
 }
 
@@ -32,13 +34,17 @@ type SyncProvider interface {
 	Import(ctx context.Context, ID string, resourceType string, data resources.ResourceData, workspaceId, remoteId string) (*resources.ResourceData, error)
 }
 
-func New(p SyncProvider) (*ProjectSyncer, error) {
+func New(p SyncProvider, workspace *client.Workspace) (*ProjectSyncer, error) {
 	if p == nil {
 		return nil, fmt.Errorf("provider is required")
 	}
+	if workspace == nil {
+		return nil, fmt.Errorf("workspace is required")
+	}
 
 	return &ProjectSyncer{
-		provider: p,
+		provider:  p,
+		workspace: workspace,
 	}, nil
 }
 

--- a/cli/internal/syncer/syncer.go
+++ b/cli/internal/syncer/syncer.go
@@ -100,7 +100,7 @@ func (s *ProjectSyncer) apply(ctx context.Context, target *resources.Graph, opti
 
 	source := stateToGraph(state)
 
-	p := planner.New()
+	p := planner.New(s.workspace.ID)
 	plan := p.Plan(source, target)
 
 	differ.PrintDiff(plan.Diff)

--- a/cli/internal/syncer/syncer.go
+++ b/cli/internal/syncer/syncer.go
@@ -16,7 +16,7 @@ import (
 )
 
 type ProjectSyncer struct {
-	provider SyncProvider
+	provider   SyncProvider
 	stateMutex sync.RWMutex
 }
 
@@ -166,7 +166,7 @@ func (s *ProjectSyncer) executePlan(ctx context.Context, state *state.State, pla
 }
 
 func (s *ProjectSyncer) executePlanSequentially(ctx context.Context, state *state.State, plan *planner.Plan, continueOnFail bool) []error {
-	var errors       []error
+	var errors []error
 
 	for _, o := range plan.Operations {
 		operationString := o.String()


### PR DESCRIPTION
## Description
In this PR, we adding ability to use import metadata in apply operations in the CLI for the entities in data-catalog.

## Changes
1. Add functionality to fetch `Workspace` information in API.
2. Add ability to apply import properties with proper workspace metadata in yaml files.
3. Planner to have `WorkspaceId` dependency to allow do imports with metadata for this workspaceId.