### PR TITLE
fix: incorrect response schema used in get event stream sources API

### DIFF
--- a/api/client/event-stream/source/source_test.go
+++ b/api/client/event-stream/source/source_test.go
@@ -12,6 +12,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func boolPtr(b bool) *bool {
+	return &b
+}
+
 func TestCreateSource(t *testing.T) {
 	httpClient := testutils.NewMockHTTPClient(t, testutils.Call{
 		Validate: func(req *http.Request) bool {
@@ -181,7 +185,16 @@ func TestGetSources(t *testing.T) {
 								"externalId": "ext-123",
 								"name": "Source 1",
 								"type": "webhook",
-								"enabled": true
+								"enabled": true,
+								"trackingPlan": {
+									"id": "tp-123",
+									"config": {
+										"track": {
+											"propagateViolations": true,
+											"dropUnplannedEvents": true
+										}
+									}
+								}
 							}
 						],
 						"paging": {
@@ -240,6 +253,17 @@ func TestGetSources(t *testing.T) {
 					Name:       "Source 1",
 					Type:       "webhook",
 					Enabled:    true,
+					TrackingPlan: &esSource.TrackingPlan{
+						ID: "tp-123",
+						Config: &esSource.TrackingPlanConfig{
+							Track: &esSource.TrackConfig{
+								EventTypeConfig: &esSource.EventTypeConfig{
+									PropagateViolations: boolPtr(true),
+								},
+								DropUnplannedEvents: boolPtr(true),
+							},
+						},
+					},
 				},
 				{
 					ID:         "src-456",

--- a/api/client/event-stream/source/types.go
+++ b/api/client/event-stream/source/types.go
@@ -2,7 +2,6 @@ package source
 
 import (
 	"github.com/rudderlabs/rudder-iac/api/client"
-	trackingplanClient "github.com/rudderlabs/rudder-iac/api/client/event-stream/tracking-plan-connection"
 )
 
 type CreateSourceRequest struct {
@@ -34,9 +33,31 @@ type EventStreamSource struct {
 	TrackingPlan *TrackingPlan `json:"trackingPlan"`
 }
 
+// The response shape is different for the GET API compared
+// to the APIs present in the tracking-plan-connection package
+type TrackingPlanConfig struct {
+	Track    *TrackConfig     `json:"track,omitempty"`
+	Identify *EventTypeConfig `json:"identify,omitempty"`
+	Group    *EventTypeConfig `json:"group,omitempty"`
+	Page     *EventTypeConfig `json:"page,omitempty"`
+	Screen   *EventTypeConfig `json:"screen,omitempty"`
+}
+
+type TrackConfig struct {
+	*EventTypeConfig
+	DropUnplannedEvents *bool `json:"dropUnplannedEvents,omitempty"`
+}
+
+type EventTypeConfig struct {
+	PropagateViolations *bool   `json:"propagateViolations,omitempty"`
+	DropUnplannedProperties       *bool `json:"dropUnplannedProperties,omitempty"`
+	DropOtherViolations         *bool `json:"dropOtherViolations,omitempty"`
+}
+
+
 type TrackingPlan struct {
 	ID     string                               `json:"id"`
-	Config *trackingplanClient.ConnectionConfig `json:"config"`
+	Config *TrackingPlanConfig `json:"config"`
 }
 
 type eventStreamSourcesPage struct {

--- a/cli/internal/providers/event-stream/source/handler.go
+++ b/cli/internal/providers/event-stream/source/handler.go
@@ -589,13 +589,13 @@ func mapStateEventTypeConfigToRemote(config map[string]interface{}, key string) 
 	return eventTypeConfig
 }
 
-func mapRemoteTPConfigToState(config *trackingplanClient.ConnectionConfig) map[string]interface{} {
+func mapRemoteTPConfigToState(config *sourceClient.TrackingPlanConfig) map[string]interface{} {
 	result := make(map[string]interface{})
 
 	if config.Track != nil {
 		trackMap := buildStateEventConfigMap(config.Track.EventTypeConfig)
-		if config.Track.AllowUnplannedEvents != nil {
-			trackMap[DropUnplannedEventsKey] = !(*config.Track.AllowUnplannedEvents)
+		if config.Track.DropUnplannedEvents != nil {
+			trackMap[DropUnplannedEventsKey] = *config.Track.DropUnplannedEvents
 		}
 		result[TrackKey] = trackMap
 	}
@@ -619,7 +619,7 @@ func mapRemoteTPConfigToState(config *trackingplanClient.ConnectionConfig) map[s
 	return result
 }
 
-func buildStateEventConfigMap(config *trackingplanClient.EventTypeConfig) map[string]interface{} {
+func buildStateEventConfigMap(config *sourceClient.EventTypeConfig) map[string]interface{} {
 	if config == nil {
 		return map[string]interface{}{}
 	}
@@ -627,26 +627,19 @@ func buildStateEventConfigMap(config *trackingplanClient.EventTypeConfig) map[st
 	result := map[string]interface{}{}
 
 	// Only include fields that are explicitly set
-	if config.PropagateValidationErrors != nil {
-		result[PropagateViolationsKey] = *config.PropagateValidationErrors
+	if config.PropagateViolations != nil {
+		result[PropagateViolationsKey] = *config.PropagateViolations
 	}
 
-	if config.UnplannedProperties != nil {
-		result[DropUnplannedPropertiesKey] = shouldDrop(config.UnplannedProperties)
+	if config.DropUnplannedProperties != nil {
+		result[DropUnplannedPropertiesKey] = *config.DropUnplannedProperties
 	}
 
-	if config.AnyOtherViolation != nil {
-		result[DropOtherViolationsKey] = shouldDrop(config.AnyOtherViolation)
+	if config.DropOtherViolations != nil {
+		result[DropOtherViolationsKey] = *config.DropOtherViolations
 	}
 
 	return result
-}
-
-func shouldDrop(action *trackingplanClient.Action) bool {
-	if action == nil {
-		return false
-	}
-	return *action == trackingplanClient.Drop
 }
 
 func dropToAction(drop bool) trackingplanClient.Action {

--- a/cli/internal/providers/event-stream/source/handler_test.go
+++ b/cli/internal/providers/event-stream/source/handler_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	sourceClient "github.com/rudderlabs/rudder-iac/api/client/event-stream/source"
-	trackingplanClient "github.com/rudderlabs/rudder-iac/api/client/event-stream/tracking-plan-connection"
 
 	"github.com/rudderlabs/rudder-iac/cli/internal/project/specs"
 	"github.com/rudderlabs/rudder-iac/cli/internal/providers/event-stream/source"
@@ -21,11 +20,6 @@ import (
 // Helper function to convert boolean to pointer
 func boolPtr(b bool) *bool {
 	return &b
-}
-
-// Helper function to convert Action to pointer
-func actionPtr(a trackingplanClient.Action) *trackingplanClient.Action {
-	return &a
 }
 
 func TestEventStreamSourceHandler(t *testing.T) {
@@ -709,29 +703,29 @@ func TestEventStreamSourceHandler(t *testing.T) {
 					Enabled:    true,
 					TrackingPlan: &sourceClient.TrackingPlan{
 						ID: "remote-tp-123",
-						Config: &trackingplanClient.ConnectionConfig{
-							Track: &trackingplanClient.TrackConfig{
-								AllowUnplannedEvents: boolPtr(false),
+						Config: &sourceClient.TrackingPlanConfig{
+							Track: &sourceClient.TrackConfig{
+								DropUnplannedEvents: boolPtr(true),
 							},
-							Identify: &trackingplanClient.EventTypeConfig{
-								PropagateValidationErrors: boolPtr(false),
-								UnplannedProperties:       actionPtr(trackingplanClient.Drop),
-								AnyOtherViolation:         actionPtr(trackingplanClient.Forward),
+							Identify: &sourceClient.EventTypeConfig{
+								PropagateViolations: boolPtr(false),
+								DropUnplannedProperties:       boolPtr(true),
+								DropOtherViolations:         boolPtr(false),
 							},
-							Group: &trackingplanClient.EventTypeConfig{
-								PropagateValidationErrors: boolPtr(true),
-								UnplannedProperties:       actionPtr(trackingplanClient.Forward),
-								AnyOtherViolation:         actionPtr(trackingplanClient.Forward),
+							Group: &sourceClient.EventTypeConfig{
+								PropagateViolations: boolPtr(true),
+								DropUnplannedProperties:       boolPtr(false),
+								DropOtherViolations:         boolPtr(false),
 							},
-							Page: &trackingplanClient.EventTypeConfig{
-								PropagateValidationErrors: boolPtr(false),
-								UnplannedProperties:       actionPtr(trackingplanClient.Forward),
-								AnyOtherViolation:         actionPtr(trackingplanClient.Drop),
+							Page: &sourceClient.EventTypeConfig{
+								PropagateViolations: boolPtr(false),
+								DropUnplannedProperties:       boolPtr(false),
+								DropOtherViolations:         boolPtr(true),
 							},
-							Screen: &trackingplanClient.EventTypeConfig{
-								PropagateValidationErrors: boolPtr(true),
-								UnplannedProperties:       actionPtr(trackingplanClient.Forward),
-								AnyOtherViolation:         actionPtr(trackingplanClient.Forward),
+							Screen: &sourceClient.EventTypeConfig{
+								PropagateViolations: boolPtr(true),
+								DropUnplannedProperties:  boolPtr(false),
+								DropOtherViolations:         boolPtr(false),
 							},
 						},
 					},
@@ -925,9 +919,9 @@ func TestEventStreamSourceHandler(t *testing.T) {
 					Enabled:    true,
 					TrackingPlan: &sourceClient.TrackingPlan{
 						ID: "remote-tp-789",
-						Config: &trackingplanClient.ConnectionConfig{
-							Track: &trackingplanClient.TrackConfig{
-								AllowUnplannedEvents: boolPtr(false),
+						Config: &sourceClient.TrackingPlanConfig{
+							Track: &sourceClient.TrackConfig{
+								DropUnplannedEvents: boolPtr(true),
 							},
 						},
 					},

--- a/cli/internal/syncer/syncer.go
+++ b/cli/internal/syncer/syncer.go
@@ -9,6 +9,7 @@ import (
 	"github.com/rudderlabs/rudder-iac/api/client"
 	"github.com/rudderlabs/rudder-iac/cli/internal/config"
 	dcstate "github.com/rudderlabs/rudder-iac/cli/internal/providers/datacatalog/state"
+	esSource "github.com/rudderlabs/rudder-iac/cli/internal/providers/event-stream/source"
 	"github.com/rudderlabs/rudder-iac/cli/internal/syncer/differ"
 	"github.com/rudderlabs/rudder-iac/cli/internal/syncer/planner"
 	"github.com/rudderlabs/rudder-iac/cli/internal/syncer/resources"
@@ -79,7 +80,14 @@ func (s *ProjectSyncer) apply(ctx context.Context, target *resources.Graph, opti
 	var reconstate *state.State
 	if config.GetConfig().ExperimentalFlags.StatelessCLI {
 		// remove state for stateless resources - this is to avoid conflicts b/w the api state and the reconstructed state
-		apistate = removeStateForResourceTypes(apistate, []string{dcstate.CategoryResourceType, dcstate.EventResourceType, dcstate.PropertyResourceType, dcstate.CustomTypeResourceType, dcstate.TrackingPlanResourceType})
+		apistate = removeStateForResourceTypes(apistate, []string{
+			dcstate.CategoryResourceType,
+			dcstate.EventResourceType,
+			dcstate.PropertyResourceType,
+			dcstate.CustomTypeResourceType,
+			dcstate.TrackingPlanResourceType,
+			esSource.ResourceType,
+		})
 		// load resources
 		resources, err := s.provider.LoadResourcesFromRemote(ctx)
 		if err != nil {


### PR DESCRIPTION
**Summary**

Fixed incorrect response schema handling for Event Stream Sources GET API. The tracking plan configuration structure returned by the GET sources API differs from the POST/PUT APIs in the tracking-plan-connection package.

**Changes**

- API Client Types: Added dedicated response types (TrackingPlanConfig, TrackConfig, EventTypeConfig) specific to the GET sources API, instead of reusing types from the tracking-plan-connection package
- Handler Logic: Updated mapping functions to work with the corrected response schema:
   Changed field mappings from AllowUnplannedEvents → DropUnplannedEvents
   Changed from PropagateValidationErrors → PropagateViolations
   Simplified action mapping by using boolean fields directly instead of Action enum types
- State Reconstruction: Added Event Stream Source to stateless resource types to avoid state conflicts