### PR TITLE
fix: move the e2e tests to generic apply and destroy

### DIFF
--- a/api/client/event-stream/source/source.go
+++ b/api/client/event-stream/source/source.go
@@ -101,6 +101,9 @@ func (r *rudderSourceStore) list(ctx context.Context, paging client.Paging) (*ev
 	if paging.Next == "" {
 		return nil, nil
 	}
+
+	fmt.Printf("subpath: %s\n", paging.Next)
+
 	res, err := r.client.Do(ctx, "GET", paging.Next, nil)
 	if err != nil {
 		return nil, fmt.Errorf("getting event stream sources: %w", err)

--- a/cli/tests/command_apply_test.go
+++ b/cli/tests/command_apply_test.go
@@ -17,17 +17,17 @@ func TestProjectApply(t *testing.T) {
 	executor, err := NewCmdExecutor("")
 	require.NoError(t, err)
 
-	output, err := executor.Execute(cliBinPath, "tp", "destroy", "--confirm=false")
+	output, err := executor.Execute(cliBinPath, "destroy", "--confirm=false")
 	require.NoError(t, err, "Failed to destroy resources: %v, output: %s", err, string(output))
 
 	t.Run("should create entities in catalog from project", func(t *testing.T) {
-		output, err := executor.Execute(cliBinPath, "tp", "apply", "-l", filepath.Join("testdata", "project", "create"), "--confirm=false")
+		output, err := executor.Execute(cliBinPath, "apply", "-l", filepath.Join("testdata", "project", "create"), "--confirm=false")
 		require.NoError(t, err, "Initial apply command failed with output: %s", string(output))
 		verifyState(t, "create")
 	})
 
 	t.Run("should update entities in catalog from project", func(t *testing.T) {
-		output, err := executor.Execute(cliBinPath, "tp", "apply", "-l", filepath.Join("testdata", "project", "update"), "--confirm=false")
+		output, err := executor.Execute(cliBinPath, "apply", "-l", filepath.Join("testdata", "project", "update"), "--confirm=false")
 		require.NoError(t, err, "Update apply command failed with output: %s", string(output))
 		verifyState(t, "update")
 	})


### PR DESCRIPTION
## Description

The e2e tests needs to be moved to the generic apply and destroy commands as we need to capture the issues across the providers and not only catalog provider.