### PR TITLE
feat(cli): warn on legacy v0.1 specs in apply and validate

### DIFF
--- a/cli/internal/cmd/import/workspace.go
+++ b/cli/internal/cmd/import/workspace.go
@@ -41,6 +41,10 @@ func NewCmdWorkspaceImport() *cobra.Command {
 				return fmt.Errorf("loading and validating project: %w", err)
 			}
 
+			if project.HasLegacySpecs(p.Specs()) {
+				ui.PrintDeprecationWarning(project.ImportLegacySpecWarning)
+			}
+
 			_, err := os.Stat(filepath.Join(location, importer.ImportedDir))
 			if err == nil {
 				return fmt.Errorf("directory for import: %s already exists", filepath.Join(location, importer.ImportedDir))

--- a/cli/internal/cmd/project/apply/apply.go
+++ b/cli/internal/cmd/project/apply/apply.go
@@ -11,7 +11,6 @@ import (
 	"github.com/rudderlabs/rudder-iac/cli/internal/logger"
 	"github.com/rudderlabs/rudder-iac/cli/internal/project"
 	"github.com/rudderlabs/rudder-iac/cli/internal/syncer"
-	"github.com/rudderlabs/rudder-iac/cli/internal/ui"
 	"github.com/spf13/cobra"
 )
 
@@ -58,9 +57,7 @@ func NewCmdApply() *cobra.Command {
 				return fmt.Errorf("loading and validating project: %w", err)
 			}
 
-			if project.HasLegacySpecs(p.Specs()) {
-				ui.PrintDeprecationWarning(project.LegacySpecDeprecationWarning)
-			}
+			project.PrintLegacySpecDeprecationIfNeeded(p.Specs())
 
 			return nil
 		},

--- a/cli/internal/cmd/project/apply/apply.go
+++ b/cli/internal/cmd/project/apply/apply.go
@@ -11,6 +11,7 @@ import (
 	"github.com/rudderlabs/rudder-iac/cli/internal/logger"
 	"github.com/rudderlabs/rudder-iac/cli/internal/project"
 	"github.com/rudderlabs/rudder-iac/cli/internal/syncer"
+	"github.com/rudderlabs/rudder-iac/cli/internal/ui"
 	"github.com/spf13/cobra"
 )
 
@@ -57,7 +58,9 @@ func NewCmdApply() *cobra.Command {
 				return fmt.Errorf("loading and validating project: %w", err)
 			}
 
-			project.PrintLegacySpecDeprecationIfNeeded(p.Specs())
+			if project.HasLegacySpecs(p.Specs()) {
+				ui.PrintDeprecationWarning(project.LegacySpecDeprecationWarning)
+			}
 
 			return nil
 		},

--- a/cli/internal/cmd/project/apply/apply.go
+++ b/cli/internal/cmd/project/apply/apply.go
@@ -11,6 +11,7 @@ import (
 	"github.com/rudderlabs/rudder-iac/cli/internal/logger"
 	"github.com/rudderlabs/rudder-iac/cli/internal/project"
 	"github.com/rudderlabs/rudder-iac/cli/internal/syncer"
+	"github.com/rudderlabs/rudder-iac/cli/internal/ui"
 	"github.com/spf13/cobra"
 )
 
@@ -55,6 +56,10 @@ func NewCmdApply() *cobra.Command {
 			// Load and validate the project configuration
 			if err := p.Load(location); err != nil {
 				return fmt.Errorf("loading and validating project: %w", err)
+			}
+
+			if project.HasLegacySpecs(p.Specs()) {
+				ui.PrintDeprecationWarning(project.LegacySpecDeprecationWarning)
 			}
 
 			return nil

--- a/cli/internal/cmd/project/validate/validate.go
+++ b/cli/internal/cmd/project/validate/validate.go
@@ -61,6 +61,10 @@ func NewCmdValidate() *cobra.Command {
 				return fmt.Errorf("validating project: %w", err)
 			}
 
+			if project.HasLegacySpecs(p.Specs()) {
+				ui.PrintDeprecationWarning(project.LegacySpecDeprecationWarning)
+			}
+
 			validateLog.Info("Project configuration is valid")
 			ui.PrintSuccess("Project configuration is valid")
 			return nil

--- a/cli/internal/cmd/project/validate/validate.go
+++ b/cli/internal/cmd/project/validate/validate.go
@@ -61,9 +61,7 @@ func NewCmdValidate() *cobra.Command {
 				return fmt.Errorf("validating project: %w", err)
 			}
 
-			if project.HasLegacySpecs(p.Specs()) {
-				ui.PrintDeprecationWarning(project.LegacySpecDeprecationWarning)
-			}
+			project.PrintLegacySpecDeprecationIfNeeded(p.Specs())
 
 			validateLog.Info("Project configuration is valid")
 			ui.PrintSuccess("Project configuration is valid")

--- a/cli/internal/cmd/project/validate/validate.go
+++ b/cli/internal/cmd/project/validate/validate.go
@@ -61,7 +61,9 @@ func NewCmdValidate() *cobra.Command {
 				return fmt.Errorf("validating project: %w", err)
 			}
 
-			project.PrintLegacySpecDeprecationIfNeeded(p.Specs())
+			if project.HasLegacySpecs(p.Specs()) {
+				ui.PrintDeprecationWarning(project.LegacySpecDeprecationWarning)
+			}
 
 			validateLog.Info("Project configuration is valid")
 			ui.PrintSuccess("Project configuration is valid")

--- a/cli/internal/project/deprecation.go
+++ b/cli/internal/project/deprecation.go
@@ -2,14 +2,13 @@ package project
 
 import (
 	"github.com/rudderlabs/rudder-iac/cli/internal/project/specs"
-	"github.com/rudderlabs/rudder-iac/cli/internal/ui"
 )
 
 // LegacySpecDeprecationWarning is shown when any loaded spec uses the v0.1 format.
 // Replace <migration-guide-url> when the upstream migration guide is published.
 const LegacySpecDeprecationWarning = `v0.1 spec format is deprecated and will be removed in a future release.
          Run ` + "`rudder-cli migrate`" + ` to upgrade to v1.
-         See: <migration-guide-url>`
+         See: https://github.com/rudderlabs/rudder-iac/blob/main/BREAKING_CHANGES.md`
 
 // HasLegacySpecs reports whether any spec in specMap uses a legacy (v0.1) version.
 func HasLegacySpecs(specMap map[string]*specs.Spec) bool {
@@ -19,13 +18,4 @@ func HasLegacySpecs(specMap map[string]*specs.Spec) bool {
 		}
 	}
 	return false
-}
-
-// PrintLegacySpecDeprecationIfNeeded prints a deprecation warning once per run when specMap
-// contains any v0.1 spec. It is a no-op when there are no legacy specs.
-func PrintLegacySpecDeprecationIfNeeded(specMap map[string]*specs.Spec) {
-	if !HasLegacySpecs(specMap) {
-		return
-	}
-	ui.PrintDeprecationWarning(LegacySpecDeprecationWarning)
 }

--- a/cli/internal/project/deprecation.go
+++ b/cli/internal/project/deprecation.go
@@ -1,0 +1,19 @@
+package project
+
+import "github.com/rudderlabs/rudder-iac/cli/internal/project/specs"
+
+// LegacySpecDeprecationWarning is shown when any loaded spec uses the v0.1 format.
+// Replace <migration-guide-url> when the upstream migration guide is published.
+const LegacySpecDeprecationWarning = `v0.1 spec format is deprecated and will be removed in a future release.
+         Run ` + "`rudder-cli migrate`" + ` to upgrade to v1.
+         See: <migration-guide-url>`
+
+// HasLegacySpecs reports whether any spec in specMap uses a legacy (v0.1) version.
+func HasLegacySpecs(specMap map[string]*specs.Spec) bool {
+	for _, s := range specMap {
+		if s != nil && s.IsLegacyVersion() {
+			return true
+		}
+	}
+	return false
+}

--- a/cli/internal/project/deprecation.go
+++ b/cli/internal/project/deprecation.go
@@ -1,6 +1,9 @@
 package project
 
-import "github.com/rudderlabs/rudder-iac/cli/internal/project/specs"
+import (
+	"github.com/rudderlabs/rudder-iac/cli/internal/project/specs"
+	"github.com/rudderlabs/rudder-iac/cli/internal/ui"
+)
 
 // LegacySpecDeprecationWarning is shown when any loaded spec uses the v0.1 format.
 // Replace <migration-guide-url> when the upstream migration guide is published.
@@ -16,4 +19,13 @@ func HasLegacySpecs(specMap map[string]*specs.Spec) bool {
 		}
 	}
 	return false
+}
+
+// PrintLegacySpecDeprecationIfNeeded prints a deprecation warning once per run when specMap
+// contains any v0.1 spec. It is a no-op when there are no legacy specs.
+func PrintLegacySpecDeprecationIfNeeded(specMap map[string]*specs.Spec) {
+	if !HasLegacySpecs(specMap) {
+		return
+	}
+	ui.PrintDeprecationWarning(LegacySpecDeprecationWarning)
 }

--- a/cli/internal/project/deprecation.go
+++ b/cli/internal/project/deprecation.go
@@ -5,7 +5,6 @@ import (
 )
 
 // LegacySpecDeprecationWarning is shown when any loaded spec uses the v0.1 format.
-// Replace <migration-guide-url> when the upstream migration guide is published.
 const LegacySpecDeprecationWarning = `v0.1 spec format is deprecated and will be removed in a future release.
          Run ` + "`rudder-cli migrate`" + ` to upgrade existing specs to v1.
          See: https://github.com/rudderlabs/rudder-iac/blob/main/BREAKING_CHANGES.md`

--- a/cli/internal/project/deprecation.go
+++ b/cli/internal/project/deprecation.go
@@ -7,7 +7,14 @@ import (
 // LegacySpecDeprecationWarning is shown when any loaded spec uses the v0.1 format.
 // Replace <migration-guide-url> when the upstream migration guide is published.
 const LegacySpecDeprecationWarning = `v0.1 spec format is deprecated and will be removed in a future release.
-         Run ` + "`rudder-cli migrate`" + ` to upgrade to v1.
+         Run ` + "`rudder-cli migrate`" + ` to upgrade existing specs to v1.
+         See: https://github.com/rudderlabs/rudder-iac/blob/main/BREAKING_CHANGES.md`
+
+// ImportLegacySpecWarning is shown during import when the project has existing v0.1 specs.
+// It informs users that newly imported resources will be in v1 format and nudges migration of existing specs.
+const ImportLegacySpecWarning = `Imported resources will be generated in v1 spec format.
+         v0.1 spec format is deprecated and will be removed in a future release.
+         Run ` + "`rudder-cli migrate`" + ` to upgrade existing specs to v1.
          See: https://github.com/rudderlabs/rudder-iac/blob/main/BREAKING_CHANGES.md`
 
 // HasLegacySpecs reports whether any spec in specMap uses a legacy (v0.1) version.

--- a/cli/internal/project/deprecation_test.go
+++ b/cli/internal/project/deprecation_test.go
@@ -1,14 +1,11 @@
 package project
 
 import (
-	"bytes"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"github.com/rudderlabs/rudder-iac/cli/internal/project/specs"
-	"github.com/rudderlabs/rudder-iac/cli/internal/ui"
 )
 
 func TestHasLegacySpecs(t *testing.T) {
@@ -76,38 +73,4 @@ func TestHasLegacySpecs(t *testing.T) {
 			assert.Equal(t, tt.wantTrue, got)
 		})
 	}
-}
-
-func TestPrintLegacySpecDeprecationIfNeeded(t *testing.T) {
-	t.Parallel()
-
-	t.Run("no legacy specs prints nothing", func(t *testing.T) {
-		t.Parallel()
-		var buf bytes.Buffer
-		ui.SetWriter(&buf)
-		t.Cleanup(ui.RestoreWriter)
-
-		PrintLegacySpecDeprecationIfNeeded(map[string]*specs.Spec{
-			"a.yaml": {Version: specs.SpecVersionV1},
-		})
-
-		assert.Empty(t, buf.String())
-	})
-
-	t.Run("legacy specs prints deprecation", func(t *testing.T) {
-		t.Parallel()
-		var buf bytes.Buffer
-		ui.SetWriter(&buf)
-		t.Cleanup(ui.RestoreWriter)
-
-		PrintLegacySpecDeprecationIfNeeded(map[string]*specs.Spec{
-			"a.yaml": {Version: specs.SpecVersionV0_1},
-		})
-
-		out := buf.String()
-		require.Contains(t, out, "Warning:")
-		require.Contains(t, out, "v0.1 spec format")
-		require.Contains(t, out, "rudder-cli migrate")
-		require.Contains(t, out, "<migration-guide-url>")
-	})
 }

--- a/cli/internal/project/deprecation_test.go
+++ b/cli/internal/project/deprecation_test.go
@@ -1,11 +1,14 @@
 package project
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/rudderlabs/rudder-iac/cli/internal/project/specs"
+	"github.com/rudderlabs/rudder-iac/cli/internal/ui"
 )
 
 func TestHasLegacySpecs(t *testing.T) {
@@ -73,4 +76,38 @@ func TestHasLegacySpecs(t *testing.T) {
 			assert.Equal(t, tt.wantTrue, got)
 		})
 	}
+}
+
+func TestPrintLegacySpecDeprecationIfNeeded(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no legacy specs prints nothing", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		ui.SetWriter(&buf)
+		t.Cleanup(ui.RestoreWriter)
+
+		PrintLegacySpecDeprecationIfNeeded(map[string]*specs.Spec{
+			"a.yaml": {Version: specs.SpecVersionV1},
+		})
+
+		assert.Empty(t, buf.String())
+	})
+
+	t.Run("legacy specs prints deprecation", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		ui.SetWriter(&buf)
+		t.Cleanup(ui.RestoreWriter)
+
+		PrintLegacySpecDeprecationIfNeeded(map[string]*specs.Spec{
+			"a.yaml": {Version: specs.SpecVersionV0_1},
+		})
+
+		out := buf.String()
+		require.Contains(t, out, "Warning:")
+		require.Contains(t, out, "v0.1 spec format")
+		require.Contains(t, out, "rudder-cli migrate")
+		require.Contains(t, out, "<migration-guide-url>")
+	})
 }

--- a/cli/internal/project/deprecation_test.go
+++ b/cli/internal/project/deprecation_test.go
@@ -1,0 +1,76 @@
+package project
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/rudderlabs/rudder-iac/cli/internal/project/specs"
+)
+
+func TestHasLegacySpecs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		specMap  map[string]*specs.Spec
+		wantTrue bool
+	}{
+		{
+			name:     "nil map",
+			specMap:  nil,
+			wantTrue: false,
+		},
+		{
+			name:     "empty map",
+			specMap:  map[string]*specs.Spec{},
+			wantTrue: false,
+		},
+		{
+			name: "all v1",
+			specMap: map[string]*specs.Spec{
+				"a.yaml": {Version: specs.SpecVersionV1},
+				"b.yaml": {Version: specs.SpecVersionV1},
+			},
+			wantTrue: false,
+		},
+		{
+			name: "rudder/0.1 only",
+			specMap: map[string]*specs.Spec{
+				"a.yaml": {Version: specs.SpecVersionV0_1},
+			},
+			wantTrue: true,
+		},
+		{
+			name: "rudder/v0.1 variant",
+			specMap: map[string]*specs.Spec{
+				"a.yaml": {Version: specs.SpecVersionV0_1Variant},
+			},
+			wantTrue: true,
+		},
+		{
+			name: "mix v1 and v0.1",
+			specMap: map[string]*specs.Spec{
+				"a.yaml": {Version: specs.SpecVersionV1},
+				"b.yaml": {Version: specs.SpecVersionV0_1},
+			},
+			wantTrue: true,
+		},
+		{
+			name: "nil spec entry skipped",
+			specMap: map[string]*specs.Spec{
+				"a.yaml": nil,
+				"b.yaml": {Version: specs.SpecVersionV1},
+			},
+			wantTrue: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := HasLegacySpecs(tt.specMap)
+			assert.Equal(t, tt.wantTrue, got)
+		})
+	}
+}

--- a/cli/internal/ui/messages.go
+++ b/cli/internal/ui/messages.go
@@ -33,6 +33,13 @@ func PrintWarning(message string) {
 	fmt.Fprintln(uiWriter, Warning(message))
 }
 
+// PrintDeprecationWarning prints a multi-line deprecation message to stdout with surrounding blank lines.
+func PrintDeprecationWarning(message string) {
+	fmt.Fprintln(uiWriter, "")
+	fmt.Fprintln(uiWriter, Warning(message))
+	fmt.Fprintln(uiWriter, "")
+}
+
 // Failure returns a failure message string in a styled format, including a red "x" symbol.
 func Failure(message string) string {
 	return fmt.Sprintf("%s %s", Color("x", ColorRed), message)

--- a/cli/internal/ui/messages_test.go
+++ b/cli/internal/ui/messages_test.go
@@ -22,5 +22,5 @@ func TestPrintDeprecationWarning(t *testing.T) {
 	assert.Contains(t, out, "Warning:")
 	assert.Contains(t, out, "line one")
 	assert.Contains(t, out, "line two")
-	assert.True(t, strings.HasSuffix(out, "\n\n") || strings.HasSuffix(out, "\n"), "expected trailing newline(s)")
+	assert.True(t, strings.HasSuffix(out, "\n"), "expected trailing blank line")
 }

--- a/cli/internal/ui/messages_test.go
+++ b/cli/internal/ui/messages_test.go
@@ -1,0 +1,26 @@
+package ui
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPrintDeprecationWarning(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	SetWriter(&buf)
+	t.Cleanup(RestoreWriter)
+
+	PrintDeprecationWarning("line one\nline two")
+
+	out := buf.String()
+	assert.True(t, strings.HasPrefix(out, "\n"), "expected leading blank line")
+	assert.Contains(t, out, "Warning:")
+	assert.Contains(t, out, "line one")
+	assert.Contains(t, out, "line two")
+	assert.True(t, strings.HasSuffix(out, "\n\n") || strings.HasSuffix(out, "\n"), "expected trailing newline(s)")
+}


### PR DESCRIPTION

## 🔗 Ticket

<!-- Required for traceability -->
Resolves: [DEX-304](https://linear.app/rudderstack/issue/DEX-304/add-deprecation-warning-for-v01-specs-in-apply-validate-and-destroy)

---

## Summary

When `apply` or `validate` loads a project that includes v0.1 specs (`rudder/0.1` or `rudder/v0.1`), the CLI prints a single deprecation warning per run to stdout with a `migrate` hint and a placeholder migration guide URL. `destroy` is unchanged (no spec loading). Behavior of v0.1 specs is otherwise unchanged.

---

## Changes

- Added `HasLegacySpecs` and `LegacySpecDeprecationWarning` in `cli/internal/project/deprecation.go`
- Added `PrintDeprecationWarning` in `cli/internal/ui/messages.go` (stdout, blank lines for visibility)
- Wired warning after successful `Load` in `apply` (`PreRunE`) and `validate` (`RunE`)
- Table-driven unit tests for `HasLegacySpecs`

---

## Testing

- `make lint` — pass
- `go test ./cli/internal/project/... ./cli/internal/cmd/project/apply/... ./cli/internal/cmd/project/validate/... ./cli/internal/ui/...` — pass
- Full `make test` may fail without `RUDDERSTACK_ACCESS_TOKEN` for `cli/pkg/exp/project` tests; unrelated to this change

---

## Risk / Impact

Low — additive stdout warning only; no validation or apply behavior changes.

---

## Checklist

- [x] Ticket linked
- [x] Tests added/updated
- [x] No breaking changes (or documented)

---
<img width="946" height="154" alt="Screenshot 2026-04-09 at 2 01 42 PM" src="https://github.com/user-attachments/assets/0aa827de-79a3-43e6-8fc9-635135559b9b" />

<img width="1347" height="202" alt="Screenshot 2026-04-13 at 11 35 15 AM" src="https://github.com/user-attachments/assets/e464465d-152c-4e73-9bc5-edf415551f0f" />

<img width="983" height="191" alt="Screenshot 2026-04-13 at 11 37 23 AM" src="https://github.com/user-attachments/assets/8c0ba712-303e-46f6-95b3-c764bb48e44f" />



