### PR TITLE
fix(workspace): bound table height to terminal viewport for large result sets

### DIFF
--- a/cli/internal/lister/table.go
+++ b/cli/internal/lister/table.go
@@ -62,6 +62,11 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.width = msg.Width
 		m.height = msg.Height
 		m.help.Width = msg.Width
+
+		// Reserve space for help footer and margins
+		helpHeight := 1
+		tableHeight := max(msg.Height-helpHeight-1, 3)
+		m.table.SetHeight(tableHeight)
 	case tea.KeyMsg:
 		switch {
 		case key.Matches(msg, m.keys.Quit):
@@ -88,9 +93,11 @@ func (m model) View() string {
 	detailsContent := lipgloss.NewStyle().Padding(0, 2).Render(detailsView)
 	fullDetailsView := lipgloss.JoinVertical(lipgloss.Top, detailsHeader, ruler, detailsContent)
 
-	// Main Layout
+	// Main Layout — constrain details pane to match table height
+	tableHeight := m.table.Height() + 1 // +1 for header border
 	detailsStyle := lipgloss.NewStyle().
-		Padding(0, 2)
+		Padding(0, 2).
+		Height(tableHeight)
 
 	mainView := lipgloss.JoinHorizontal(
 		lipgloss.Top,
@@ -146,7 +153,7 @@ func printTableWithDetails(rs []resources.ResourceData, columnWidths map[string]
 		table.WithColumns(columns),
 		table.WithRows(rows),
 		table.WithFocused(true),
-		table.WithHeight(len(rows)+1), // +1 for the header
+		table.WithHeight(20),
 	)
 
 	s := table.DefaultStyles()

--- a/cli/internal/lister/table.go
+++ b/cli/internal/lister/table.go
@@ -94,14 +94,15 @@ func (m model) View() string {
 	fullDetailsView := lipgloss.JoinVertical(lipgloss.Top, detailsHeader, ruler, detailsContent)
 
 	// Main Layout — constrain details pane to match table height
-	tableHeight := m.table.Height() + 1 // +1 for header border
+	tableView := m.table.View()
+	tableHeight := lipgloss.Height(tableView)
 	detailsStyle := lipgloss.NewStyle().
 		Padding(0, 2).
 		Height(tableHeight)
 
 	mainView := lipgloss.JoinHorizontal(
 		lipgloss.Top,
-		m.table.View(),
+		tableView,
 		detailsStyle.Render(fullDetailsView),
 	)
 

--- a/cli/internal/lister/table_test.go
+++ b/cli/internal/lister/table_test.go
@@ -1,0 +1,62 @@
+package lister
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/bubbles/help"
+	"github.com/charmbracelet/bubbles/table"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/assert"
+)
+
+func testColumns() []table.Column {
+	return []table.Column{
+		{Title: "#", Width: 4},
+		{Title: "ID", Width: 27},
+		{Title: "Name", Width: 30},
+	}
+}
+
+func TestModel_WindowSizeMsg_SetsTableHeight(t *testing.T) {
+	rows := make([]table.Row, 100)
+	for i := range rows {
+		rows[i] = table.Row{"1", "id", "name"}
+	}
+
+	m := model{
+		table: table.New(
+			table.WithColumns(testColumns()),
+			table.WithRows(rows),
+			table.WithHeight(20),
+		),
+		help: help.New(),
+		keys: keys,
+	}
+
+	msg := tea.WindowSizeMsg{Width: 120, Height: 40}
+	updated, _ := m.Update(msg)
+	updatedModel := updated.(model)
+
+	// table.Height() returns viewport height (SetHeight value minus 1 for header)
+	setHeight := 40 - 1 - 1 // height - helpHeight - margin
+	assert.Equal(t, setHeight-1, updatedModel.table.Height())
+	assert.Less(t, updatedModel.table.Height(), len(rows))
+}
+
+func TestModel_WindowSizeMsg_EnforcesMinimumHeight(t *testing.T) {
+	m := model{
+		table: table.New(
+			table.WithColumns(testColumns()),
+			table.WithHeight(20),
+		),
+		help: help.New(),
+		keys: keys,
+	}
+
+	msg := tea.WindowSizeMsg{Width: 80, Height: 3}
+	updated, _ := m.Update(msg)
+	updatedModel := updated.(model)
+
+	// min height of 3 is passed to SetHeight; Height() returns 3-1=2
+	assert.Equal(t, 2, updatedModel.table.Height())
+}


### PR DESCRIPTION
## 🔗 Ticket

[DEX-266](https://linear.app/rudderstack/issue/DEX-266)

---

## Summary

Running `rudder-cli workspace accounts list` with >80 accounts caused the TUI to render poorly because the table height was set to `len(rows)+1`, rendering every row at once with no viewport constraint. This fix caps the table to a bounded default height and dynamically resizes on terminal window changes, enabling bubbletea's built-in scrolling.

---

## Changes

* Set a default table height of 20 instead of unbounded `len(rows)+1`
* Recalculate table height dynamically on `WindowSizeMsg`, reserving space for help footer
* Constrain the details pane height to match the table using `lipgloss.Height()` on the rendered table view, avoiding off-by-one errors from manual header/border offset calculations
* Add unit tests verifying height is bounded and minimum height is enforced

---

## Testing

* Unit tests added (`cli/internal/lister/table_test.go`)
* `make lint` — passes
* `make test` — passes

---

## Risk / Impact

Low — only affects TUI table rendering; no changes to data flow or business logic.

---

## Checklist

* [x] Ticket linked
* [x] Tests added/updated
* [x] No breaking changes (or documented)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to TUI sizing/rendering and add unit coverage; no data fetching or business logic is modified.
> 
> **Overview**
> Fixes `workspace accounts list` TUI rendering for large result sets by **capping and dynamically resizing** the table height to the terminal viewport (reserving space for the help footer and enforcing a minimum height).
> 
> Updates the layout to **match the details pane height to the rendered table height** (via `lipgloss.Height`) and adds unit tests covering window resize height calculation and minimum-height behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ab2eee0000bdf54b09c9e13282369111f57663d2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->