### PR TITLE
fix: incorrect field type used when configuring tracking plan connection

### DIFF
--- a/api/client/event-stream/tracking-plan-connection/connection_test.go
+++ b/api/client/event-stream/tracking-plan-connection/connection_test.go
@@ -12,8 +12,9 @@ import (
 )
 
 // Helper function to convert boolean to pointer
-func boolPtr(b bool) *bool {
-	return &b
+func strBoolPtr(b string) *trackingplanconnection.StringBool {
+	x := trackingplanconnection.StringBool(b)
+	return &x
 }
 
 // Helper function to convert Action to pointer
@@ -26,11 +27,11 @@ func TestLinkTP(t *testing.T) {
 		Validate: func(req *http.Request) bool {
 			expected := `{
 				"config": {
-					"track":{"propagateValidationErrors":true,"unplannedProperties":"forward","anyOtherViolation":"forward","allowUnplannedEvents":false},
-					"identify":{"propagateValidationErrors":false,"unplannedProperties":"drop","anyOtherViolation":"forward"},
-					"group":{"propagateValidationErrors":true,"unplannedProperties":"forward","anyOtherViolation":"forward"},
-					"page":{"propagateValidationErrors":false,"unplannedProperties":"forward","anyOtherViolation":"drop"},
-					"screen":{"propagateValidationErrors":true,"unplannedProperties":"forward","anyOtherViolation":"forward"}
+					"track":{"propagateValidationErrors":"true","unplannedProperties":"forward","anyOtherViolation":"forward","allowUnplannedEvents":"false"},
+					"identify":{"propagateValidationErrors":"false","unplannedProperties":"drop","anyOtherViolation":"forward"},
+					"group":{"propagateValidationErrors":"true","unplannedProperties":"forward","anyOtherViolation":"forward"},
+					"page":{"propagateValidationErrors":"false","unplannedProperties":"forward","anyOtherViolation":"drop"},
+					"screen":{"propagateValidationErrors":"true","unplannedProperties":"forward","anyOtherViolation":"forward"}
 				}
 			}`
 			return testutils.ValidateRequest(t, req, "POST", "v2/catalog/tracking-plans/tp-123/sources/src-456", expected)
@@ -45,29 +46,29 @@ func TestLinkTP(t *testing.T) {
 	config := &trackingplanconnection.ConnectionConfig{
 		Track: &trackingplanconnection.TrackConfig{
 			EventTypeConfig: &trackingplanconnection.EventTypeConfig{
-				PropagateValidationErrors: boolPtr(true),
+				PropagateValidationErrors: strBoolPtr("true"),
 				UnplannedProperties:       actionPtr(trackingplanconnection.Forward),
 				AnyOtherViolation:         actionPtr(trackingplanconnection.Forward),
 			},
-			AllowUnplannedEvents: boolPtr(false),
+			AllowUnplannedEvents: strBoolPtr("false"),
 		},
 		Identify: &trackingplanconnection.EventTypeConfig{
-			PropagateValidationErrors: boolPtr(false),
+			PropagateValidationErrors: strBoolPtr("false"),
 			UnplannedProperties:       actionPtr(trackingplanconnection.Drop),
 			AnyOtherViolation:         actionPtr(trackingplanconnection.Forward),
 		},
 		Group: &trackingplanconnection.EventTypeConfig{
-			PropagateValidationErrors: boolPtr(true),
+			PropagateValidationErrors: strBoolPtr("true"),
 			UnplannedProperties:       actionPtr(trackingplanconnection.Forward),
 			AnyOtherViolation:         actionPtr(trackingplanconnection.Forward),
 		},
 		Page: &trackingplanconnection.EventTypeConfig{
-			PropagateValidationErrors: boolPtr(false),
+			PropagateValidationErrors: strBoolPtr("false"),
 			UnplannedProperties:       actionPtr(trackingplanconnection.Forward),
 			AnyOtherViolation:         actionPtr(trackingplanconnection.Drop),
 		},
 		Screen: &trackingplanconnection.EventTypeConfig{
-			PropagateValidationErrors: boolPtr(true),
+			PropagateValidationErrors: strBoolPtr("true"),
 			UnplannedProperties:       actionPtr(trackingplanconnection.Forward),
 			AnyOtherViolation:         actionPtr(trackingplanconnection.Forward),
 		},
@@ -83,9 +84,9 @@ func TestUpdateTPConnection(t *testing.T) {
 		Validate: func(req *http.Request) bool {
 			expected := `{
 				"config": {
-					"track":{"propagateValidationErrors":false,"unplannedProperties":"drop","anyOtherViolation":"forward","allowUnplannedEvents":true},
+					"track":{"propagateValidationErrors":"false","unplannedProperties":"drop","anyOtherViolation":"forward","allowUnplannedEvents":"true"},
 					"identify":{"unplannedProperties":"forward","anyOtherViolation":"drop"},
-					"group":{"propagateValidationErrors":false,"unplannedProperties":"forward","anyOtherViolation":"drop"}
+					"group":{"propagateValidationErrors":"false","unplannedProperties":"forward","anyOtherViolation":"drop"}
 				}
 			}`
 			return testutils.ValidateRequest(t, req, "PUT", "v2/catalog/tracking-plans/tp-123/sources/src-456", expected)
@@ -101,11 +102,11 @@ func TestUpdateTPConnection(t *testing.T) {
 	config := &trackingplanconnection.ConnectionConfig{
 		Track: &trackingplanconnection.TrackConfig{
 			EventTypeConfig: &trackingplanconnection.EventTypeConfig{
-				PropagateValidationErrors: boolPtr(false),
+				PropagateValidationErrors: strBoolPtr("false"),
 				UnplannedProperties:       actionPtr(trackingplanconnection.Drop),
 				AnyOtherViolation:         actionPtr(trackingplanconnection.Forward),
 			},
-			AllowUnplannedEvents: boolPtr(true),
+			AllowUnplannedEvents: strBoolPtr("true"),
 		},
 		Identify: &trackingplanconnection.EventTypeConfig{
 			PropagateValidationErrors: nil,
@@ -113,7 +114,7 @@ func TestUpdateTPConnection(t *testing.T) {
 			AnyOtherViolation:         actionPtr(trackingplanconnection.Drop),
 		},
 		Group: &trackingplanconnection.EventTypeConfig{
-			PropagateValidationErrors: boolPtr(false),
+			PropagateValidationErrors: strBoolPtr("false"),
 			UnplannedProperties:       actionPtr(trackingplanconnection.Forward),
 			AnyOtherViolation:         actionPtr(trackingplanconnection.Drop),
 		},

--- a/api/client/event-stream/tracking-plan-connection/types.go
+++ b/api/client/event-stream/tracking-plan-connection/types.go
@@ -10,9 +10,16 @@ type TrackingPlanConnectionStore interface {
 
 type Action string
 
+type StringBool string
+
 const (
 	Forward Action = "forward"
 	Drop    Action = "drop"
+)
+
+const (
+	True  StringBool = "true"
+	False StringBool = "false"
 )
 
 type ConnectionConfig struct {
@@ -24,14 +31,14 @@ type ConnectionConfig struct {
 }
 
 type EventTypeConfig struct {
-	PropagateValidationErrors *bool   `json:"propagateValidationErrors,omitempty"`
+	PropagateValidationErrors *StringBool   `json:"propagateValidationErrors,omitempty"`
 	UnplannedProperties       *Action `json:"unplannedProperties,omitempty"`
 	AnyOtherViolation         *Action `json:"anyOtherViolation,omitempty"`
 }
 
 type TrackConfig struct {
 	*EventTypeConfig
-	AllowUnplannedEvents *bool `json:"allowUnplannedEvents,omitempty"`
+	AllowUnplannedEvents *StringBool `json:"allowUnplannedEvents,omitempty"`
 }
 
 type requestBody struct {

--- a/cli/internal/providers/event-stream/source/handler.go
+++ b/cli/internal/providers/event-stream/source/handler.go
@@ -542,7 +542,12 @@ func mapStateTrackConfigToRemote(config map[string]interface{}, key string) *tra
 
 	if val, exists := configMap[DropUnplannedEventsKey]; exists {
 		if dropUnplannedEvents, ok := val.(bool); ok {
-			allowUnplannedEvents := !dropUnplannedEvents
+			var allowUnplannedEvents trackingplanClient.StringBool
+			if dropUnplannedEvents {
+				allowUnplannedEvents = trackingplanClient.False
+			} else {
+				allowUnplannedEvents = trackingplanClient.True
+			}
 			trackConfig.AllowUnplannedEvents = &allowUnplannedEvents
 		}
 	}
@@ -566,7 +571,13 @@ func mapStateEventTypeConfigToRemote(config map[string]interface{}, key string) 
 	// Only set PropagateValidationErrors if explicitly provided
 	if val, exists := configMap[PropagateViolationsKey]; exists {
 		if propagateViolations, ok := val.(bool); ok {
-			eventTypeConfig.PropagateValidationErrors = &propagateViolations
+			var propagateViolationsStr trackingplanClient.StringBool
+			if propagateViolations {
+				propagateViolationsStr = trackingplanClient.True
+			} else {
+				propagateViolationsStr = trackingplanClient.False
+			}
+			eventTypeConfig.PropagateValidationErrors = &propagateViolationsStr
 		}
 	}
 


### PR DESCRIPTION
**Summary**

Fixes incorrect field type used when configuring tracking plan connections. The API expects boolean values as strings ("true"/"false") rather than actual boolean types.

Changes
- Added `StringBool` type with `True` and `False` constants in `types.go`
- Updated `PropagateValidationErrors` and `AllowUnplannedEvents` field type from `*bool` to `*StringBool` in `types.go`
- Updated state mapping logic to convert boolean values to StringBool type in `handler.go`