### PR TITLE
fix: double apply on the e2e test to check for no changes to apply

### DIFF
--- a/cli/tests/command_apply_test.go
+++ b/cli/tests/command_apply_test.go
@@ -25,13 +25,18 @@ func TestProjectApply(t *testing.T) {
 
 	projectDir := filepath.Join("testdata", "project")
 
-	t.Run("rudder/v0.1 specs", func(t *testing.T) {
+	t.Run("rudder specs", func(t *testing.T) {
 		applyAndVerify(t, executor, projectDir)
 	})
 
 	t.Run("rudder/v1 specs after migration", func(t *testing.T) {
 		migratedDir := copyAndMigrateProject(t, executor, projectDir)
-		verifyNoDiffAfterMigration(t, executor, migratedDir)
+		// to make sure migration is applied correctly, we need to verify no
+		// changes are introduced after we run it and hence
+		// we apply the same in migrated project
+		verifyNoChangesToApply(t, executor, filepath.Join(migratedDir, "update"))
+		// then we apply this project again and verify that even after migration,
+		// no changes are introduced in upstream resource state.
 		applyAndVerify(t, executor, migratedDir)
 	})
 }
@@ -42,25 +47,45 @@ func applyAndVerify(t *testing.T, executor *CmdExecutor, projectDir string) {
 	output, err := executor.Execute(cliBinPath, "destroy", "--confirm=false")
 	require.NoError(t, err, "Failed to destroy resources: %v, output: %s", err, string(output))
 
+	var (
+		createDir = filepath.Join(projectDir, "create")
+		updateDir = filepath.Join(projectDir, "update")
+	)
+
 	t.Run("should create entities in catalog from project", func(t *testing.T) {
-		output, err := executor.Execute(cliBinPath, "apply", "-l", filepath.Join(projectDir, "create"), "--confirm=false")
+		output, err := executor.Execute(cliBinPath, "apply", "-l", createDir, "--confirm=false")
 		require.NoError(t, err, "Initial apply command failed with output: %s", string(output))
 		verifyState(t, "create")
 	})
 
 	t.Run("should update entities in catalog from project", func(t *testing.T) {
 		time.Sleep(5 * time.Second)
-		output, err := executor.Execute(cliBinPath, "apply", "-l", filepath.Join(projectDir, "update"), "--confirm=false")
+
+		output, err := executor.Execute(cliBinPath, "apply", "-l", updateDir, "--confirm=false")
 		require.NoError(t, err, "Update apply command failed with output: %s", string(output))
 		verifyState(t, "update")
 	})
+
+	t.Run("applying on already applied project should not create any diff", func(t *testing.T) {
+		// If we reapply the update directory, we should
+		// not see any changes meaning double apply without any changes
+		// should report no changes to apply.
+		verifyNoChangesToApply(t, executor, updateDir)
+	})
 }
 
-func verifyNoDiffAfterMigration(t *testing.T, executor *CmdExecutor, migratedDir string) {
+func verifyNoChangesToApply(t *testing.T, executor *CmdExecutor, path string) {
 	t.Helper()
 
 	// we only verify no diff after migration for the update directory, as the last apply was run on it
-	output, err := executor.Execute(cliBinPath, "apply", "-l", filepath.Join(migratedDir, "update"), "--dry-run", "--confirm=false")
+	output, err := executor.Execute(
+		cliBinPath,
+		"apply",
+		"-l",
+		path,
+		"--dry-run",
+		"--confirm=false",
+	)
 	require.NoError(t, err, "Dry run failed for update: %s", string(output))
 	assert.Contains(t, string(output), "No changes to apply", "Expected no diff after migration, but got: %s", string(output))
 }

--- a/cli/tests/command_apply_test.go
+++ b/cli/tests/command_apply_test.go
@@ -32,8 +32,8 @@ func TestProjectApply(t *testing.T) {
 	t.Run("rudder/v1 specs after migration", func(t *testing.T) {
 		migratedDir := copyAndMigrateProject(t, executor, projectDir)
 		// to make sure migration is applied correctly, we need to verify no
-		// changes are introduced after we run it and hence
-		// we apply the same in migrated project
+		// changes are reported if we re-apply the same project, therefore we dedicatedly
+		// test this scenario below
 		verifyNoChangesToApply(t, executor, filepath.Join(migratedDir, "update"))
 		// then we apply this project again and verify that even after migration,
 		// no changes are introduced in upstream resource state.

--- a/cli/tests/command_apply_test.go
+++ b/cli/tests/command_apply_test.go
@@ -35,8 +35,9 @@ func TestProjectApply(t *testing.T) {
 		// changes are reported if we re-apply the same project, therefore we dedicatedly
 		// test this scenario below
 		verifyNoChangesToApply(t, executor, filepath.Join(migratedDir, "update"))
-		// then we apply this project again and verify that even after migration,
-		// no changes are introduced in upstream resource state.
+		// then we apply this project again from scratch and verify no
+		// changes are reported in snapshot tests meaning after migration of the directory
+		// the upstream resources are created same
 		applyAndVerify(t, executor, migratedDir)
 	})
 }


### PR DESCRIPTION
Scanned-by: gitleaks 8.30.0

## 🔗 Ticket

<!-- Required for traceability -->

Resolves [DEX-312](https://linear.app/rudderstack/issue/DEX-312/double-apply-the-e2e-test-so-that-we-can-verify-that-once-the-changes)

---

## Summary

Added scenario for double applying without any changes to the project. This allows us to identify cases where we might have missed publishing fields to upstream.

---

## Changes

- Updated the command_apply_test.go file

---

## Testing

How was this tested?

- e2e tests

---

## Risk / Impact

Low / Medium / High
Notes (if any):

---

## Checklist

- [x] Ticket linked
- [x] Tests added/updated
- [x] No breaking changes (or documented)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk since changes are limited to CLI e2e tests, but adds an extra `apply --dry-run` step that could introduce minor CI flakiness if upstream state is eventually consistent.
> 
> **Overview**
> Strengthens `TestProjectApply` by adding an explicit *double-apply/idempotency* assertion: after applying the `update` project, the test now runs `apply --dry-run` and expects **"No changes to apply"**.
> 
> The migration flow is updated to use the same `verifyNoChangesToApply` helper (renamed/generalized from the old migration-specific check) to ensure migrated projects also produce no diff when re-applied.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19c18a592e6b12c3d090f998abaaac34edd864d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->