### PR TITLE
feat: separate out the importable resources in the print diff

### DIFF
--- a/cli/internal/syncer/differ/diff_test.go
+++ b/cli/internal/syncer/differ/diff_test.go
@@ -52,7 +52,7 @@ func TestComputeDiff(t *testing.T) {
 	g2.AddResource(resources.NewResource("r3", "some-type", resources.ResourceData{"key1": "value1", "key2": "value3"}, []string{}))
 	g2.AddResource(resources.NewResource("r4", "some-type", resources.ResourceData{"key1": "value1", "key2": "value4"}, []string{}, resources.WithResourceImportMetadata("remote-id-r4", "workspace-id")))
 
-	diff := differ.ComputeDiff(g1, g2, differ.DiffOptions{WorkspaceID: "workspace1"})
+	diff := differ.ComputeDiff(g1, g2, differ.DiffOptions{WorkspaceID: "workspace-id"})
 
 	assert.Len(t, diff.NewResources, 1)
 	assert.Len(t, diff.ImportableResources, 1)

--- a/cli/internal/syncer/differ/diff_test.go
+++ b/cli/internal/syncer/differ/diff_test.go
@@ -50,15 +50,18 @@ func TestComputeDiff(t *testing.T) {
 	g2.AddResource(resources.NewResource("r0", "some-type", resources.ResourceData{"key1": "value1", "key2": "value2"}, []string{}))
 	g2.AddResource(resources.NewResource("r1", "some-type", resources.ResourceData{"key1": "value1", "key2": "value3"}, []string{}))
 	g2.AddResource(resources.NewResource("r3", "some-type", resources.ResourceData{"key1": "value1", "key2": "value3"}, []string{}))
+	g2.AddResource(resources.NewResource("r4", "some-type", resources.ResourceData{"key1": "value1", "key2": "value4"}, []string{}, resources.WithResourceImportMetadata("remote-id-r4", "workspace-id")))
 
 	diff := differ.ComputeDiff(g1, g2, differ.DiffOptions{WorkspaceID: "workspace1"})
 
 	assert.Len(t, diff.NewResources, 1)
+	assert.Len(t, diff.ImportableResources, 1)
 	assert.Len(t, diff.UpdatedResources, 1)
 	assert.Len(t, diff.RemovedResources, 1)
 	assert.Len(t, diff.UnmodifiedResources, 1)
 
 	assert.Contains(t, diff.NewResources, "some-type:r3")
+	assert.Contains(t, diff.ImportableResources, "some-type:r4")
 	assert.Equal(t, diff.UpdatedResources["some-type:r1"], differ.ResourceDiff{URN: "some-type:r1", Diffs: map[string]differ.PropertyDiff{"key2": {Property: "key2", SourceValue: "value2", TargetValue: "value3"}}})
 	assert.Contains(t, diff.RemovedResources, "some-type:r2")
 	assert.Contains(t, diff.UnmodifiedResources, "some-type:r0")

--- a/cli/internal/syncer/differ/diff_test.go
+++ b/cli/internal/syncer/differ/diff_test.go
@@ -51,7 +51,7 @@ func TestComputeDiff(t *testing.T) {
 	g2.AddResource(resources.NewResource("r1", "some-type", resources.ResourceData{"key1": "value1", "key2": "value3"}, []string{}))
 	g2.AddResource(resources.NewResource("r3", "some-type", resources.ResourceData{"key1": "value1", "key2": "value3"}, []string{}))
 
-	diff := differ.ComputeDiff(g1, g2)
+	diff := differ.ComputeDiff(g1, g2, differ.DiffOptions{WorkspaceID: "workspace1"})
 
 	assert.Len(t, diff.NewResources, 1)
 	assert.Len(t, diff.UpdatedResources, 1)

--- a/cli/internal/syncer/differ/printer.go
+++ b/cli/internal/syncer/differ/printer.go
@@ -8,6 +8,10 @@ import (
 )
 
 func PrintDiff(diff *Diff) {
+	if len(diff.ImportableResources) > 0 {
+		listResources("Importable resources", diff.ImportableResources, nil)
+	}
+
 	if len(diff.NewResources) > 0 {
 		listResources("New resources", diff.NewResources, nil)
 	}

--- a/cli/internal/syncer/planner/planner.go
+++ b/cli/internal/syncer/planner/planner.go
@@ -58,24 +58,26 @@ func New(workspaceId string) *Planner {
 }
 
 func (p *Planner) Plan(source, target *resources.Graph) *Plan {
-	diff := differ.ComputeDiff(source, target)
+	diff := differ.ComputeDiff(source, target, differ.DiffOptions{WorkspaceID: p.workspaceId})
 	plan := &Plan{
 		Diff: diff,
 	}
 
+	// Handle importable resources (will be imported from remote)
+	sortedImportable := sortByDependencies(diff.ImportableResources, target)
+	for _, urn := range sortedImportable {
+		resource, _ := target.GetResource(urn)
+		plan.Operations = append(plan.Operations, &Operation{Type: Import, Resource: resource})
+	}
+
+	// Handle new resources (will be created)
 	sortedNew := sortByDependencies(diff.NewResources, target)
 	for _, urn := range sortedNew {
 		resource, _ := target.GetResource(urn)
-		var opType OperationType = Create
-
-		// Only import resources that are defined for the current workspace
-		if resource.ImportMetadata() != nil &&
-			resource.ImportMetadata().WorkspaceId == p.workspaceId {
-			opType = Import
-		}
-		plan.Operations = append(plan.Operations, &Operation{Type: opType, Resource: resource})
+		plan.Operations = append(plan.Operations, &Operation{Type: Create, Resource: resource})
 	}
 
+	// Handle updated resources
 	updatedURNs := make([]string, 0, len(diff.UpdatedResources))
 	for r := range diff.UpdatedResources {
 		updatedURNs = append(updatedURNs, r)
@@ -86,6 +88,7 @@ func (p *Planner) Plan(source, target *resources.Graph) *Plan {
 		plan.Operations = append(plan.Operations, &Operation{Type: Update, Resource: resource})
 	}
 
+	// Handle deleted resources
 	sortedDeleted := sortByDependencies(diff.RemovedResources, source)
 	slices.Reverse(sortedDeleted)
 	for _, urn := range sortedDeleted {

--- a/cli/internal/syncer/planner/planner_test.go
+++ b/cli/internal/syncer/planner/planner_test.go
@@ -131,7 +131,7 @@ func TestPlanner_Plan(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := planner.New("test-workspace-id")
+			p := planner.New("workspace-id")
 			plan := p.Plan(tt.source, tt.target)
 			for i, op := range plan.Operations {
 				fmt.Printf("Operation %d: %d %s\n", i, op.Type, op.Resource.ID())

--- a/cli/internal/syncer/planner/planner_test.go
+++ b/cli/internal/syncer/planner/planner_test.go
@@ -19,6 +19,7 @@ func TestPlanner_Plan(t *testing.T) {
 	targetWithDependency := newResource("res2", "target resource 2", &resources.PropertyRef{URN: sourceUnmodified.URN(), Property: "name"})
 	targetToBeUpdated := newResource("res3", "target resource 3", nil)
 	targetToBeCreated := newResource("res4", "target resource 4", nil)
+	targetToBeImported := newResource("res5", "target resource 5", nil, resources.WithResourceImportMetadata("remote-res5", "workspace-id"))
 
 	tests := []struct {
 		name     string
@@ -98,6 +99,34 @@ func TestPlanner_Plan(t *testing.T) {
 				{Type: planner.Delete, Resource: sourceToBeDeleted},
 			},
 		},
+		{
+			name:   "import single resource",
+			source: newGraph(),
+			target: newGraphWithResources(targetToBeImported),
+			expected: []*planner.Operation{
+				{Type: planner.Import, Resource: targetToBeImported},
+			},
+		},
+		{
+			name: "combined import, create, update and delete",
+			source: newGraphWithResources(
+				sourceToBeDeleted,
+				sourceUnmodified,
+				sourceToBeUpdated,
+			),
+			target: newGraphWithResources(
+				targetUnmodified,
+				targetToBeUpdated,
+				targetToBeCreated,
+				targetToBeImported,
+			),
+			expected: []*planner.Operation{
+				{Type: planner.Import, Resource: targetToBeImported},
+				{Type: planner.Create, Resource: targetToBeCreated},
+				{Type: planner.Update, Resource: targetToBeUpdated},
+				{Type: planner.Delete, Resource: sourceToBeDeleted},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -124,12 +153,12 @@ func newGraphWithResources(rs ...*resources.Resource) *resources.Graph {
 	return g
 }
 
-func newResource(id string, name string, dependency *resources.PropertyRef) *resources.Resource {
+func newResource(id string, name string, dependency *resources.PropertyRef, opts ...resources.ResourceOpts) *resources.Resource {
 	data := resources.ResourceData{
 		"name": name,
 	}
 	if dependency != nil {
 		data["dependency"] = *dependency
 	}
-	return resources.NewResource(id, "some-type", data, []string{})
+	return resources.NewResource(id, "some-type", data, []string{}, opts...)
 }


### PR DESCRIPTION
## Description
We are clubbing importable resources with new resources when diffing the previous and current state. This creates confusion for the user as to what resources are getting imported and what will be created , updated / removed.

## Changes
1. Added a new `importableResources` field on the differ
2. Using the import metadata on the resource with current workspaceId as indication to add it to the current importable resources list.
3. Created a new `DiffOptions` to cleanly pass WorkspaceID to the differ.

## Example
<img width="674" height="194" alt="Screenshot 2025-10-04 at 12 12 34 AM" src="https://github.com/user-attachments/assets/f4b06eae-7110-45ff-bb62-32f6ca2f64a1" />
