### PR TITLE
fix: enabled field of EventStreamSource is defaulting to false

### DIFF
--- a/api/client/event-stream/source/source.go
+++ b/api/client/event-stream/source/source.go
@@ -12,8 +12,8 @@ import (
 const prefix = "/v2/event-stream-sources"
 
 type SourceStore interface {
-	Create(ctx context.Context, source *CreateSourceRequest) (*EventStreamSource, error)
-	Update(ctx context.Context, sourceId string, source *UpdateSourceRequest) (*EventStreamSource, error)
+	Create(ctx context.Context, source *CreateSourceRequest) (*CreateUpdateSourceResponse, error)
+	Update(ctx context.Context, sourceId string, source *UpdateSourceRequest) (*CreateUpdateSourceResponse, error)
 	Delete(ctx context.Context, sourceId string) error
 	GetSources(ctx context.Context) ([]EventStreamSource, error)
 }
@@ -29,7 +29,7 @@ func NewRudderSourceStore(client *client.Client) SourceStore {
 	return store
 }
 
-func (r *rudderSourceStore) Create(ctx context.Context, source *CreateSourceRequest) (*EventStreamSource, error) {
+func (r *rudderSourceStore) Create(ctx context.Context, source *CreateSourceRequest) (*CreateUpdateSourceResponse, error) {
 	data, err := json.Marshal(source)
 	if err != nil {
 		return nil, fmt.Errorf("marshalling create source request: %w", err)
@@ -38,14 +38,14 @@ func (r *rudderSourceStore) Create(ctx context.Context, source *CreateSourceRequ
 	if err != nil {
 		return nil, fmt.Errorf("creating event stream source: %w", err)
 	}
-	var result EventStreamSource
+	var result CreateUpdateSourceResponse
 	if err := json.Unmarshal(resp, &result); err != nil {
 		return nil, fmt.Errorf("unmarshalling create source response: %w", err)
 	}
 	return &result, nil
 }
 
-func (r *rudderSourceStore) Update(ctx context.Context, sourceId string, source *UpdateSourceRequest) (*EventStreamSource, error) {
+func (r *rudderSourceStore) Update(ctx context.Context, sourceId string, source *UpdateSourceRequest) (*CreateUpdateSourceResponse, error) {
 	data, err := json.Marshal(source)
 	if err != nil {
 		return nil, fmt.Errorf("marshalling update source request: %w", err)
@@ -56,7 +56,7 @@ func (r *rudderSourceStore) Update(ctx context.Context, sourceId string, source 
 		return nil, fmt.Errorf("updating event stream source: %w", err)
 	}
 
-	var result EventStreamSource
+	var result CreateUpdateSourceResponse
 	if err := json.Unmarshal(resp, &result); err != nil {
 		return nil, fmt.Errorf("unmarshalling update source response: %w", err)
 	}

--- a/api/client/event-stream/source/source_test.go
+++ b/api/client/event-stream/source/source_test.go
@@ -43,7 +43,7 @@ func TestCreateSource(t *testing.T) {
 	created, err := eventStreamClient.Create(context.Background(), source)
 	require.NoError(t, err)
 
-	assert.Equal(t, &esSource.EventStreamSource{
+	assert.Equal(t, &esSource.CreateUpdateSourceResponse{
 		ID:         "src-123",
 		ExternalID: "ext-123",
 		Name:       "Test Source",
@@ -56,7 +56,7 @@ func TestCreateSource(t *testing.T) {
 func TestUpdateSource(t *testing.T) {
 	httpClient := testutils.NewMockHTTPClient(t, testutils.Call{
 		Validate: func(req *http.Request) bool {
-			expected := `{"name":"Updated Source"}`
+			expected := `{"name":"Updated Source","enabled":true}`
 			return testutils.ValidateRequest(t, req, "PUT", "/v2/event-stream-sources/src-123", expected)
 		},
 		ResponseStatus: 200,
@@ -76,12 +76,13 @@ func TestUpdateSource(t *testing.T) {
 
 	source := &esSource.UpdateSourceRequest{
 		Name: "Updated Source",
+		Enabled: true,
 	}
 
 	updated, err := eventStreamClient.Update(context.Background(), "src-123", source)
 	require.NoError(t, err)
 
-	assert.Equal(t, &esSource.EventStreamSource{
+	assert.Equal(t, &esSource.CreateUpdateSourceResponse{
 		ID:         "src-123",
 		ExternalID: "ext-123",
 		Name:       "Updated Source",
@@ -112,8 +113,8 @@ func TestDeleteSource(t *testing.T) {
 
 func TestGetSources(t *testing.T) {
 	tests := []struct {
-		name           string
-		calls          []testutils.Call
+		name            string
+		calls           []testutils.Call
 		expectedSources []esSource.EventStreamSource
 	}{
 		{

--- a/api/client/event-stream/source/types.go
+++ b/api/client/event-stream/source/types.go
@@ -14,20 +14,28 @@ type CreateSourceRequest struct {
 
 type UpdateSourceRequest struct {
 	Name    string `json:"name,omitempty"`
-	Enabled bool   `json:"enabled,omitempty"`
+	Enabled bool   `json:"enabled"`
+}
+
+type CreateUpdateSourceResponse struct {
+	ID         string `json:"id"`
+	ExternalID string `json:"externalId"`
+	Name       string `json:"name"`
+	Type       string `json:"type"`
+	Enabled    bool   `json:"enabled"`
 }
 
 type EventStreamSource struct {
-	ID          string `json:"id"`
-	ExternalID  string `json:"externalId"`
-	Name        string `json:"name"`
-	Type        string `json:"type"`
-	Enabled     bool   `json:"enabled"`
+	ID           string        `json:"id"`
+	ExternalID   string        `json:"externalId"`
+	Name         string        `json:"name"`
+	Type         string        `json:"type"`
+	Enabled      bool          `json:"enabled"`
 	TrackingPlan *TrackingPlan `json:"trackingPlan"`
 }
 
 type TrackingPlan struct {
-	ID string `json:"id"`
+	ID     string                               `json:"id"`
 	Config *trackingplanClient.ConnectionConfig `json:"config"`
 }
 

--- a/cli/internal/providers/event-stream/source/handler.go
+++ b/cli/internal/providers/event-stream/source/handler.go
@@ -13,9 +13,9 @@ import (
 	trackingplanClient "github.com/rudderlabs/rudder-iac/api/client/event-stream/tracking-plan-connection"
 	"github.com/rudderlabs/rudder-iac/cli/internal/config"
 	"github.com/rudderlabs/rudder-iac/cli/internal/project/specs"
+	dcstate "github.com/rudderlabs/rudder-iac/cli/internal/providers/datacatalog/state"
 	"github.com/rudderlabs/rudder-iac/cli/internal/syncer/resources"
 	"github.com/rudderlabs/rudder-iac/cli/internal/syncer/state"
-	dcstate "github.com/rudderlabs/rudder-iac/cli/internal/providers/datacatalog/state"
 )
 
 type Handler struct {
@@ -35,11 +35,16 @@ func (h *Handler) LoadSpec(_ string, s *specs.Spec) error {
 	if _, exists := h.resources[spec.LocalId]; exists {
 		return fmt.Errorf("event stream source with id %s already exists", spec.LocalId)
 	}
+	// Default enabled to true when not specified in the spec
+	enabled := true
+	if spec.Enabled != nil {
+		enabled = *spec.Enabled
+	}
 	sourceResource := &sourceResource{
 		LocalId:          spec.LocalId,
 		Name:             spec.Name,
 		SourceDefinition: spec.SourceDefinition,
-		Enabled:          spec.Enabled,
+		Enabled:          enabled,
 		Governance:       &governanceResource{},
 	}
 	if err := h.loadTrackingPlanSpec(spec, sourceResource); err != nil {

--- a/cli/internal/providers/event-stream/source/handler_test.go
+++ b/cli/internal/providers/event-stream/source/handler_test.go
@@ -287,7 +287,6 @@ func TestEventStreamSourceHandler(t *testing.T) {
 					"id":      "test-source-1",
 					"name":    "Test Source 1",
 					"type":    "javascript",
-					"enabled": true,
 				},
 			},
 			{

--- a/cli/internal/providers/event-stream/source/mock_client.go
+++ b/cli/internal/providers/event-stream/source/mock_client.go
@@ -18,9 +18,9 @@ type MockSourceClient struct {
 	getSourcesFunc   func(ctx context.Context) ([]sourceClient.EventStreamSource, error)
 }
 
-func (m *MockSourceClient) Create(ctx context.Context, req *sourceClient.CreateSourceRequest) (*sourceClient.EventStreamSource, error) {
+func (m *MockSourceClient) Create(ctx context.Context, req *sourceClient.CreateSourceRequest) (*sourceClient.CreateUpdateSourceResponse, error) {
 	m.createCalled = true
-	return &sourceClient.EventStreamSource{
+	return &sourceClient.CreateUpdateSourceResponse{
 		ExternalID: req.ExternalID,
 		Name:       req.Name,
 		Type:       req.Type,
@@ -28,9 +28,9 @@ func (m *MockSourceClient) Create(ctx context.Context, req *sourceClient.CreateS
 	}, nil
 }
 
-func (m *MockSourceClient) Update(ctx context.Context, sourceID string, req *sourceClient.UpdateSourceRequest) (*sourceClient.EventStreamSource, error) {
+func (m *MockSourceClient) Update(ctx context.Context, sourceID string, req *sourceClient.UpdateSourceRequest) (*sourceClient.CreateUpdateSourceResponse, error) {
 	m.updateCalled = true
-	return &sourceClient.EventStreamSource{
+	return &sourceClient.CreateUpdateSourceResponse{
 		ID:         sourceID,
 		ExternalID: "external-123",
 		Name:       req.Name,

--- a/cli/internal/providers/event-stream/source/model.go
+++ b/cli/internal/providers/event-stream/source/model.go
@@ -17,10 +17,10 @@ const (
 	TrackingPlanConfigKey = "tracking_plan_config"
 	TrackingPlanIDKey     = "tracking_plan_id"
 
-	PropagateViolationsKey = "propagate_violations"
+	PropagateViolationsKey     = "propagate_violations"
 	DropUnplannedPropertiesKey = "drop_unplanned_properties"
-	DropOtherViolationsKey = "drop_other_violations"
-	DropUnplannedEventsKey = "drop_unplanned_events"
+	DropOtherViolationsKey     = "drop_other_violations"
+	DropUnplannedEventsKey     = "drop_unplanned_events"
 
 	ResourceType = "event-stream-source"
 )
@@ -48,7 +48,7 @@ type sourceSpec struct {
 	LocalId          string                `mapstructure:"id"`
 	Name             string                `mapstructure:"name"`
 	SourceDefinition string                `mapstructure:"type"`
-	Enabled          bool                  `mapstructure:"enabled"`
+	Enabled          *bool                 `mapstructure:"enabled"`
 	Governance       *sourceGovernanceSpec `mapstructure:"governance"`
 }
 
@@ -76,7 +76,7 @@ type eventConfigSpec struct {
 }
 
 type trackConfigSpec struct {
-	eventConfigSpec `mapstructure:",squash"`
+	eventConfigSpec     `mapstructure:",squash"`
 	DropUnplannedEvents *bool `json:"drop_unplanned_events" mapstructure:"drop_unplanned_events"`
 }
 

--- a/cli/internal/syncer/syncer.go
+++ b/cli/internal/syncer/syncer.go
@@ -9,6 +9,7 @@ import (
 	"github.com/rudderlabs/rudder-iac/api/client"
 	"github.com/rudderlabs/rudder-iac/cli/internal/config"
 	dcstate "github.com/rudderlabs/rudder-iac/cli/internal/providers/datacatalog/state"
+	esSource "github.com/rudderlabs/rudder-iac/cli/internal/providers/event-stream/source"
 	"github.com/rudderlabs/rudder-iac/cli/internal/syncer/differ"
 	"github.com/rudderlabs/rudder-iac/cli/internal/syncer/planner"
 	"github.com/rudderlabs/rudder-iac/cli/internal/syncer/resources"
@@ -79,7 +80,13 @@ func (s *ProjectSyncer) apply(ctx context.Context, target *resources.Graph, opti
 	var reconstate *state.State
 	if config.GetConfig().ExperimentalFlags.StatelessCLI {
 		// remove state for stateless resources - this is to avoid conflicts b/w the api state and the reconstructed state
-		apistate = removeStateForResourceTypes(apistate, []string{dcstate.CategoryResourceType, dcstate.EventResourceType, dcstate.PropertyResourceType, dcstate.CustomTypeResourceType})
+		apistate = removeStateForResourceTypes(apistate, []string{
+			dcstate.CategoryResourceType,
+			dcstate.EventResourceType,
+			dcstate.PropertyResourceType,
+			dcstate.CustomTypeResourceType,
+			esSource.ResourceType,
+		})
 		// load resources
 		resources, err := s.provider.LoadResourcesFromRemote(ctx)
 		if err != nil {


### PR DESCRIPTION
**Summary**
Fixed a bug where the enabled field of EventStreamSource was defaulting to false instead of true when not explicitly specified in the configuration.

**Problem**

Previously, when creating or updating Event Stream Sources without explicitly setting the enabled field in the spec, the field would default to false due to Go's zero-value behavior for boolean types. This caused sources to be disabled by default, which is not the desired behavior.

- Enabled field in `UpdateSourceRequest` to always serialize (removed `omitempty`) to ensure the value is properly sent to the API
- Introduced `CreateUpdateSourceResponse` type separate from `EventStreamSource` to properly handle the response structure from create/update operations
- Included event-stream-source in the list of stateless resource types