### PR TITLE
chore: improve test results serialization with output types and actual output files

### DIFF
--- a/api/client/transformations/types.go
+++ b/api/client/transformations/types.go
@@ -157,6 +157,7 @@ type TransformationTestResult struct {
 
 // LibraryTestResult represents validation result for a library in batch test response
 type LibraryTestResult struct {
+	ID         string `json:"id"`
 	HandleName string `json:"handleName"`
 	VersionID  string `json:"versionId"`
 	Pass       bool   `json:"pass"`

--- a/api/client/transformations/types.go
+++ b/api/client/transformations/types.go
@@ -93,6 +93,7 @@ type TestDefinition struct {
 	ID             string `json:"id"`
 	Name           string `json:"name"`
 	Description    string `json:"description,omitempty"`
+	Filename       string `json:"filename,omitempty"`
 	InputFile      string `json:"inputFile,omitempty"`
 	OutputFile     string `json:"outputFile,omitempty"`
 	Input          []any  `json:"input"`

--- a/cli/internal/cmd/transformations/test/test.go
+++ b/cli/internal/cmd/transformations/test/test.go
@@ -2,8 +2,11 @@ package test
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/spf13/cobra"
@@ -28,13 +31,14 @@ var (
 
 func NewCmdTest() *cobra.Command {
 	var (
-		deps     app.Deps
-		p        project.Project
-		err      error
-		location string
-		all      bool
-		modified bool
-		verbose  bool
+		deps       app.Deps
+		p          project.Project
+		err        error
+		location   string
+		all        bool
+		modified   bool
+		verbose    bool
+		outputPath string
 	)
 
 	cmd := &cobra.Command{
@@ -62,7 +66,7 @@ func NewCmdTest() *cobra.Command {
 		`),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			// Validate flags first
-			if err := validateFlags(args, all, modified); err != nil {
+			if err := validateFlags(args, all, modified, outputPath); err != nil {
 				return err
 			}
 
@@ -135,6 +139,15 @@ func NewCmdTest() *cobra.Command {
 				return fmt.Errorf("running tests: %w", err)
 			}
 
+			resultsDir := outputPath
+			if resultsDir == "" {
+				resultsDir = location
+			}
+
+			if err = writeResultsFile(filepath.Join(resultsDir, "test-results.json"), results); err != nil {
+				return fmt.Errorf("writing results file: %w", err)
+			}
+
 			if results.Status == testorchestrator.RunStatusNoResources {
 				ui.Println("No resources to test")
 				return nil
@@ -155,12 +168,13 @@ func NewCmdTest() *cobra.Command {
 	cmd.Flags().BoolVar(&all, "all", false, "Test all transformations in the project")
 	cmd.Flags().BoolVar(&modified, "modified", false, "Test only new or modified transformations")
 	cmd.Flags().BoolVar(&verbose, "verbose", false, "Show detailed output including diffs for failures")
+	cmd.Flags().StringVar(&outputPath, "output-path", "", "Directory to write test-results.json (default: project directory)")
 
 	return cmd
 }
 
 // validateFlags validates the command flags and arguments
-func validateFlags(args []string, all, modified bool) error {
+func validateFlags(args []string, all, modified bool, outputPath string) error {
 	// Count active modes
 	modes := 0
 	hasID := len(args) > 0
@@ -185,6 +199,32 @@ func validateFlags(args []string, all, modified bool) error {
 	// Only one ID allowed
 	if len(args) > 1 {
 		return fmt.Errorf("only one transformation/library ID allowed, got %d arguments", len(args))
+	}
+
+	if outputPath != "" {
+		info, err := os.Stat(outputPath)
+		if os.IsNotExist(err) {
+			return fmt.Errorf("output-path directory does not exist: %s", outputPath)
+		}
+		if err == nil && !info.IsDir() {
+			return fmt.Errorf("output-path is not a directory: %s", outputPath)
+		}
+	}
+
+	return nil
+}
+
+func writeResultsFile(path string, results *testorchestrator.TestResults) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("creating results file: %w", err)
+	}
+	defer f.Close()
+
+	enc := json.NewEncoder(f)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(results); err != nil {
+		return fmt.Errorf("encoding results: %w", err)
 	}
 
 	return nil

--- a/cli/internal/cmd/transformations/test/test.go
+++ b/cli/internal/cmd/transformations/test/test.go
@@ -220,6 +220,14 @@ func writeResultsFile(dir string, results *testorchestrator.TestResults) error {
 		return fmt.Errorf("creating test-results directory: %w", err)
 	}
 
+	output, outputEntries := results.ToOutput()
+
+	for _, entry := range outputEntries {
+		if err := writeActualOutputFile(resultsDir, entry); err != nil {
+			return fmt.Errorf("writing actual output file: %w", err)
+		}
+	}
+
 	f, err := os.Create(filepath.Join(resultsDir, "results.json"))
 	if err != nil {
 		return fmt.Errorf("creating results file: %w", err)
@@ -228,9 +236,23 @@ func writeResultsFile(dir string, results *testorchestrator.TestResults) error {
 
 	enc := json.NewEncoder(f)
 	enc.SetIndent("", "  ")
-	if err := enc.Encode(results); err != nil {
+	if err := enc.Encode(output); err != nil {
 		return fmt.Errorf("encoding results: %w", err)
 	}
 
 	return nil
+}
+
+func writeActualOutputFile(resultsDir string, entry testorchestrator.ActualOutputEntry) error {
+	fullPath := filepath.Join(resultsDir, entry.RelPath)
+	if err := os.MkdirAll(filepath.Dir(fullPath), 0o755); err != nil {
+		return fmt.Errorf("creating directory for %s: %w", entry.RelPath, err)
+	}
+
+	data, err := json.MarshalIndent(entry.ActualOutput, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling actual output for %s: %w", entry.RelPath, err)
+	}
+
+	return os.WriteFile(fullPath, data, 0o644)
 }

--- a/cli/internal/cmd/transformations/test/test.go
+++ b/cli/internal/cmd/transformations/test/test.go
@@ -31,14 +31,14 @@ var (
 
 func NewCmdTest() *cobra.Command {
 	var (
-		deps       app.Deps
-		p          project.Project
-		err        error
-		location   string
-		all        bool
-		modified   bool
-		verbose    bool
-		outputPath string
+		deps      app.Deps
+		p         project.Project
+		err       error
+		location  string
+		all       bool
+		modified  bool
+		verbose   bool
+		outputDir string
 	)
 
 	cmd := &cobra.Command{
@@ -66,7 +66,7 @@ func NewCmdTest() *cobra.Command {
 		`),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			// Validate flags first
-			if err := validateFlags(args, all, modified, outputPath); err != nil {
+			if err := validateFlags(args, all, modified, outputDir); err != nil {
 				return err
 			}
 
@@ -139,12 +139,12 @@ func NewCmdTest() *cobra.Command {
 				return fmt.Errorf("running tests: %w", err)
 			}
 
-			resultsDir := outputPath
+			resultsDir := outputDir
 			if resultsDir == "" {
 				resultsDir = location
 			}
 
-			if err = writeResultsFile(filepath.Join(resultsDir, "test-results.json"), results); err != nil {
+			if err = writeResultsFile(resultsDir, results); err != nil {
 				return fmt.Errorf("writing results file: %w", err)
 			}
 
@@ -168,13 +168,13 @@ func NewCmdTest() *cobra.Command {
 	cmd.Flags().BoolVar(&all, "all", false, "Test all transformations in the project")
 	cmd.Flags().BoolVar(&modified, "modified", false, "Test only new or modified transformations")
 	cmd.Flags().BoolVar(&verbose, "verbose", false, "Show detailed output including diffs for failures")
-	cmd.Flags().StringVar(&outputPath, "output-path", "", "Directory to write test-results.json (default: project directory)")
+	cmd.Flags().StringVar(&outputDir, "output-dir", "", "Directory to write test-results/results.json (default: project directory)")
 
 	return cmd
 }
 
 // validateFlags validates the command flags and arguments
-func validateFlags(args []string, all, modified bool, outputPath string) error {
+func validateFlags(args []string, all, modified bool, outputDir string) error {
 	// Count active modes
 	modes := 0
 	hasID := len(args) > 0
@@ -201,21 +201,26 @@ func validateFlags(args []string, all, modified bool, outputPath string) error {
 		return fmt.Errorf("only one transformation/library ID allowed, got %d arguments", len(args))
 	}
 
-	if outputPath != "" {
-		info, err := os.Stat(outputPath)
+	if outputDir != "" {
+		info, err := os.Stat(outputDir)
 		if os.IsNotExist(err) {
-			return fmt.Errorf("output-path directory does not exist: %s", outputPath)
+			return fmt.Errorf("output-dir does not exist: %s", outputDir)
 		}
 		if err == nil && !info.IsDir() {
-			return fmt.Errorf("output-path is not a directory: %s", outputPath)
+			return fmt.Errorf("output-dir is not a directory: %s", outputDir)
 		}
 	}
 
 	return nil
 }
 
-func writeResultsFile(path string, results *testorchestrator.TestResults) error {
-	f, err := os.Create(path)
+func writeResultsFile(dir string, results *testorchestrator.TestResults) error {
+	resultsDir := filepath.Join(dir, "test-results")
+	if err := os.MkdirAll(resultsDir, 0o755); err != nil {
+		return fmt.Errorf("creating test-results directory: %w", err)
+	}
+
+	f, err := os.Create(filepath.Join(resultsDir, "results.json"))
 	if err != nil {
 		return fmt.Errorf("creating results file: %w", err)
 	}

--- a/cli/internal/cmd/transformations/test/test_test.go
+++ b/cli/internal/cmd/transformations/test/test_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	transformations "github.com/rudderlabs/rudder-iac/api/client/transformations"
 	"github.com/rudderlabs/rudder-iac/cli/internal/providers/transformations/testorchestrator"
 )
 
@@ -147,19 +148,37 @@ func TestValidateFlags(t *testing.T) {
 }
 
 func TestWriteResultsFile(t *testing.T) {
-	t.Run("writes JSON to test-results/results.json", func(t *testing.T) {
+	t.Run("writes JSON to test-results/results.json with flattened structure", func(t *testing.T) {
 		dir := t.TempDir()
 
-		results := &testorchestrator.TestResults{Status: testorchestrator.RunStatusExecuted}
+		results := &testorchestrator.TestResults{
+			Status: testorchestrator.RunStatusExecuted,
+			Transformations: []*testorchestrator.TransformationTestWithDefinitions{
+				{
+					Result: &transformations.TransformationTestResult{
+						ID:        "tr-1",
+						Name:      "My Transform",
+						VersionID: "v-1",
+						Pass:      true,
+						TestSuiteResult: transformations.TestSuiteRunResult{
+							Status: transformations.TestRunStatusPass,
+						},
+					},
+				},
+			},
+		}
 		err := writeResultsFile(dir, results)
 		require.NoError(t, err)
 
 		data, err := os.ReadFile(filepath.Join(dir, "test-results", "results.json"))
 		require.NoError(t, err)
 
-		var got testorchestrator.TestResults
+		var got testorchestrator.TestResultsOutput
 		require.NoError(t, json.Unmarshal(data, &got))
 		assert.Equal(t, testorchestrator.RunStatusExecuted, got.Status)
+		require.Len(t, got.Transformations, 1)
+		assert.Equal(t, "tr-1", got.Transformations[0].ID)
+		assert.Equal(t, "v-1", got.Transformations[0].VersionID)
 	})
 
 	t.Run("creates test-results dir if not exists", func(t *testing.T) {
@@ -185,7 +204,7 @@ func TestWriteResultsFile(t *testing.T) {
 		data, err := os.ReadFile(filepath.Join(dir, "test-results", "results.json"))
 		require.NoError(t, err)
 
-		var got testorchestrator.TestResults
+		var got testorchestrator.TestResultsOutput
 		require.NoError(t, json.Unmarshal(data, &got))
 		assert.Equal(t, testorchestrator.RunStatusNoResources, got.Status)
 	})
@@ -194,5 +213,102 @@ func TestWriteResultsFile(t *testing.T) {
 		err := writeResultsFile("/nonexistent/dir", &testorchestrator.TestResults{})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "creating test-results directory")
+	})
+
+	t.Run("writes actual output files and references them in results.json", func(t *testing.T) {
+		dir := t.TempDir()
+
+		results := &testorchestrator.TestResults{
+			Status: testorchestrator.RunStatusExecuted,
+			Transformations: []*testorchestrator.TransformationTestWithDefinitions{
+				{
+					Result: &transformations.TransformationTestResult{
+						ID:   "tr-1",
+						Name: "My Transform",
+						Pass: true,
+						TestSuiteResult: transformations.TestSuiteRunResult{
+							Status: transformations.TestRunStatusPass,
+							Results: []transformations.TestResult{
+								{
+									ID:           "suite/input/event.json",
+									Name:         "suite",
+									Status:       transformations.TestRunStatusPass,
+									ActualOutput: []any{map[string]any{"key": "value"}},
+								},
+							},
+						},
+					},
+					Definitions: []*transformations.TestDefinition{
+						{
+							ID:        "suite/input/event.json",
+							Filename:  "event.json",
+							InputFile: "input/event.json",
+						},
+					},
+				},
+			},
+		}
+		err := writeResultsFile(dir, results)
+		require.NoError(t, err)
+
+		// Verify actual output file exists with correct content
+		actualOutputPath := filepath.Join(dir, "test-results", "My Transform", "suite", "event.json")
+		actualData, err := os.ReadFile(actualOutputPath)
+		require.NoError(t, err)
+
+		var actualOutput []any
+		require.NoError(t, json.Unmarshal(actualData, &actualOutput))
+		require.Len(t, actualOutput, 1)
+		assert.Equal(t, "value", actualOutput[0].(map[string]any)["key"])
+
+		// Verify results.json references the file
+		resultsData, err := os.ReadFile(filepath.Join(dir, "test-results", "results.json"))
+		require.NoError(t, err)
+
+		var got testorchestrator.TestResultsOutput
+		require.NoError(t, json.Unmarshal(resultsData, &got))
+
+		testResult := got.Transformations[0].TestSuiteResult.Results[0]
+		assert.Equal(t, "My Transform/suite/event.json", testResult.ActualOutputFile)
+		assert.Equal(t, "input/event.json", testResult.InputLocation)
+	})
+
+	t.Run("writes default_events.json for default-events tests", func(t *testing.T) {
+		dir := t.TempDir()
+
+		results := &testorchestrator.TestResults{
+			Status: testorchestrator.RunStatusExecuted,
+			Transformations: []*testorchestrator.TransformationTestWithDefinitions{
+				{
+					Result: &transformations.TransformationTestResult{
+						Name: "Transform",
+						TestSuiteResult: transformations.TestSuiteRunResult{
+							Status: transformations.TestRunStatusPass,
+							Results: []transformations.TestResult{
+								{
+									ID:           "default-events",
+									Name:         "default-events",
+									Status:       transformations.TestRunStatusPass,
+									ActualOutput: []any{map[string]any{"event": "data"}},
+								},
+							},
+						},
+					},
+					Definitions: []*transformations.TestDefinition{
+						{
+							ID:       "default-events",
+							Name:     "default-events",
+							Filename: "default_events.json",
+						},
+					},
+				},
+			},
+		}
+		err := writeResultsFile(dir, results)
+		require.NoError(t, err)
+
+		actualOutputPath := filepath.Join(dir, "test-results", "Transform", "default-events", "default_events.json")
+		_, err = os.Stat(actualOutputPath)
+		require.NoError(t, err)
 	})
 }

--- a/cli/internal/cmd/transformations/test/test_test.go
+++ b/cli/internal/cmd/transformations/test/test_test.go
@@ -1,10 +1,15 @@
 package test
 
 import (
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/transformations/testorchestrator"
 )
 
 func TestValidateFlags(t *testing.T) {
@@ -15,6 +20,7 @@ func TestValidateFlags(t *testing.T) {
 		args          []string
 		all           bool
 		modified      bool
+		outputPath    string
 		expectedError bool
 		errorContains string
 	}{
@@ -38,6 +44,14 @@ func TestValidateFlags(t *testing.T) {
 			args:          []string{},
 			all:           false,
 			modified:      true,
+			expectedError: false,
+		},
+		{
+			name:          "valid --output-path with existing dir",
+			args:          []string{},
+			all:           true,
+			modified:      false,
+			outputPath:    os.TempDir(),
 			expectedError: false,
 		},
 
@@ -90,14 +104,39 @@ func TestValidateFlags(t *testing.T) {
 			expectedError: true,
 			errorContains: "must specify either an ID, --all, or --modified",
 		},
+		{
+			name:          "invalid --output-path with non-existent dir",
+			args:          []string{},
+			all:           true,
+			modified:      false,
+			outputPath:    "/nonexistent/dir",
+			expectedError: true,
+			errorContains: "output-path directory does not exist",
+		},
+		{
+			name:          "invalid --output-path pointing to a file",
+			args:          []string{},
+			all:           true,
+			modified:      false,
+			outputPath:    filepath.Join(os.TempDir(), "not-a-dir.json"),
+			expectedError: true,
+			errorContains: "output-path is not a directory",
+		},
 	}
+
+	// Create a file in TempDir for the "not a directory" case
+	notADir := filepath.Join(os.TempDir(), "not-a-dir.json")
+	f, err := os.Create(notADir)
+	require.NoError(t, err)
+	f.Close()
+	t.Cleanup(func() { os.Remove(notADir) })
 
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			err := validateFlags(tt.args, tt.all, tt.modified)
+			err := validateFlags(tt.args, tt.all, tt.modified, tt.outputPath)
 
 			if tt.expectedError {
 				require.Error(t, err)
@@ -107,4 +146,28 @@ func TestValidateFlags(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestWriteResultsFile(t *testing.T) {
+	t.Run("writes JSON to the given path", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "test-results.json")
+
+		results := &testorchestrator.TestResults{Status: testorchestrator.RunStatusExecuted}
+		err := writeResultsFile(path, results)
+		require.NoError(t, err)
+
+		data, err := os.ReadFile(path)
+		require.NoError(t, err)
+
+		var got testorchestrator.TestResults
+		require.NoError(t, json.Unmarshal(data, &got))
+		assert.Equal(t, testorchestrator.RunStatusExecuted, got.Status)
+	})
+
+	t.Run("returns error when path is not writable", func(t *testing.T) {
+		err := writeResultsFile("/nonexistent/dir/out.json", &testorchestrator.TestResults{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "creating results file")
+	})
 }

--- a/cli/internal/cmd/transformations/test/test_test.go
+++ b/cli/internal/cmd/transformations/test/test_test.go
@@ -26,7 +26,7 @@ func TestValidateFlags(t *testing.T) {
 		args          []string
 		all           bool
 		modified      bool
-		outputPath    string
+		outputDir     string
 		expectedError bool
 		errorContains string
 	}{
@@ -53,11 +53,11 @@ func TestValidateFlags(t *testing.T) {
 			expectedError: false,
 		},
 		{
-			name:          "valid --output-path with existing dir",
+			name:          "valid --output-dir with existing dir",
 			args:          []string{},
 			all:           true,
 			modified:      false,
-			outputPath:    t.TempDir(),
+			outputDir:     t.TempDir(),
 			expectedError: false,
 		},
 
@@ -111,22 +111,22 @@ func TestValidateFlags(t *testing.T) {
 			errorContains: "must specify either an ID, --all, or --modified",
 		},
 		{
-			name:          "invalid --output-path with non-existent dir",
+			name:          "invalid --output-dir with non-existent dir",
 			args:          []string{},
 			all:           true,
 			modified:      false,
-			outputPath:    "/nonexistent/dir",
+			outputDir:     "/nonexistent/dir",
 			expectedError: true,
-			errorContains: "output-path directory does not exist",
+			errorContains: "output-dir does not exist",
 		},
 		{
-			name:          "invalid --output-path pointing to a file",
+			name:          "invalid --output-dir pointing to a file",
 			args:          []string{},
 			all:           true,
 			modified:      false,
-			outputPath:    notADir,
+			outputDir:     notADir,
 			expectedError: true,
-			errorContains: "output-path is not a directory",
+			errorContains: "output-dir is not a directory",
 		},
 	}
 
@@ -134,7 +134,7 @@ func TestValidateFlags(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			err := validateFlags(tt.args, tt.all, tt.modified, tt.outputPath)
+			err := validateFlags(tt.args, tt.all, tt.modified, tt.outputDir)
 
 			if tt.expectedError {
 				require.Error(t, err)
@@ -147,15 +147,14 @@ func TestValidateFlags(t *testing.T) {
 }
 
 func TestWriteResultsFile(t *testing.T) {
-	t.Run("writes JSON to the given path", func(t *testing.T) {
+	t.Run("writes JSON to test-results/results.json", func(t *testing.T) {
 		dir := t.TempDir()
-		path := filepath.Join(dir, "test-results.json")
 
 		results := &testorchestrator.TestResults{Status: testorchestrator.RunStatusExecuted}
-		err := writeResultsFile(path, results)
+		err := writeResultsFile(dir, results)
 		require.NoError(t, err)
 
-		data, err := os.ReadFile(path)
+		data, err := os.ReadFile(filepath.Join(dir, "test-results", "results.json"))
 		require.NoError(t, err)
 
 		var got testorchestrator.TestResults
@@ -163,9 +162,37 @@ func TestWriteResultsFile(t *testing.T) {
 		assert.Equal(t, testorchestrator.RunStatusExecuted, got.Status)
 	})
 
-	t.Run("returns error when path is not writable", func(t *testing.T) {
-		err := writeResultsFile("/nonexistent/dir/out.json", &testorchestrator.TestResults{})
+	t.Run("creates test-results dir if not exists", func(t *testing.T) {
+		dir := t.TempDir()
+
+		err := writeResultsFile(dir, &testorchestrator.TestResults{Status: testorchestrator.RunStatusExecuted})
+		require.NoError(t, err)
+
+		info, err := os.Stat(filepath.Join(dir, "test-results"))
+		require.NoError(t, err)
+		assert.True(t, info.IsDir())
+	})
+
+	t.Run("silently overwrites existing results.json", func(t *testing.T) {
+		dir := t.TempDir()
+
+		first := &testorchestrator.TestResults{Status: testorchestrator.RunStatusExecuted}
+		require.NoError(t, writeResultsFile(dir, first))
+
+		second := &testorchestrator.TestResults{Status: testorchestrator.RunStatusNoResources}
+		require.NoError(t, writeResultsFile(dir, second))
+
+		data, err := os.ReadFile(filepath.Join(dir, "test-results", "results.json"))
+		require.NoError(t, err)
+
+		var got testorchestrator.TestResults
+		require.NoError(t, json.Unmarshal(data, &got))
+		assert.Equal(t, testorchestrator.RunStatusNoResources, got.Status)
+	})
+
+	t.Run("returns error when dir is not writable", func(t *testing.T) {
+		err := writeResultsFile("/nonexistent/dir", &testorchestrator.TestResults{})
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "creating results file")
+		assert.Contains(t, err.Error(), "creating test-results directory")
 	})
 }

--- a/cli/internal/cmd/transformations/test/test_test.go
+++ b/cli/internal/cmd/transformations/test/test_test.go
@@ -15,6 +15,12 @@ import (
 func TestValidateFlags(t *testing.T) {
 	t.Parallel()
 
+	// Create a file for the "not a directory" case; t.TempDir() cleans up automatically.
+	notADir := filepath.Join(t.TempDir(), "not-a-dir.json")
+	f, err := os.Create(notADir)
+	require.NoError(t, err)
+	f.Close()
+
 	tests := []struct {
 		name          string
 		args          []string
@@ -51,7 +57,7 @@ func TestValidateFlags(t *testing.T) {
 			args:          []string{},
 			all:           true,
 			modified:      false,
-			outputPath:    os.TempDir(),
+			outputPath:    t.TempDir(),
 			expectedError: false,
 		},
 
@@ -118,21 +124,13 @@ func TestValidateFlags(t *testing.T) {
 			args:          []string{},
 			all:           true,
 			modified:      false,
-			outputPath:    filepath.Join(os.TempDir(), "not-a-dir.json"),
+			outputPath:    notADir,
 			expectedError: true,
 			errorContains: "output-path is not a directory",
 		},
 	}
 
-	// Create a file in TempDir for the "not a directory" case
-	notADir := filepath.Join(os.TempDir(), "not-a-dir.json")
-	f, err := os.Create(notADir)
-	require.NoError(t, err)
-	f.Close()
-	t.Cleanup(func() { os.Remove(notADir) })
-
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/cli/internal/providers/transformations/display/result_displayer.go
+++ b/cli/internal/providers/transformations/display/result_displayer.go
@@ -359,10 +359,12 @@ func (rd *ResultDisplayer) displayTestResult(
 	testResult transformations.TestResult,
 	def transformations.TestDefinition,
 ) {
+	displayName := testDisplayName(testResult.Name, def.Filename)
+
 	switch testResult.Status {
 	case transformations.TestRunStatusPass:
 		printWithPadding(
-			fmt.Sprintf("  %s %s", ui.Color(symbolPass, ui.ColorGreen), testResult.Name),
+			fmt.Sprintf("  %s %s", ui.Color(symbolPass, ui.ColorGreen), displayName),
 			testStatusPassed,
 			statusColumn,
 		)
@@ -370,7 +372,7 @@ func (rd *ResultDisplayer) displayTestResult(
 
 	case transformations.TestRunStatusFail:
 		printWithPadding(
-			fmt.Sprintf("  %s %s", ui.Color(symbolMismatch, ui.ColorYellow), testResult.Name),
+			fmt.Sprintf("  %s %s", ui.Color(symbolMismatch, ui.ColorYellow), displayName),
 			testStatusMismatch,
 			statusColumn,
 		)
@@ -378,7 +380,7 @@ func (rd *ResultDisplayer) displayTestResult(
 
 		rd.suiteCounter.failures = append(rd.suiteCounter.failures, failureDetail{
 			transformationName: transformationName,
-			testName:           testResult.Name,
+			testName:           displayName,
 			inputFile:          def.InputFile,
 			outputFile:         def.OutputFile,
 			status:             testResult.Status,
@@ -389,7 +391,7 @@ func (rd *ResultDisplayer) displayTestResult(
 
 	case transformations.TestRunStatusError:
 		printWithPadding(
-			fmt.Sprintf("  %s %s", ui.Color(symbolError, ui.ColorRed), testResult.Name),
+			fmt.Sprintf("  %s %s", ui.Color(symbolError, ui.ColorRed), displayName),
 			testStatusError,
 			statusColumn,
 		)
@@ -397,13 +399,22 @@ func (rd *ResultDisplayer) displayTestResult(
 
 		rd.suiteCounter.failures = append(rd.suiteCounter.failures, failureDetail{
 			transformationName: transformationName,
-			testName:           testResult.Name,
+			testName:           displayName,
 			inputFile:          def.InputFile,
 			outputFile:         def.OutputFile,
 			status:             testResult.Status,
 			errors:             testResult.Errors,
 		})
 	}
+}
+
+// testDisplayName builds a display-friendly name by combining the test name with
+// the filename when available. Returns "name (filename)" or just "name".
+func testDisplayName(name, filename string) string {
+	if filename == "" {
+		return name
+	}
+	return fmt.Sprintf("%s (%s)", name, filename)
 }
 
 func (rd *ResultDisplayer) printSuiteFailures() {

--- a/cli/internal/providers/transformations/display/result_displayer_test.go
+++ b/cli/internal/providers/transformations/display/result_displayer_test.go
@@ -325,7 +325,8 @@ func TestResultDisplayer_Display_WithMismatchFailures_ShowsFilePaths(t *testing.
 	testDefinitions := []*transformations.TestDefinition{
 		{
 			ID:             "suite/inputs/event.json",
-			Name:           "suite (event.json)",
+			Name:           "suite",
+			Filename:       "event.json",
 			InputFile:      "inputs/event.json",
 			OutputFile:     "outputs/event.json",
 			ExpectedOutput: []any{map[string]any{"status": "success"}},
@@ -341,7 +342,7 @@ func TestResultDisplayer_Display_WithMismatchFailures_ShowsFilePaths(t *testing.
 						Results: []transformations.TestResult{
 							{
 								ID:           "suite/inputs/event.json",
-								Name:         "suite (event.json)",
+								Name:         "suite",
 								Status:       transformations.TestRunStatusFail,
 								ActualOutput: []any{map[string]any{"status": "failed"}},
 							},
@@ -356,6 +357,7 @@ func TestResultDisplayer_Display_WithMismatchFailures_ShowsFilePaths(t *testing.
 	displayer.Display(results)
 
 	output := buf.String()
+	assert.Contains(t, output, "suite (event.json)")
 	assert.Contains(t, output, "inputs/event.json")
 	assert.Contains(t, output, "outputs/event.json")
 }

--- a/cli/internal/providers/transformations/testorchestrator/inputs.go
+++ b/cli/internal/providers/transformations/testorchestrator/inputs.go
@@ -86,7 +86,8 @@ func buildTestDefinitionsForSuite(suite specs.TransformationTest) ([]*transforma
 
 		testDef := &transformations.TestDefinition{
 			ID:             fmt.Sprintf("%s/%s/%s", suite.Name, suite.Input, filename),
-			Name:           fmt.Sprintf("%s (%s)", suite.Name, filename),
+			Name:           suite.Name,
+			Filename:       filename,
 			InputFile:      filepath.Join(suite.Input, filename),
 			OutputFile:     outputFile,
 			Input:          inputEvents,
@@ -109,6 +110,7 @@ func defaultTestDefinitions() ([]*transformations.TestDefinition, error) {
 	testDef := &transformations.TestDefinition{
 		ID:             "default-events",
 		Name:           "default-events",
+		Filename:       defaultEventsOutputFilename,
 		Input:          allEvents,
 		ExpectedOutput: nil,
 	}

--- a/cli/internal/providers/transformations/testorchestrator/inputs_test.go
+++ b/cli/internal/providers/transformations/testorchestrator/inputs_test.go
@@ -26,6 +26,7 @@ func TestResolveTestDefinitions(t *testing.T) {
 		require.Len(t, result, 1)
 		assert.Equal(t, "default-events", result[0].ID)
 		assert.Equal(t, "default-events", result[0].Name)
+		assert.Equal(t, defaultEventsOutputFilename, result[0].Filename)
 		assert.NotEmpty(t, result[0].Input)
 		assert.Nil(t, result[0].ExpectedOutput)
 		assert.Empty(t, result[0].InputFile)
@@ -52,6 +53,7 @@ func TestResolveTestDefinitions(t *testing.T) {
 		require.Len(t, result, 1)
 		assert.Equal(t, "default-events", result[0].ID)
 		assert.Equal(t, "default-events", result[0].Name)
+		assert.Equal(t, defaultEventsOutputFilename, result[0].Filename)
 	})
 
 	t.Run("suite with input files only", func(t *testing.T) {
@@ -80,7 +82,8 @@ func TestResolveTestDefinitions(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, result, 1)
 		assert.Equal(t, fmt.Sprintf("My Suite/%s/event.json", inputDir), result[0].ID)
-		assert.Equal(t, "My Suite (event.json)", result[0].Name)
+		assert.Equal(t, "My Suite", result[0].Name)
+		assert.Equal(t, "event.json", result[0].Filename)
 		assert.Equal(t, filepath.Join(inputDir, "event.json"), result[0].InputFile)
 		assert.Empty(t, result[0].OutputFile)
 		require.Len(t, result[0].Input, 1)
@@ -122,7 +125,8 @@ func TestResolveTestDefinitions(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, result, 1)
 		assert.Equal(t, fmt.Sprintf("Suite/%s/event.json", inputDir), result[0].ID)
-		assert.Equal(t, "Suite (event.json)", result[0].Name)
+		assert.Equal(t, "Suite", result[0].Name)
+		assert.Equal(t, "event.json", result[0].Filename)
 		assert.Equal(t, filepath.Join(inputDir, "event.json"), result[0].InputFile)
 		assert.Equal(t, filepath.Join(outputDir, "event.json"), result[0].OutputFile)
 		assert.NotNil(t, result[0].ExpectedOutput)
@@ -152,8 +156,12 @@ func TestResolveTestDefinitions(t *testing.T) {
 		require.Len(t, result, 2)
 
 		names := []string{result[0].Name, result[1].Name}
-		assert.Contains(t, names, "Suite One (a.json)")
-		assert.Contains(t, names, "Suite Two (b.json)")
+		assert.Contains(t, names, "Suite One")
+		assert.Contains(t, names, "Suite Two")
+
+		filenames := []string{result[0].Filename, result[1].Filename}
+		assert.Contains(t, filenames, "a.json")
+		assert.Contains(t, filenames, "b.json")
 
 		ids := []string{result[0].ID, result[1].ID}
 		assert.Contains(t, ids, fmt.Sprintf("Suite One/%s/a.json", suite1))

--- a/cli/internal/providers/transformations/testorchestrator/test_results.go
+++ b/cli/internal/providers/transformations/testorchestrator/test_results.go
@@ -21,7 +21,7 @@ type TransformationTestWithDefinitions struct {
 
 // TestResults contains the results of all test executions with their definitions
 type TestResults struct {
-	Status          RunStatus                             `json:"status"`
+	Status          RunStatus                            `json:"status"`
 	Libraries       []transformations.LibraryTestResult  `json:"libraries,omitempty"`
 	Transformations []*TransformationTestWithDefinitions `json:"transformations,omitempty"`
 }

--- a/cli/internal/providers/transformations/testorchestrator/test_results.go
+++ b/cli/internal/providers/transformations/testorchestrator/test_results.go
@@ -6,24 +6,24 @@ import (
 	transformations "github.com/rudderlabs/rudder-iac/api/client/transformations"
 )
 
-type RunStatus int
+type RunStatus string
 
 const (
-	RunStatusExecuted RunStatus = iota
-	RunStatusNoResources
+	RunStatusExecuted    RunStatus = "executed"
+	RunStatusNoResources RunStatus = "no_resources"
 )
 
 // TransformationTestWithDefinitions combines test results with their original definitions
 type TransformationTestWithDefinitions struct {
-	Result      *transformations.TransformationTestResult
-	Definitions []*transformations.TestDefinition
+	Result      *transformations.TransformationTestResult `json:"result"`
+	Definitions []*transformations.TestDefinition         `json:"-"`
 }
 
 // TestResults contains the results of all test executions with their definitions
 type TestResults struct {
-	Status          RunStatus
-	Libraries       []transformations.LibraryTestResult
-	Transformations []*TransformationTestWithDefinitions
+	Status          RunStatus                             `json:"status"`
+	Libraries       []transformations.LibraryTestResult  `json:"libraries,omitempty"`
+	Transformations []*TransformationTestWithDefinitions `json:"transformations,omitempty"`
 }
 
 // HasFailures computes whether any tests failed or errored

--- a/cli/internal/providers/transformations/testorchestrator/test_results_output.go
+++ b/cli/internal/providers/transformations/testorchestrator/test_results_output.go
@@ -1,0 +1,143 @@
+package testorchestrator
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/samber/lo"
+
+	transformations "github.com/rudderlabs/rudder-iac/api/client/transformations"
+)
+
+const defaultEventsOutputFilename = "default_events.json"
+
+// TestResultsOutput is the serialization struct for results.json.
+type TestResultsOutput struct {
+	Status          RunStatus                           `json:"status"`
+	Libraries       []transformations.LibraryTestResult `json:"libraries,omitempty"`
+	Transformations []TransformationTestOutput          `json:"transformations,omitempty"`
+}
+
+type TransformationTestOutput struct {
+	ID              string                `json:"id"`
+	Name            string                `json:"name"`
+	VersionID       string                `json:"versionId"`
+	Imports         []string              `json:"imports,omitempty"`
+	Pass            bool                  `json:"pass"`
+	TestSuiteResult TestSuiteResultOutput `json:"testResult"`
+	Message         string                `json:"message,omitempty"`
+}
+
+type TestSuiteResultOutput struct {
+	Status  transformations.TestRunStatus `json:"status"`
+	Results []TestResultOutput            `json:"results"`
+}
+
+// TestResultOutput replaces TestResult for JSON output.
+// Adds inputLocation/outputLocation, replaces actualOutput with actualOutputFile.
+type TestResultOutput struct {
+	ID               string                        `json:"id"`
+	Name             string                        `json:"name"`
+	Description      string                        `json:"description,omitempty"`
+	Status           transformations.TestRunStatus `json:"status"`
+	InputLocation    string                        `json:"inputLocation,omitempty"`
+	OutputLocation   string                        `json:"outputLocation,omitempty"`
+	ActualOutputFile string                        `json:"actualOutputFile,omitempty"`
+	Errors           []transformations.TestError   `json:"errors,omitempty"`
+}
+
+// ActualOutputEntry pairs a relative file path (under test-results/) with actual output data
+// to be written as a separate JSON file.
+type ActualOutputEntry struct {
+	RelPath      string
+	ActualOutput []any
+}
+
+// ToOutput converts TestResults into the serialization-ready TestResultsOutput,
+// also returning actual output entries to be written as separate files.
+func (r *TestResults) ToOutput() (*TestResultsOutput, []ActualOutputEntry) {
+	var (
+		trOutputs     []TransformationTestOutput
+		outputEntries []ActualOutputEntry
+	)
+
+	for _, tr := range r.Transformations {
+		trOut, entries := buildTransformationOutput(tr)
+		trOutputs = append(trOutputs, trOut)
+		outputEntries = append(outputEntries, entries...)
+	}
+
+	return &TestResultsOutput{
+		Status:          r.Status,
+		Libraries:       r.Libraries,
+		Transformations: trOutputs,
+	}, outputEntries
+}
+
+func buildTransformationOutput(tr *TransformationTestWithDefinitions) (TransformationTestOutput, []ActualOutputEntry) {
+	result := tr.Result
+	defsByID := lo.SliceToMap(tr.Definitions, func(def *transformations.TestDefinition) (string, *transformations.TestDefinition) {
+		return def.ID, def
+	})
+
+	var (
+		resultOutputs []TestResultOutput
+		entries       []ActualOutputEntry
+	)
+
+	for _, testResult := range result.TestSuiteResult.Results {
+		def := defsByID[testResult.ID]
+
+		var inputLocation, outputLocation, actualOutputFile string
+		if def != nil {
+			inputLocation = def.InputFile
+			outputLocation = def.OutputFile
+
+			if len(testResult.ActualOutput) > 0 {
+				actualOutputFile = filepath.Join(
+					sanitizePath(result.Name),
+					sanitizePath(testResult.Name),
+					def.Filename,
+				)
+				entries = append(entries, ActualOutputEntry{
+					RelPath:      actualOutputFile,
+					ActualOutput: testResult.ActualOutput,
+				})
+			}
+		}
+
+		resultOutputs = append(resultOutputs, TestResultOutput{
+			ID:               testResult.ID,
+			Name:             testResult.Name,
+			Description:      testResult.Description,
+			Status:           testResult.Status,
+			InputLocation:    inputLocation,
+			OutputLocation:   outputLocation,
+			ActualOutputFile: actualOutputFile,
+			Errors:           testResult.Errors,
+		})
+	}
+
+	return TransformationTestOutput{
+		ID:        result.ID,
+		Name:      result.Name,
+		VersionID: result.VersionID,
+		Imports:   result.Imports,
+		Pass:      result.Pass,
+		TestSuiteResult: TestSuiteResultOutput{
+			Status:  result.TestSuiteResult.Status,
+			Results: resultOutputs,
+		},
+		Message: result.Message,
+	}, entries
+}
+
+// sanitizePath replaces filesystem-unsafe characters with underscores.
+func sanitizePath(s string) string {
+	replacer := strings.NewReplacer(
+		"/", "_", "\\", "_", ":", "_",
+		"*", "_", "?", "_", "\"", "_",
+		"<", "_", ">", "_", "|", "_",
+	)
+	return strings.TrimSpace(replacer.Replace(s))
+}

--- a/cli/internal/providers/transformations/testorchestrator/test_results_output_test.go
+++ b/cli/internal/providers/transformations/testorchestrator/test_results_output_test.go
@@ -1,0 +1,322 @@
+package testorchestrator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	transformations "github.com/rudderlabs/rudder-iac/api/client/transformations"
+)
+
+func TestToOutput(t *testing.T) {
+	t.Run("flattens result wrapper in transformation output", func(t *testing.T) {
+		results := &TestResults{
+			Status: RunStatusExecuted,
+			Transformations: []*TransformationTestWithDefinitions{
+				{
+					Result: &transformations.TransformationTestResult{
+						ID:        "tr-1",
+						Name:      "My Transform",
+						VersionID: "v-1",
+						Imports:   []string{"libA"},
+						Pass:      true,
+						TestSuiteResult: transformations.TestSuiteRunResult{
+							Status: transformations.TestRunStatusPass,
+						},
+					},
+				},
+			},
+		}
+
+		output, _ := results.ToOutput()
+
+		require.Len(t, output.Transformations, 1)
+		assert.Equal(t, TransformationTestOutput{
+			ID:        "tr-1",
+			Name:      "My Transform",
+			VersionID: "v-1",
+			Imports:   []string{"libA"},
+			Pass:      true,
+			TestSuiteResult: TestSuiteResultOutput{
+				Status: transformations.TestRunStatusPass,
+			},
+		}, output.Transformations[0])
+	})
+
+	t.Run("maps input and output location from definitions", func(t *testing.T) {
+		results := &TestResults{
+			Status: RunStatusExecuted,
+			Transformations: []*TransformationTestWithDefinitions{
+				{
+					Result: &transformations.TransformationTestResult{
+						Name: "Transform",
+						TestSuiteResult: transformations.TestSuiteRunResult{
+							Status: transformations.TestRunStatusFail,
+							Results: []transformations.TestResult{
+								{
+									ID:     "suite/input/event.json",
+									Name:   "suite (event.json)",
+									Status: transformations.TestRunStatusFail,
+								},
+							},
+						},
+					},
+					Definitions: []*transformations.TestDefinition{
+						{
+							ID:         "suite/input/event.json",
+							Name:       "suite (event.json)",
+							Filename:   "event.json",
+							InputFile:  "input/event.json",
+							OutputFile: "output/event.json",
+						},
+					},
+				},
+			},
+		}
+
+		output, _ := results.ToOutput()
+
+		result := output.Transformations[0].TestSuiteResult.Results[0]
+		assert.Equal(t, "input/event.json", result.InputLocation)
+		assert.Equal(t, "output/event.json", result.OutputLocation)
+	})
+
+	t.Run("omits locations when no definition matches", func(t *testing.T) {
+		results := &TestResults{
+			Status: RunStatusExecuted,
+			Transformations: []*TransformationTestWithDefinitions{
+				{
+					Result: &transformations.TransformationTestResult{
+						Name: "Remote Transform",
+						TestSuiteResult: transformations.TestSuiteRunResult{
+							Status: transformations.TestRunStatusPass,
+							Results: []transformations.TestResult{
+								{
+									ID:     "unknown-test",
+									Name:   "unknown-test",
+									Status: transformations.TestRunStatusPass,
+								},
+							},
+						},
+					},
+					// No definitions — standalone library transformation result
+				},
+			},
+		}
+
+		output, entries := results.ToOutput()
+
+		result := output.Transformations[0].TestSuiteResult.Results[0]
+		assert.Empty(t, result.InputLocation)
+		assert.Empty(t, result.OutputLocation)
+		assert.Empty(t, result.ActualOutputFile)
+		assert.Empty(t, entries)
+	})
+
+	t.Run("replaces actualOutput with file path reference", func(t *testing.T) {
+		results := &TestResults{
+			Status: RunStatusExecuted,
+			Transformations: []*TransformationTestWithDefinitions{
+				{
+					Result: &transformations.TransformationTestResult{
+						Name: "My Transform",
+						TestSuiteResult: transformations.TestSuiteRunResult{
+							Status: transformations.TestRunStatusPass,
+							Results: []transformations.TestResult{
+								{
+									ID:           "suite/input/event.json",
+									Name:         "suite (event.json)",
+									Status:       transformations.TestRunStatusPass,
+									ActualOutput: []any{map[string]any{"key": "value"}},
+								},
+							},
+						},
+					},
+					Definitions: []*transformations.TestDefinition{
+						{
+							ID:        "suite/input/event.json",
+							Filename:  "event.json",
+							InputFile: "input/event.json",
+						},
+					},
+				},
+			},
+		}
+
+		output, entries := results.ToOutput()
+
+		result := output.Transformations[0].TestSuiteResult.Results[0]
+		assert.Equal(t, "My Transform/suite (event.json)/event.json", result.ActualOutputFile)
+		assert.Nil(t, result.Errors)
+
+		require.Len(t, entries, 1)
+		assert.Equal(t, "My Transform/suite (event.json)/event.json", entries[0].RelPath)
+		assert.Equal(t, []any{map[string]any{"key": "value"}}, entries[0].ActualOutput)
+	})
+
+	t.Run("uses default_events.json for default-events tests", func(t *testing.T) {
+		results := &TestResults{
+			Status: RunStatusExecuted,
+			Transformations: []*TransformationTestWithDefinitions{
+				{
+					Result: &transformations.TransformationTestResult{
+						Name: "My Transform",
+						TestSuiteResult: transformations.TestSuiteRunResult{
+							Status: transformations.TestRunStatusPass,
+							Results: []transformations.TestResult{
+								{
+									ID:           "default-events",
+									Name:         "default-events",
+									Status:       transformations.TestRunStatusPass,
+									ActualOutput: []any{map[string]any{"event": "data"}},
+								},
+							},
+						},
+					},
+					Definitions: []*transformations.TestDefinition{
+						{
+							ID:       "default-events",
+							Name:     "default-events",
+							Filename: "default_events.json",
+						},
+					},
+				},
+			},
+		}
+
+		output, entries := results.ToOutput()
+
+		result := output.Transformations[0].TestSuiteResult.Results[0]
+		assert.Equal(t, "My Transform/default-events/default_events.json", result.ActualOutputFile)
+		assert.Empty(t, result.InputLocation)
+		assert.Empty(t, result.OutputLocation)
+
+		require.Len(t, entries, 1)
+		assert.Equal(t, "My Transform/default-events/default_events.json", entries[0].RelPath)
+	})
+
+	t.Run("skips actual output entries when actualOutput is empty", func(t *testing.T) {
+		results := &TestResults{
+			Status: RunStatusExecuted,
+			Transformations: []*TransformationTestWithDefinitions{
+				{
+					Result: &transformations.TransformationTestResult{
+						Name: "Transform",
+						TestSuiteResult: transformations.TestSuiteRunResult{
+							Status: transformations.TestRunStatusError,
+							Results: []transformations.TestResult{
+								{
+									ID:     "suite/input/event.json",
+									Name:   "suite (event.json)",
+									Status: transformations.TestRunStatusError,
+									Errors: []transformations.TestError{{Message: "some error"}},
+								},
+							},
+						},
+					},
+					Definitions: []*transformations.TestDefinition{
+						{
+							ID:        "suite/input/event.json",
+							Filename:  "event.json",
+							InputFile: "input/event.json",
+						},
+					},
+				},
+			},
+		}
+
+		output, entries := results.ToOutput()
+
+		result := output.Transformations[0].TestSuiteResult.Results[0]
+		assert.Empty(t, result.ActualOutputFile)
+		assert.Equal(t, "input/event.json", result.InputLocation)
+		assert.Empty(t, entries)
+	})
+
+	t.Run("sanitizes transformation and test names in paths", func(t *testing.T) {
+		results := &TestResults{
+			Status: RunStatusExecuted,
+			Transformations: []*TransformationTestWithDefinitions{
+				{
+					Result: &transformations.TransformationTestResult{
+						Name: "My/Transform:v2",
+						TestSuiteResult: transformations.TestSuiteRunResult{
+							Status: transformations.TestRunStatusPass,
+							Results: []transformations.TestResult{
+								{
+									ID:           "test-1",
+									Name:         "suite<1>",
+									Status:       transformations.TestRunStatusPass,
+									ActualOutput: []any{"data"},
+								},
+							},
+						},
+					},
+					Definitions: []*transformations.TestDefinition{
+						{
+							ID:       "test-1",
+							Filename: "event.json",
+						},
+					},
+				},
+			},
+		}
+
+		_, entries := results.ToOutput()
+
+		require.Len(t, entries, 1)
+		assert.Equal(t, "My_Transform_v2/suite_1_/event.json", entries[0].RelPath)
+	})
+
+	t.Run("preserves library results unchanged", func(t *testing.T) {
+		libs := []transformations.LibraryTestResult{
+			{HandleName: "lib1", VersionID: "v1", Pass: true},
+			{HandleName: "lib2", VersionID: "v2", Pass: false, Message: "syntax error"},
+		}
+
+		results := &TestResults{
+			Status:    RunStatusExecuted,
+			Libraries: libs,
+		}
+
+		output, _ := results.ToOutput()
+
+		assert.Equal(t, libs, output.Libraries)
+	})
+
+	t.Run("handles nil transformations", func(t *testing.T) {
+		results := &TestResults{
+			Status: RunStatusExecuted,
+		}
+
+		output, entries := results.ToOutput()
+
+		assert.Equal(t, RunStatusExecuted, output.Status)
+		assert.Nil(t, output.Transformations)
+		assert.Nil(t, entries)
+	})
+}
+
+func TestSanitizePath(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"simple", "simple"},
+		{"path/with/slashes", "path_with_slashes"},
+		{"name:v2", "name_v2"},
+		{"file<1>", "file_1_"},
+		{"a*b?c", "a_b_c"},
+		{"back\\slash", "back_slash"},
+		{`with"quotes`, "with_quotes"},
+		{"pipe|char", "pipe_char"},
+		{"  spaces  ", "spaces"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			assert.Equal(t, tt.expected, sanitizePath(tt.input))
+		})
+	}
+}

--- a/cli/internal/providers/transformations/testorchestrator/test_results_test.go
+++ b/cli/internal/providers/transformations/testorchestrator/test_results_test.go
@@ -9,8 +9,8 @@ import (
 )
 
 func TestRunStatus(t *testing.T) {
-	t.Run("RunStatusExecuted is the zero value", func(t *testing.T) {
-		r := &TestResults{}
+	t.Run("RunStatusExecuted is the default run status", func(t *testing.T) {
+		r := &TestResults{Status: RunStatusExecuted}
 		assert.Equal(t, RunStatusExecuted, r.Status)
 	})
 }


### PR DESCRIPTION
## 🔗 Ticket

resolves [DAW-3201](https://linear.app/rudderstack/issue/DAW-3201/chore-improve-test-results-serialization-with-output-types-and-actual)

---

## Summary

Improves the `transformations test` command's `results.json` output by adding input/output location fields per test result, extracting `actualOutput` data into separate files with path references, and flattening the redundant `result` wrapper in the transformations array. Introduces dedicated output types (`TestResultsOutput`, `TransformationTestOutput`, `TestResultOutput`) via a `ToOutput()` conversion method, keeping internal types unchanged for backward compatibility with display and orchestration logic.

---

## Changes

* Added `Filename` field to `TestDefinition` to carry the base input filename separately from `Name` and `InputFile`
* Changed `TestDefinition.Name` from `"suite (filename)"` to just `"suite"` — display now builds the full name via `testDisplayName(name, filename)` helper
* Created `test_results_output.go` with output types, `ToOutput()` method, `sanitizePath` helper, and `ActualOutputEntry` for file writing
* Updated `writeResultsFile` to call `ToOutput()`, write actual output JSON files under `test-results/<transform>/<test>/<filename>`, and serialize `TestResultsOutput`
* Updated display to combine `testResult.Name` + `def.Filename` for test result line output

### Actual Output File Tree

```
test-results/
  results.json
  Allow List Test/
    default-events/
      default_events.json
  Simple Transform updated/
    Test sample events/
      product_clicked.json
    Test sample events/
      product_viewed.json
  py Transformation/
    default-events/
      default_events.json
```

---

## Testing

* Unit tests for `ToOutput()` covering: location mapping, actualOutputFile paths, default-events handling, sanitization, nil slices
* Unit tests for `sanitizePath` with various unsafe characters
* Updated `writeResultsFile` tests to verify flattened JSON structure, actual output file creation, and path references
* Updated `inputs_test.go` to assert new `Filename` field and changed `Name` format
* Updated display test to verify `Filename`-based display name construction
* Full test suite passes (`make test`), lint clean (`make lint`)

---

## Risk / Impact

Low
Output-only change to `results.json` format. Internal types unchanged. Display produces same visual output. E2E tests will need to deserialize into `TestResultsOutput` instead of `TestResults`.

---

## Checklist

* [x] Ticket linked
* [x] Tests added/updated
* [x] No breaking changes (or documented)