### PR TITLE
chore: add spinner to apply flow for loading feedback

### DIFF
--- a/cli/internal/cmd/project/apply/apply.go
+++ b/cli/internal/cmd/project/apply/apply.go
@@ -11,6 +11,7 @@ import (
 	"github.com/rudderlabs/rudder-iac/cli/internal/logger"
 	"github.com/rudderlabs/rudder-iac/cli/internal/project"
 	"github.com/rudderlabs/rudder-iac/cli/internal/syncer"
+	"github.com/rudderlabs/rudder-iac/cli/internal/ui"
 	"github.com/spf13/cobra"
 )
 
@@ -71,6 +72,9 @@ func NewCmdApply() *cobra.Command {
 				}...)
 			}()
 
+			spinner := ui.NewSpinner("Preparing to apply changes...")
+			spinner.Start()
+
 			workspace, err := deps.Client().Workspaces.GetByAuthToken(context.Background())
 			if err != nil {
 				return fmt.Errorf("fetching workspace information: %w", err)
@@ -97,6 +101,8 @@ func NewCmdApply() *cobra.Command {
 			if err != nil {
 				return err
 			}
+
+			spinner.Stop()
 
 			// Apply the changes
 			err = s.Sync(context.Background(), graph)

--- a/cli/internal/cmd/project/apply/apply.go
+++ b/cli/internal/cmd/project/apply/apply.go
@@ -11,7 +11,6 @@ import (
 	"github.com/rudderlabs/rudder-iac/cli/internal/logger"
 	"github.com/rudderlabs/rudder-iac/cli/internal/project"
 	"github.com/rudderlabs/rudder-iac/cli/internal/syncer"
-	"github.com/rudderlabs/rudder-iac/cli/internal/ui"
 	"github.com/spf13/cobra"
 )
 
@@ -72,9 +71,6 @@ func NewCmdApply() *cobra.Command {
 				}...)
 			}()
 
-			spinner := ui.NewSpinner("Preparing to apply changes...")
-			spinner.Start()
-
 			workspace, err := deps.Client().Workspaces.GetByAuthToken(context.Background())
 			if err != nil {
 				return fmt.Errorf("fetching workspace information: %w", err)
@@ -101,8 +97,6 @@ func NewCmdApply() *cobra.Command {
 			if err != nil {
 				return err
 			}
-
-			spinner.Stop()
 
 			// Apply the changes
 			err = s.Sync(context.Background(), graph)

--- a/cli/internal/syncer/syncer.go
+++ b/cli/internal/syncer/syncer.go
@@ -11,6 +11,7 @@ import (
 	"github.com/rudderlabs/rudder-iac/cli/internal/resources/state"
 	"github.com/rudderlabs/rudder-iac/cli/internal/syncer/planner"
 	"github.com/rudderlabs/rudder-iac/cli/internal/syncer/reporters"
+	"github.com/rudderlabs/rudder-iac/cli/internal/ui"
 	"github.com/rudderlabs/rudder-iac/cli/pkg/tasker"
 )
 
@@ -118,6 +119,9 @@ func (s *ProjectSyncer) Destroy(ctx context.Context) []error {
 }
 
 func (s *ProjectSyncer) apply(ctx context.Context, target *resources.Graph, continueOnFail bool) []error {
+	spinner := ui.NewSpinner("Preparing to apply changes...")
+	spinner.Start()
+
 	resources, err := s.provider.LoadResourcesFromRemote(ctx)
 	if err != nil {
 		return []error{err}
@@ -131,6 +135,8 @@ func (s *ProjectSyncer) apply(ctx context.Context, target *resources.Graph, cont
 
 	p := planner.New(s.workspace.ID)
 	plan := p.Plan(source, target)
+
+	spinner.Stop()
 
 	s.reporter.ReportPlan(plan)
 

--- a/cli/internal/syncer/syncer.go
+++ b/cli/internal/syncer/syncer.go
@@ -119,7 +119,7 @@ func (s *ProjectSyncer) Destroy(ctx context.Context) []error {
 }
 
 func (s *ProjectSyncer) apply(ctx context.Context, target *resources.Graph, continueOnFail bool) []error {
-	spinner := ui.NewSpinner("Preparing to apply changes...")
+	spinner := ui.NewSpinner("Loading state ...")
 	spinner.Start()
 
 	resources, err := s.provider.LoadResourcesFromRemote(ctx)


### PR DESCRIPTION
## 🔗 Ticket

resolves [QA-2194](https://linear.app/rudderstack/issue/QA-2194/no-loading-icon-is-displayed-when-applying-the-changes)

---

## Summary

Adds spinner indicators to the apply command flow so users get visual feedback while the CLI is working. A spinner in `syncer.go` covers the remote state loading and plan computation phase.

---

## Changes

* Added spinner in `syncer.go` around `LoadResourcesFromRemote`, `MapRemoteToState`, and plan computation

---

## Testing

* Manual — verified spinner displays during apply flow

---

## Risk / Impact

Low
Purely additive UI change — no logic affected.

---

## Checklist

* [x] Ticket linked
* [ ] Tests added/updated
* [x] No breaking changes (or documented)