### PR TITLE
chore: add AGENTS.md with Cursor Cloud development environment setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,28 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Overview
+
+This is a Go CLI project (`rudder-cli`) with no local service dependencies. All remote API calls go to `api.rudderstack.com`. Build, lint, and test commands are in the `Makefile`.
+
+### Quick reference
+
+| Task | Command |
+|------|---------|
+| Build | `make build` |
+| Lint | `make lint` |
+| Unit tests | `make test` |
+| E2E tests | `make test-e2e` |
+| Integration tests | `make test-it` |
+| All tests | `make test-all` |
+
+See `CLAUDE.md` for full project architecture, code standards, and workflow details.
+
+### Non-obvious caveats
+
+- **`go.mod` replace directive**: The `go.mod` has a `replace` pointing to `../rudder-data-catalog-provider/sdk`. No Go source files import this module, so it does not affect `go build`, `go test`, or `go mod download`. If it ever becomes an active import, the sibling repo would need to be cloned at `../rudder-data-catalog-provider/`.
+- **One test requires `RUDDERSTACK_ACCESS_TOKEN`**: `cli/pkg/exp/project/project_test.go` (`TestProjectLoad`) fails without a valid access token. This is the only unit test that needs external auth; all other unit tests pass without credentials.
+- **golangci-lint auto-downloads Go toolchain**: The linter (`v2.9.0`) requires Go >= 1.25.0 and will auto-download `go1.25.8` via the Go toolchain mechanism on first run. This is expected behavior.
+- **CLI binary location**: `make build` produces `bin/rudder-cli` in the workspace root.
+- **No Docker or local services needed**: This is a pure CLI client. No databases, containers, or docker-compose services are required for development.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with Cursor Cloud specific instructions for future cloud agents working on this repository.

---

## Changes

- Added `AGENTS.md` with quick-reference table for build/lint/test commands
- Documented non-obvious caveats (go.mod replace directive, test requiring auth token, golangci-lint auto-downloading Go toolchain)

---

## Testing

- `make build` — builds successfully
- `make lint` — 0 issues
- `make test` — all unit tests pass except one experimental test requiring `RUDDERSTACK_ACCESS_TOKEN`
- CLI binary runs and responds to commands (`--help`, `--version`, `telemetry status/enable/disable`, `completion bash`)

---

## Risk / Impact

Low — documentation-only change.

---

## Checklist

- [x] No breaking changes
- [x] Verified build, lint, and test commands work
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b079155c-7331-42dd-80b8-072b93a954ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b079155c-7331-42dd-80b8-072b93a954ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

