### PR TITLE
chore: create imput and out folders for transformations import

### DIFF
--- a/cli/internal/project/writer/write.go
+++ b/cli/internal/project/writer/write.go
@@ -11,9 +11,11 @@ import (
 
 // FormattableEntity represents an importable entity with content and path.
 // The path extension is used to determine the formatter to use (e.g .yaml for YAML files).
+// If IsDirectory is true, only the directory at RelativePath will be created (Content is ignored).
 type FormattableEntity struct {
 	Content      any
 	RelativePath string
+	IsDirectory  bool
 }
 
 // Write is a helper function to write the files based on the formattable entities
@@ -22,6 +24,14 @@ func Write(_ context.Context, baseDir string, formatters formatter.Formatters, d
 
 	for _, datum := range data {
 		path := filepath.Join(baseDir, datum.RelativePath)
+
+		// If this is a directory-only entity, create it and skip file writing
+		if datum.IsDirectory {
+			if err := os.MkdirAll(path, 0755); err != nil {
+				return fmt.Errorf("creating directory %s: %w", path, err)
+			}
+			continue
+		}
 
 		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 			return fmt.Errorf("creating directory %s: %w", filepath.Dir(path), err)

--- a/cli/internal/providers/transformations/handlers/transformation/handler.go
+++ b/cli/internal/providers/transformations/handlers/transformation/handler.go
@@ -324,6 +324,18 @@ func (h *HandlerImpl) FormatForExport(
 
 	formattables := make([]writer.FormattableEntity, 0)
 
+	// Create empty input and output folders in transformations directory
+	formattables = append(formattables,
+		writer.FormattableEntity{
+			RelativePath: filepath.Join(handlers.TransformationsDir, "input"),
+			IsDirectory:  true,
+		},
+		writer.FormattableEntity{
+			RelativePath: filepath.Join(handlers.TransformationsDir, "output"),
+			IsDirectory:  true,
+		},
+	)
+
 	for externalID, remote := range remotes {
 		// Validate language
 		if remote.Language != handlers.JavaScript && remote.Language != handlers.Python {

--- a/cli/internal/providers/transformations/handlers/transformation/handler_test.go
+++ b/cli/internal/providers/transformations/handlers/transformation/handler_test.go
@@ -1315,14 +1315,24 @@ func TestFormatForExport(t *testing.T) {
 		result, err := handler.Impl.FormatForExport(remotes, namer, resolver)
 
 		require.NoError(t, err)
-		require.Len(t, result, 2)
+		require.Len(t, result, 4) // 2 directories + 1 spec + 1 code file
+
+		// Check input directory
+		assert.Equal(t, "transformations/input", result[0].RelativePath)
+		assert.True(t, result[0].IsDirectory)
+
+		// Check output directory
+		assert.Equal(t, "transformations/output", result[1].RelativePath)
+		assert.True(t, result[1].IsDirectory)
 
 		// Check YAML spec file
-		assert.Equal(t, "transformations/test-trans.yaml", result[0].RelativePath)
+		assert.Equal(t, "transformations/test-trans.yaml", result[2].RelativePath)
+		assert.False(t, result[2].IsDirectory)
 
 		// Check code file
-		assert.Equal(t, "transformations/javascript/test-trans.js", result[1].RelativePath)
-		assert.Equal(t, "export function transformEvent(event, metadata) { return event; }", result[1].Content)
+		assert.Equal(t, "transformations/javascript/test-trans.js", result[3].RelativePath)
+		assert.Equal(t, "export function transformEvent(event, metadata) { return event; }", result[3].Content)
+		assert.False(t, result[3].IsDirectory)
 	})
 
 	t.Run("python transformation exports to python folder", func(t *testing.T) {
@@ -1351,11 +1361,19 @@ func TestFormatForExport(t *testing.T) {
 		result, err := handler.Impl.FormatForExport(remotes, namer, resolver)
 
 		require.NoError(t, err)
-		require.Len(t, result, 2)
+		require.Len(t, result, 4) // 2 directories + 1 spec + 1 code file
+
+		// Check input directory
+		assert.Equal(t, "transformations/input", result[0].RelativePath)
+		assert.True(t, result[0].IsDirectory)
+
+		// Check output directory
+		assert.Equal(t, "transformations/output", result[1].RelativePath)
+		assert.True(t, result[1].IsDirectory)
 
 		// Check code file path
-		assert.Equal(t, "transformations/python/test-trans.py", result[1].RelativePath)
-		assert.Equal(t, "def transform(event):\n    return event", result[1].Content)
+		assert.Equal(t, "transformations/python/test-trans.py", result[3].RelativePath)
+		assert.Equal(t, "def transform(event):\n    return event", result[3].Content)
 	})
 
 	t.Run("unsupported language returns error", func(t *testing.T) {
@@ -1455,6 +1473,12 @@ func TestFormatForExport(t *testing.T) {
 		result, err := handler.Impl.FormatForExport(remotes, namer, resolver)
 
 		require.NoError(t, err)
-		require.Len(t, result, 4) // 2 specs + 2 code files
+		require.Len(t, result, 6) // 2 directories + 2 specs + 2 code files
+
+		// Check directories are created first
+		assert.Equal(t, "transformations/input", result[0].RelativePath)
+		assert.True(t, result[0].IsDirectory)
+		assert.Equal(t, "transformations/output", result[1].RelativePath)
+		assert.True(t, result[1].IsDirectory)
 	})
 }


### PR DESCRIPTION
🔒 Scanned for secrets using gitleaks 8.28.0

## 🔗 Ticket

<!-- Required for traceability -->

[DEX-235](link-to-ticket)

---

## Summary

Transformation Import: create empty folders input and output which users can use to add test files

Option 1: extend writer to support creating directory
Option2: create a readme file with instructions on how input / output folder works, so that these folders will be created

---

## Changes

* Option 1

---

## Testing

How was this tested?

* Unit tests / Integration tests / Manual testing

---

## Risk / Impact

Low / Medium / High
Notes (if any):

---

## Checklist

* [ ] Ticket linked
* [ ] Tests added/updated
* [ ] No breaking changes (or documented)
