### PR TITLE
fix: add duplicate validations for tracking plan rule ids, events, and properties

### DIFF
--- a/cli/internal/providers/datacatalog/rules/customtype/customtype_semantic_valid.go
+++ b/cli/internal/providers/datacatalog/rules/customtype/customtype_semantic_valid.go
@@ -46,7 +46,7 @@ func validateCustomTypeVariants(spec localcatalog.CustomTypeSpec, graph *resourc
 		for j, prop := range ct.Properties {
 			ownRefs[j] = prop.Ref
 		}
-		results = append(results, variant.ValidateVariantDiscriminatorsV0(
+		results = append(results, variant.ValidateVariantSemanticV0(
 			ct.Variants, ownRefs, fmt.Sprintf("/types/%d", i), graph,
 		)...)
 	}
@@ -63,7 +63,7 @@ func validateCustomTypeVariantsV1(spec localcatalog.CustomTypeSpecV1, graph *res
 			ownRefs[j] = prop.Property
 		}
 
-		results = append(results, variant.ValidateVariantDiscriminatorsV1(
+		results = append(results, variant.ValidateVariantSemanticV1(
 			ct.Variants,
 			ownRefs,
 			fmt.Sprintf("/types/%d", i),

--- a/cli/internal/providers/datacatalog/rules/customtype/customtype_semantic_validation_test.go
+++ b/cli/internal/providers/datacatalog/rules/customtype/customtype_semantic_validation_test.go
@@ -13,6 +13,10 @@ import (
 	_ "github.com/rudderlabs/rudder-iac/cli/internal/providers/datacatalog/rules"
 )
 
+// V0 specs are internally converted to V1 ref style before semantic validation runs.
+// Tests in this file use V1-style refs (e.g. #property:email) for V0 specs,
+// not the legacy format (e.g. #/properties/group/email).
+
 // customTypeResource creates a custom-type resource with name in its data.
 func customTypeResource(id, name string) *resources.Resource {
 	data := resources.ResourceData{"name": name}
@@ -658,5 +662,106 @@ func TestCustomTypeSemanticValid_VariantDiscriminator(t *testing.T) {
 
 		results := validateCustomTypeSemantic(localcatalog.KindCustomTypes, specs.SpecVersionV0_1, nil, spec, graph)
 		assert.Empty(t, results, "no variants means no variant errors")
+	})
+}
+
+func TestCustomTypeSemanticValid_VariantDuplicateProperties(t *testing.T) {
+	t.Parallel()
+
+	t.Run("duplicate in variant case and default properties", func(t *testing.T) {
+		t.Parallel()
+
+		graph := resources.NewGraph()
+		graph.AddResource(propertyResourceWithType("email", "Email", "string"))
+		graph.AddResource(propertyResourceWithType("name", "Name", "string"))
+		graph.AddResource(propertyResourceWithType("method", "Method", "string"))
+
+		spec := localcatalog.CustomTypeSpec{
+			Types: []localcatalog.CustomType{
+				{
+					LocalID: "ct1",
+					Name:    "CT1",
+					Type:    "object",
+					Properties: []localcatalog.CustomTypeProperty{
+						{Ref: "#property:email"},
+						{Ref: "#property:method"},
+					},
+					Variants: localcatalog.Variants{
+						{
+							Type:          "discriminator",
+							Discriminator: "#property:method",
+							Cases: []localcatalog.VariantCase{
+								{
+									DisplayName: "Case 1",
+									Properties: []localcatalog.PropertyReference{
+										{Ref: "#property:email"},
+										{Ref: "#property:name"},
+										{Ref: "#property:email"},
+									},
+								},
+							},
+							Default: []localcatalog.PropertyReference{
+								{Ref: "#property:name"},
+								{Ref: "#property:name"},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		results := validateCustomTypeSemantic(localcatalog.KindCustomTypes, specs.SpecVersionV0_1, nil, spec, graph)
+
+		refs := extractRefs(results)
+		msgs := extractMsgs(results)
+
+		assert.Contains(t, refs, "/types/0/variants/0/cases/0/properties/0/$ref")
+		assert.Contains(t, refs, "/types/0/variants/0/cases/0/properties/2/$ref")
+		assert.Contains(t, refs, "/types/0/variants/0/default/0/$ref")
+		assert.Contains(t, refs, "/types/0/variants/0/default/1/$ref")
+		assert.Contains(t, msgs, "duplicate property reference in tracking plan event rule")
+	})
+
+	t.Run("no duplicates in variant properties", func(t *testing.T) {
+		t.Parallel()
+
+		graph := resources.NewGraph()
+		graph.AddResource(propertyResourceWithType("email", "Email", "string"))
+		graph.AddResource(propertyResourceWithType("name", "Name", "string"))
+		graph.AddResource(propertyResourceWithType("method", "Method", "string"))
+
+		spec := localcatalog.CustomTypeSpec{
+			Types: []localcatalog.CustomType{
+				{
+					LocalID: "ct1",
+					Name:    "CT1",
+					Type:    "object",
+					Properties: []localcatalog.CustomTypeProperty{
+						{Ref: "#property:email"},
+						{Ref: "#property:method"},
+					},
+					Variants: localcatalog.Variants{
+						{
+							Type:          "discriminator",
+							Discriminator: "#property:method",
+							Cases: []localcatalog.VariantCase{
+								{
+									DisplayName: "Case 1",
+									Properties: []localcatalog.PropertyReference{
+										{Ref: "#property:email"},
+										{Ref: "#property:name"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		results := validateCustomTypeSemantic(localcatalog.KindCustomTypes, specs.SpecVersionV0_1, nil, spec, graph)
+		for _, r := range results {
+			assert.NotEqual(t, "duplicate property reference in tracking plan event rule", r.Message)
+		}
 	})
 }

--- a/cli/internal/providers/datacatalog/rules/customtype/customtype_v1_validation_test.go
+++ b/cli/internal/providers/datacatalog/rules/customtype/customtype_v1_validation_test.go
@@ -153,10 +153,10 @@ func TestCustomTypeSpecSyntaxValidRule_V1InvalidSpecs(t *testing.T) {
 			spec: localcatalog.CustomTypeSpecV1{
 				Types: []localcatalog.CustomTypeV1{
 					{
-						LocalID: "ct1",
-						Name: "CT1",
-						Type: "array",
-						ItemType: "string",
+						LocalID:   "ct1",
+						Name:      "CT1",
+						Type:      "array",
+						ItemType:  "string",
 						ItemTypes: []string{"number"},
 					},
 				},
@@ -456,13 +456,12 @@ func TestCustomTypeSpecSyntaxValidRule_V1_ItemTypeValidation(t *testing.T) {
 	t.Run("mixed primitives and custom type refs", func(t *testing.T) {
 		t.Parallel()
 
-
 		spec := localcatalog.CustomTypeSpecV1{
 			Types: []localcatalog.CustomTypeV1{
 				{
-					LocalID:  "mixed_list",
-					Name:     "MixedList",
-					Type:     "array",
+					LocalID:   "mixed_list",
+					Name:      "MixedList",
+					Type:      "array",
 					ItemTypes: []string{"#custom-type:Address", "string"},
 				},
 			},
@@ -478,13 +477,12 @@ func TestCustomTypeSpecSyntaxValidRule_V1_ItemTypeValidation(t *testing.T) {
 	t.Run("custom type ref in item_types", func(t *testing.T) {
 		t.Parallel()
 
-
 		spec := localcatalog.CustomTypeSpecV1{
 			Types: []localcatalog.CustomTypeV1{
 				{
-					LocalID:  "mixed_list",
-					Name:     "MixedList",
-					Type:     "array",
+					LocalID:   "mixed_list",
+					Name:      "MixedList",
+					Type:      "array",
 					ItemTypes: []string{"#custom-type:Address"},
 				},
 			},
@@ -495,5 +493,112 @@ func TestCustomTypeSpecSyntaxValidRule_V1_ItemTypeValidation(t *testing.T) {
 		require.Len(t, results, 1)
 		assert.Equal(t, "/types/0/item_types/0", results[0].Reference)
 		assert.Contains(t, results[0].Message, "must be one of [string number integer boolean null array object]")
+	})
+}
+
+func TestCustomTypeSemanticValid_V1_VariantDuplicateProperties(t *testing.T) {
+	t.Parallel()
+
+	t.Run("duplicate in variant case and default properties", func(t *testing.T) {
+		t.Parallel()
+
+		graph := resources.NewGraph()
+		graph.AddResource(propertyResourceWithType("email", "Email", "string"))
+		graph.AddResource(propertyResourceWithType("name", "Name", "string"))
+		graph.AddResource(propertyResourceWithType("method", "Method", "string"))
+		graph.AddResource(customTypeResource("ct1", "CT1"))
+
+		spec := localcatalog.CustomTypeSpecV1{
+			Types: []localcatalog.CustomTypeV1{
+				{
+					LocalID: "ct1",
+					Name:    "CT1",
+					Type:    "object",
+					Properties: []localcatalog.CustomTypePropertyV1{
+						{Property: "#property:email"},
+						{Property: "#property:method"},
+					},
+					Variants: localcatalog.VariantsV1{
+						{
+							Type:          "discriminator",
+							Discriminator: "#property:method",
+							Cases: []localcatalog.VariantCaseV1{
+								{
+									DisplayName: "Case 1",
+									Match:       []any{"a"},
+									Properties: []localcatalog.PropertyReferenceV1{
+										{Property: "#property:email"},
+										{Property: "#property:name"},
+										{Property: "#property:email"},
+									},
+								},
+							},
+							Default: localcatalog.DefaultPropertiesV1{
+								Properties: []localcatalog.PropertyReferenceV1{
+									{Property: "#property:name"},
+									{Property: "#property:name"},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		results := validateCustomTypeSemanticV1(localcatalog.KindCustomTypes, specs.SpecVersionV1, nil, spec, graph)
+
+		refs := extractRefs(results)
+		msgs := extractMsgs(results)
+
+		assert.Contains(t, refs, "/types/0/variants/0/cases/0/properties/0/property")
+		assert.Contains(t, refs, "/types/0/variants/0/cases/0/properties/2/property")
+		assert.Contains(t, refs, "/types/0/variants/0/default/properties/0/property")
+		assert.Contains(t, refs, "/types/0/variants/0/default/properties/1/property")
+		assert.Contains(t, msgs, "duplicate property reference in tracking plan event rule")
+	})
+
+	t.Run("no duplicates in variant properties", func(t *testing.T) {
+		t.Parallel()
+
+		graph := resources.NewGraph()
+		graph.AddResource(propertyResourceWithType("email", "Email", "string"))
+		graph.AddResource(propertyResourceWithType("name", "Name", "string"))
+		graph.AddResource(propertyResourceWithType("method", "Method", "string"))
+		graph.AddResource(customTypeResource("ct1", "CT1"))
+
+		spec := localcatalog.CustomTypeSpecV1{
+			Types: []localcatalog.CustomTypeV1{
+				{
+					LocalID: "ct1",
+					Name:    "CT1",
+					Type:    "object",
+					Properties: []localcatalog.CustomTypePropertyV1{
+						{Property: "#property:email"},
+						{Property: "#property:method"},
+					},
+					Variants: localcatalog.VariantsV1{
+						{
+							Type:          "discriminator",
+							Discriminator: "#property:method",
+							Cases: []localcatalog.VariantCaseV1{
+								{
+									DisplayName: "Case 1",
+									Match:       []any{"a"},
+									Properties: []localcatalog.PropertyReferenceV1{
+										{Property: "#property:email"},
+										{Property: "#property:name"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		results := validateCustomTypeSemanticV1(localcatalog.KindCustomTypes, specs.SpecVersionV1, nil, spec, graph)
+		for _, r := range results {
+			assert.NotEqual(t, "duplicate property reference in tracking plan event rule", r.Message)
+		}
 	})
 }

--- a/cli/internal/providers/datacatalog/rules/trackingplan/trackingplan_semantic_v1_valid.go
+++ b/cli/internal/providers/datacatalog/rules/trackingplan/trackingplan_semantic_v1_valid.go
@@ -21,9 +21,6 @@ var validateTrackingPlanSemanticV1 = func(_ string, _ string, _ map[string]any, 
 	return results
 }
 
-// validateDuplicateEventsV1 emits one error per occurrence of any event ref
-// that appears more than once across rules. V1 refs arrive already normalized
-// (`#event:<id>`) so raw-string equality is sufficient.
 func validateDuplicateEventsV1(spec localcatalog.TrackingPlanV1) []rules.ValidationResult {
 	counts := make(map[string]int)
 	for _, rule := range spec.Rules {
@@ -42,9 +39,6 @@ func validateDuplicateEventsV1(spec localcatalog.TrackingPlanV1) []rules.Validat
 	return results
 }
 
-// validateDuplicatePropertiesV1 walks each rule and dedupes property refs at
-// every sibling scope: rule.Properties (recursively), variants[*].cases[*].properties,
-// and variants[*].default.properties.
 func validateDuplicatePropertiesV1(spec localcatalog.TrackingPlanV1) []rules.ValidationResult {
 	var results []rules.ValidationResult
 
@@ -53,11 +47,10 @@ func validateDuplicatePropertiesV1(spec localcatalog.TrackingPlanV1) []rules.Val
 
 		results = append(results, checkDuplicateSiblingPropsV1(rule.Properties, ruleRef+"/properties")...)
 
-		// V1 variants[*].default is DefaultPropertiesV1 wrapping Properties, not a direct slice.
 		for v, variant := range rule.Variants {
-			for c, kase := range variant.Cases {
+			for c, vCase := range variant.Cases {
 				caseRef := fmt.Sprintf("%s/variants/%d/cases/%d/properties", ruleRef, v, c)
-				results = append(results, checkDuplicateVariantPropRefsV1(kase.Properties, caseRef)...)
+				results = append(results, checkDuplicateVariantPropRefsV1(vCase.Properties, caseRef)...)
 			}
 			defaultRef := fmt.Sprintf("%s/variants/%d/default/properties", ruleRef, v)
 			results = append(results, checkDuplicateVariantPropRefsV1(variant.Default.Properties, defaultRef)...)
@@ -67,8 +60,6 @@ func validateDuplicatePropertiesV1(spec localcatalog.TrackingPlanV1) []rules.Val
 	return results
 }
 
-// checkDuplicateSiblingPropsV1 dedupes one list of TPRulePropertyV1 and
-// recurses into nested Properties. Each nested list is its own sibling scope.
 func checkDuplicateSiblingPropsV1(props []*localcatalog.TPRulePropertyV1, parentRef string) []rules.ValidationResult {
 	counts := make(map[string]int)
 	for _, prop := range props {
@@ -91,8 +82,6 @@ func checkDuplicateSiblingPropsV1(props []*localcatalog.TPRulePropertyV1, parent
 	return results
 }
 
-// checkDuplicateVariantPropRefsV1 dedupes a flat list of variant property refs.
-// Variant property refs use PropertyReferenceV1 and do not recurse.
 func checkDuplicateVariantPropRefsV1(props []localcatalog.PropertyReferenceV1, parentRef string) []rules.ValidationResult {
 	counts := make(map[string]int)
 	for _, prop := range props {

--- a/cli/internal/providers/datacatalog/rules/trackingplan/trackingplan_semantic_v1_valid.go
+++ b/cli/internal/providers/datacatalog/rules/trackingplan/trackingplan_semantic_v1_valid.go
@@ -71,7 +71,7 @@ func checkDuplicateSiblingPropsV1(props []*localcatalog.TPRulePropertyV1, parent
 		if counts[prop.Property] > 1 {
 			results = append(results, rules.ValidationResult{
 				Reference: fmt.Sprintf("%s/%d/property", parentRef, i),
-				Message:   "duplicate property reference in tracking plan rules",
+				Message:   "duplicate property reference in tracking plan event rule",
 			})
 		}
 		if len(prop.Properties) > 0 {
@@ -93,7 +93,7 @@ func checkDuplicateVariantPropRefsV1(props []localcatalog.PropertyReferenceV1, p
 		if counts[prop.Property] > 1 {
 			results = append(results, rules.ValidationResult{
 				Reference: fmt.Sprintf("%s/%d/property", parentRef, i),
-				Message:   "duplicate property reference in tracking plan rules",
+				Message:   "duplicate property reference in tracking plan event rule",
 			})
 		}
 	}

--- a/cli/internal/providers/datacatalog/rules/trackingplan/trackingplan_semantic_v1_valid.go
+++ b/cli/internal/providers/datacatalog/rules/trackingplan/trackingplan_semantic_v1_valid.go
@@ -32,7 +32,7 @@ func validateDuplicateEventsV1(spec localcatalog.TrackingPlanV1) []rules.Validat
 		if counts[rule.Event] > 1 {
 			results = append(results, rules.ValidationResult{
 				Reference: fmt.Sprintf("/rules/%d/event", i),
-				Message:   fmt.Sprintf("duplicate event reference '%s' (appears %d times)", rule.Event, counts[rule.Event]),
+				Message:   "duplicate event reference in tracking plan rules",
 			})
 		}
 	}
@@ -71,7 +71,7 @@ func checkDuplicateSiblingPropsV1(props []*localcatalog.TPRulePropertyV1, parent
 		if counts[prop.Property] > 1 {
 			results = append(results, rules.ValidationResult{
 				Reference: fmt.Sprintf("%s/%d/property", parentRef, i),
-				Message:   fmt.Sprintf("duplicate property reference '%s' (appears %d times)", prop.Property, counts[prop.Property]),
+				Message:   "duplicate property reference in tracking plan rules",
 			})
 		}
 		if len(prop.Properties) > 0 {
@@ -93,7 +93,7 @@ func checkDuplicateVariantPropRefsV1(props []localcatalog.PropertyReferenceV1, p
 		if counts[prop.Property] > 1 {
 			results = append(results, rules.ValidationResult{
 				Reference: fmt.Sprintf("%s/%d/property", parentRef, i),
-				Message:   fmt.Sprintf("duplicate property reference '%s' (appears %d times)", prop.Property, counts[prop.Property]),
+				Message:   "duplicate property reference in tracking plan rules",
 			})
 		}
 	}

--- a/cli/internal/providers/datacatalog/rules/trackingplan/trackingplan_semantic_v1_valid.go
+++ b/cli/internal/providers/datacatalog/rules/trackingplan/trackingplan_semantic_v1_valid.go
@@ -44,17 +44,7 @@ func validateDuplicatePropertiesV1(spec localcatalog.TrackingPlanV1) []rules.Val
 
 	for i, rule := range spec.Rules {
 		ruleRef := fmt.Sprintf("/rules/%d", i)
-
 		results = append(results, checkDuplicateSiblingPropsV1(rule.Properties, ruleRef+"/properties")...)
-
-		for v, variant := range rule.Variants {
-			for c, vCase := range variant.Cases {
-				caseRef := fmt.Sprintf("%s/variants/%d/cases/%d/properties", ruleRef, v, c)
-				results = append(results, checkDuplicateVariantPropRefsV1(vCase.Properties, caseRef)...)
-			}
-			defaultRef := fmt.Sprintf("%s/variants/%d/default/properties", ruleRef, v)
-			results = append(results, checkDuplicateVariantPropRefsV1(variant.Default.Properties, defaultRef)...)
-		}
 	}
 
 	return results
@@ -82,36 +72,21 @@ func checkDuplicateSiblingPropsV1(props []*localcatalog.TPRulePropertyV1, parent
 	return results
 }
 
-func checkDuplicateVariantPropRefsV1(props []localcatalog.PropertyReferenceV1, parentRef string) []rules.ValidationResult {
-	counts := make(map[string]int)
-	for _, prop := range props {
-		counts[prop.Property]++
-	}
-
-	var results []rules.ValidationResult
-	for i, prop := range props {
-		if counts[prop.Property] > 1 {
-			results = append(results, rules.ValidationResult{
-				Reference: fmt.Sprintf("%s/%d/property", parentRef, i),
-				Message:   "duplicate property reference in tracking plan event rule",
-			})
-		}
-	}
-	return results
-}
-
 func validateTrackingPlanVariantsV1(spec localcatalog.TrackingPlanV1, graph *resources.Graph) []rules.ValidationResult {
 	var results []rules.ValidationResult
 	for i, rule := range spec.Rules {
 		if len(rule.Variants) == 0 {
 			continue
 		}
+
+		ruleRef := fmt.Sprintf("/rules/%d", i)
+
 		ownRefs := make([]string, 0, len(rule.Properties))
 		for _, prop := range rule.Properties {
 			ownRefs = append(ownRefs, prop.Property)
 		}
-		results = append(results, variant.ValidateVariantDiscriminatorsV1(
-			rule.Variants, ownRefs, fmt.Sprintf("/rules/%d", i), graph,
+		results = append(results, variant.ValidateVariantSemanticV1(
+			rule.Variants, ownRefs, ruleRef, graph,
 		)...)
 	}
 	return results

--- a/cli/internal/providers/datacatalog/rules/trackingplan/trackingplan_semantic_v1_valid.go
+++ b/cli/internal/providers/datacatalog/rules/trackingplan/trackingplan_semantic_v1_valid.go
@@ -15,7 +15,99 @@ var validateTrackingPlanSemanticV1 = func(_ string, _ string, _ map[string]any, 
 	results = append(results, validateTrackingPlanVariantsV1(spec, graph)...)
 	results = append(results, validatePropertyNestingV1(spec, graph)...)
 	results = append(results, validateTrackingPlanNameUniquenessV1(spec, graph)...)
+	results = append(results, validateDuplicateEventsV1(spec)...)
+	results = append(results, validateDuplicatePropertiesV1(spec)...)
 
+	return results
+}
+
+// validateDuplicateEventsV1 emits one error per occurrence of any event ref
+// that appears more than once across rules. V1 refs arrive already normalized
+// (`#event:<id>`) so raw-string equality is sufficient.
+func validateDuplicateEventsV1(spec localcatalog.TrackingPlanV1) []rules.ValidationResult {
+	counts := make(map[string]int)
+	for _, rule := range spec.Rules {
+		counts[rule.Event]++
+	}
+
+	var results []rules.ValidationResult
+	for i, rule := range spec.Rules {
+		if counts[rule.Event] > 1 {
+			results = append(results, rules.ValidationResult{
+				Reference: fmt.Sprintf("/rules/%d/event", i),
+				Message:   fmt.Sprintf("duplicate event reference '%s' (appears %d times)", rule.Event, counts[rule.Event]),
+			})
+		}
+	}
+	return results
+}
+
+// validateDuplicatePropertiesV1 walks each rule and dedupes property refs at
+// every sibling scope: rule.Properties (recursively), variants[*].cases[*].properties,
+// and variants[*].default.properties.
+func validateDuplicatePropertiesV1(spec localcatalog.TrackingPlanV1) []rules.ValidationResult {
+	var results []rules.ValidationResult
+
+	for i, rule := range spec.Rules {
+		ruleRef := fmt.Sprintf("/rules/%d", i)
+
+		results = append(results, checkDuplicateSiblingPropsV1(rule.Properties, ruleRef+"/properties")...)
+
+		// V1 variants[*].default is DefaultPropertiesV1 wrapping Properties, not a direct slice.
+		for v, variant := range rule.Variants {
+			for c, kase := range variant.Cases {
+				caseRef := fmt.Sprintf("%s/variants/%d/cases/%d/properties", ruleRef, v, c)
+				results = append(results, checkDuplicateVariantPropRefsV1(kase.Properties, caseRef)...)
+			}
+			defaultRef := fmt.Sprintf("%s/variants/%d/default/properties", ruleRef, v)
+			results = append(results, checkDuplicateVariantPropRefsV1(variant.Default.Properties, defaultRef)...)
+		}
+	}
+
+	return results
+}
+
+// checkDuplicateSiblingPropsV1 dedupes one list of TPRulePropertyV1 and
+// recurses into nested Properties. Each nested list is its own sibling scope.
+func checkDuplicateSiblingPropsV1(props []*localcatalog.TPRulePropertyV1, parentRef string) []rules.ValidationResult {
+	counts := make(map[string]int)
+	for _, prop := range props {
+		counts[prop.Property]++
+	}
+
+	var results []rules.ValidationResult
+	for i, prop := range props {
+		if counts[prop.Property] > 1 {
+			results = append(results, rules.ValidationResult{
+				Reference: fmt.Sprintf("%s/%d/property", parentRef, i),
+				Message:   fmt.Sprintf("duplicate property reference '%s' (appears %d times)", prop.Property, counts[prop.Property]),
+			})
+		}
+		if len(prop.Properties) > 0 {
+			nestedRef := fmt.Sprintf("%s/%d/properties", parentRef, i)
+			results = append(results, checkDuplicateSiblingPropsV1(prop.Properties, nestedRef)...)
+		}
+	}
+	return results
+}
+
+// checkDuplicateVariantPropRefsV1 dedupes a flat list of variant property refs.
+// Variant property refs use PropertyReferenceV1 and do not recurse.
+func checkDuplicateVariantPropRefsV1(props []localcatalog.PropertyReferenceV1, parentRef string) []rules.ValidationResult {
+	counts := make(map[string]int)
+	for _, prop := range props {
+		counts[prop.Property]++
+	}
+
+	var results []rules.ValidationResult
+	for i, prop := range props {
+		if counts[prop.Property] > 1 {
+			results = append(results, rules.ValidationResult{
+				Reference: fmt.Sprintf("%s/%d/property", parentRef, i),
+				Message:   fmt.Sprintf("duplicate property reference '%s' (appears %d times)", prop.Property, counts[prop.Property]),
+			})
+		}
+	}
 	return results
 }
 

--- a/cli/internal/providers/datacatalog/rules/trackingplan/trackingplan_semantic_valid.go
+++ b/cli/internal/providers/datacatalog/rules/trackingplan/trackingplan_semantic_valid.go
@@ -82,7 +82,7 @@ func checkDuplicateSiblingPropsV0(props []*localcatalog.TPRuleProperty, parentRe
 		if counts[prop.Ref] > 1 {
 			results = append(results, rules.ValidationResult{
 				Reference: fmt.Sprintf("%s/%d/$ref", parentRef, i),
-				Message:   "duplicate property reference in tracking plan rules",
+				Message:   "duplicate property reference in tracking plan event rule",
 			})
 		}
 		if len(prop.Properties) > 0 {
@@ -104,7 +104,7 @@ func checkDuplicateVariantPropRefsV0(props []localcatalog.PropertyReference, par
 		if counts[prop.Ref] > 1 {
 			results = append(results, rules.ValidationResult{
 				Reference: fmt.Sprintf("%s/%d/$ref", parentRef, i),
-				Message:   "duplicate property reference in tracking plan rules",
+				Message:   "duplicate property reference in tracking plan event rule",
 			})
 		}
 	}

--- a/cli/internal/providers/datacatalog/rules/trackingplan/trackingplan_semantic_valid.go
+++ b/cli/internal/providers/datacatalog/rules/trackingplan/trackingplan_semantic_valid.go
@@ -40,11 +40,10 @@ func validateDuplicateEventsV0(spec localcatalog.TrackingPlan) []rules.Validatio
 		if rule.Event == nil {
 			continue
 		}
-		ref := rule.Event.Ref
-		if counts[ref] > 1 {
+		if counts[rule.Event.Ref] > 1 {
 			results = append(results, rules.ValidationResult{
 				Reference: fmt.Sprintf("/rules/%d/event/$ref", i),
-				Message:   fmt.Sprintf("duplicate event reference '%s' (appears %d times)", ref, counts[ref]),
+				Message:   "duplicate event reference in tracking plan rules",
 			})
 		}
 	}
@@ -83,7 +82,7 @@ func checkDuplicateSiblingPropsV0(props []*localcatalog.TPRuleProperty, parentRe
 		if counts[prop.Ref] > 1 {
 			results = append(results, rules.ValidationResult{
 				Reference: fmt.Sprintf("%s/%d/$ref", parentRef, i),
-				Message:   fmt.Sprintf("duplicate property reference '%s' (appears %d times)", prop.Ref, counts[prop.Ref]),
+				Message:   "duplicate property reference in tracking plan rules",
 			})
 		}
 		if len(prop.Properties) > 0 {
@@ -105,7 +104,7 @@ func checkDuplicateVariantPropRefsV0(props []localcatalog.PropertyReference, par
 		if counts[prop.Ref] > 1 {
 			results = append(results, rules.ValidationResult{
 				Reference: fmt.Sprintf("%s/%d/$ref", parentRef, i),
-				Message:   fmt.Sprintf("duplicate property reference '%s' (appears %d times)", prop.Ref, counts[prop.Ref]),
+				Message:   "duplicate property reference in tracking plan rules",
 			})
 		}
 	}

--- a/cli/internal/providers/datacatalog/rules/trackingplan/trackingplan_semantic_valid.go
+++ b/cli/internal/providers/datacatalog/rules/trackingplan/trackingplan_semantic_valid.go
@@ -26,8 +26,6 @@ var validateTrackingPlanSemantic = func(_ string, _ string, _ map[string]any, sp
 	return results
 }
 
-// validateDuplicateEventsV0 emits one error per occurrence of any event ref
-// that appears more than once across rules. Comparison is raw-string equality.
 func validateDuplicateEventsV0(spec localcatalog.TrackingPlan) []rules.ValidationResult {
 	counts := make(map[string]int)
 	for _, rule := range spec.Rules {
@@ -53,9 +51,6 @@ func validateDuplicateEventsV0(spec localcatalog.TrackingPlan) []rules.Validatio
 	return results
 }
 
-// validateDuplicatePropertiesV0 walks each rule and dedupes property refs at
-// every sibling scope: rule.Properties (and recursively), variants[*].cases[*].properties,
-// and variants[*].default. Each sibling list is an independent scope.
 func validateDuplicatePropertiesV0(spec localcatalog.TrackingPlan) []rules.ValidationResult {
 	var results []rules.ValidationResult
 
@@ -65,9 +60,9 @@ func validateDuplicatePropertiesV0(spec localcatalog.TrackingPlan) []rules.Valid
 		results = append(results, checkDuplicateSiblingPropsV0(rule.Properties, ruleRef+"/properties")...)
 
 		for v, variant := range rule.Variants {
-			for c, kase := range variant.Cases {
+			for c, vCase := range variant.Cases {
 				caseRef := fmt.Sprintf("%s/variants/%d/cases/%d/properties", ruleRef, v, c)
-				results = append(results, checkDuplicateVariantPropRefsV0(kase.Properties, caseRef)...)
+				results = append(results, checkDuplicateVariantPropRefsV0(vCase.Properties, caseRef)...)
 			}
 			defaultRef := fmt.Sprintf("%s/variants/%d/default", ruleRef, v)
 			results = append(results, checkDuplicateVariantPropRefsV0(variant.Default, defaultRef)...)
@@ -77,8 +72,6 @@ func validateDuplicatePropertiesV0(spec localcatalog.TrackingPlan) []rules.Valid
 	return results
 }
 
-// checkDuplicateSiblingPropsV0 dedupes one list of TPRuleProperty and recurses
-// into nested Properties. Each nested list is its own sibling scope.
 func checkDuplicateSiblingPropsV0(props []*localcatalog.TPRuleProperty, parentRef string) []rules.ValidationResult {
 	counts := make(map[string]int)
 	for _, prop := range props {
@@ -101,8 +94,6 @@ func checkDuplicateSiblingPropsV0(props []*localcatalog.TPRuleProperty, parentRe
 	return results
 }
 
-// checkDuplicateVariantPropRefsV0 dedupes a flat list of variant property refs.
-// Variant property refs use PropertyReference and do not recurse.
 func checkDuplicateVariantPropRefsV0(props []localcatalog.PropertyReference, parentRef string) []rules.ValidationResult {
 	counts := make(map[string]int)
 	for _, prop := range props {

--- a/cli/internal/providers/datacatalog/rules/trackingplan/trackingplan_semantic_valid.go
+++ b/cli/internal/providers/datacatalog/rules/trackingplan/trackingplan_semantic_valid.go
@@ -55,17 +55,7 @@ func validateDuplicatePropertiesV0(spec localcatalog.TrackingPlan) []rules.Valid
 
 	for i, rule := range spec.Rules {
 		ruleRef := fmt.Sprintf("/rules/%d", i)
-
 		results = append(results, checkDuplicateSiblingPropsV0(rule.Properties, ruleRef+"/properties")...)
-
-		for v, variant := range rule.Variants {
-			for c, vCase := range variant.Cases {
-				caseRef := fmt.Sprintf("%s/variants/%d/cases/%d/properties", ruleRef, v, c)
-				results = append(results, checkDuplicateVariantPropRefsV0(vCase.Properties, caseRef)...)
-			}
-			defaultRef := fmt.Sprintf("%s/variants/%d/default", ruleRef, v)
-			results = append(results, checkDuplicateVariantPropRefsV0(variant.Default, defaultRef)...)
-		}
 	}
 
 	return results
@@ -93,36 +83,21 @@ func checkDuplicateSiblingPropsV0(props []*localcatalog.TPRuleProperty, parentRe
 	return results
 }
 
-func checkDuplicateVariantPropRefsV0(props []localcatalog.PropertyReference, parentRef string) []rules.ValidationResult {
-	counts := make(map[string]int)
-	for _, prop := range props {
-		counts[prop.Ref]++
-	}
-
-	var results []rules.ValidationResult
-	for i, prop := range props {
-		if counts[prop.Ref] > 1 {
-			results = append(results, rules.ValidationResult{
-				Reference: fmt.Sprintf("%s/%d/$ref", parentRef, i),
-				Message:   "duplicate property reference in tracking plan event rule",
-			})
-		}
-	}
-	return results
-}
-
 func validateTrackingPlanVariants(spec localcatalog.TrackingPlan, graph *resources.Graph) []rules.ValidationResult {
 	var results []rules.ValidationResult
 	for i, rule := range spec.Rules {
 		if len(rule.Variants) == 0 {
 			continue
 		}
+
+		ruleRef := fmt.Sprintf("/rules/%d", i)
+
 		ownRefs := make([]string, 0, len(rule.Properties))
 		for _, prop := range rule.Properties {
 			ownRefs = append(ownRefs, prop.Ref)
 		}
-		results = append(results, variant.ValidateVariantDiscriminatorsV0(
-			rule.Variants, ownRefs, fmt.Sprintf("/rules/%d", i), graph,
+		results = append(results, variant.ValidateVariantSemanticV0(
+			rule.Variants, ownRefs, ruleRef, graph,
 		)...)
 	}
 

--- a/cli/internal/providers/datacatalog/rules/trackingplan/trackingplan_semantic_valid.go
+++ b/cli/internal/providers/datacatalog/rules/trackingplan/trackingplan_semantic_valid.go
@@ -20,7 +20,104 @@ var validateTrackingPlanSemantic = func(_ string, _ string, _ map[string]any, sp
 	results = append(results, validateTrackingPlanVariants(spec, graph)...)
 	results = append(results, validatePropertyNestingV0(spec, graph)...)
 	results = append(results, validateTrackingPlanNameUniquenessV0(spec, graph)...)
+	results = append(results, validateDuplicateEventsV0(spec)...)
+	results = append(results, validateDuplicatePropertiesV0(spec)...)
 
+	return results
+}
+
+// validateDuplicateEventsV0 emits one error per occurrence of any event ref
+// that appears more than once across rules. Comparison is raw-string equality.
+func validateDuplicateEventsV0(spec localcatalog.TrackingPlan) []rules.ValidationResult {
+	counts := make(map[string]int)
+	for _, rule := range spec.Rules {
+		if rule.Event == nil {
+			continue
+		}
+		counts[rule.Event.Ref]++
+	}
+
+	var results []rules.ValidationResult
+	for i, rule := range spec.Rules {
+		if rule.Event == nil {
+			continue
+		}
+		ref := rule.Event.Ref
+		if counts[ref] > 1 {
+			results = append(results, rules.ValidationResult{
+				Reference: fmt.Sprintf("/rules/%d/event/$ref", i),
+				Message:   fmt.Sprintf("duplicate event reference '%s' (appears %d times)", ref, counts[ref]),
+			})
+		}
+	}
+	return results
+}
+
+// validateDuplicatePropertiesV0 walks each rule and dedupes property refs at
+// every sibling scope: rule.Properties (and recursively), variants[*].cases[*].properties,
+// and variants[*].default. Each sibling list is an independent scope.
+func validateDuplicatePropertiesV0(spec localcatalog.TrackingPlan) []rules.ValidationResult {
+	var results []rules.ValidationResult
+
+	for i, rule := range spec.Rules {
+		ruleRef := fmt.Sprintf("/rules/%d", i)
+
+		results = append(results, checkDuplicateSiblingPropsV0(rule.Properties, ruleRef+"/properties")...)
+
+		for v, variant := range rule.Variants {
+			for c, kase := range variant.Cases {
+				caseRef := fmt.Sprintf("%s/variants/%d/cases/%d/properties", ruleRef, v, c)
+				results = append(results, checkDuplicateVariantPropRefsV0(kase.Properties, caseRef)...)
+			}
+			defaultRef := fmt.Sprintf("%s/variants/%d/default", ruleRef, v)
+			results = append(results, checkDuplicateVariantPropRefsV0(variant.Default, defaultRef)...)
+		}
+	}
+
+	return results
+}
+
+// checkDuplicateSiblingPropsV0 dedupes one list of TPRuleProperty and recurses
+// into nested Properties. Each nested list is its own sibling scope.
+func checkDuplicateSiblingPropsV0(props []*localcatalog.TPRuleProperty, parentRef string) []rules.ValidationResult {
+	counts := make(map[string]int)
+	for _, prop := range props {
+		counts[prop.Ref]++
+	}
+
+	var results []rules.ValidationResult
+	for i, prop := range props {
+		if counts[prop.Ref] > 1 {
+			results = append(results, rules.ValidationResult{
+				Reference: fmt.Sprintf("%s/%d/$ref", parentRef, i),
+				Message:   fmt.Sprintf("duplicate property reference '%s' (appears %d times)", prop.Ref, counts[prop.Ref]),
+			})
+		}
+		if len(prop.Properties) > 0 {
+			nestedRef := fmt.Sprintf("%s/%d/properties", parentRef, i)
+			results = append(results, checkDuplicateSiblingPropsV0(prop.Properties, nestedRef)...)
+		}
+	}
+	return results
+}
+
+// checkDuplicateVariantPropRefsV0 dedupes a flat list of variant property refs.
+// Variant property refs use PropertyReference and do not recurse.
+func checkDuplicateVariantPropRefsV0(props []localcatalog.PropertyReference, parentRef string) []rules.ValidationResult {
+	counts := make(map[string]int)
+	for _, prop := range props {
+		counts[prop.Ref]++
+	}
+
+	var results []rules.ValidationResult
+	for i, prop := range props {
+		if counts[prop.Ref] > 1 {
+			results = append(results, rules.ValidationResult{
+				Reference: fmt.Sprintf("%s/%d/$ref", parentRef, i),
+				Message:   fmt.Sprintf("duplicate property reference '%s' (appears %d times)", prop.Ref, counts[prop.Ref]),
+			})
+		}
+	}
 	return results
 }
 

--- a/cli/internal/providers/datacatalog/rules/trackingplan/trackingplan_semantic_validation_test.go
+++ b/cli/internal/providers/datacatalog/rules/trackingplan/trackingplan_semantic_validation_test.go
@@ -1148,8 +1148,8 @@ func TestTrackingPlanSemanticValid_DuplicateEventsV0(t *testing.T) {
 
 		results := validateDuplicateEventsV0(spec)
 		assert.Equal(t, []rules.ValidationResult{
-			{Reference: "/rules/0/event/$ref", Message: "duplicate event reference '#event:signup' (appears 2 times)"},
-			{Reference: "/rules/2/event/$ref", Message: "duplicate event reference '#event:signup' (appears 2 times)"},
+			{Reference: "/rules/0/event/$ref", Message: "duplicate event reference in tracking plan rules"},
+			{Reference: "/rules/2/event/$ref", Message: "duplicate event reference in tracking plan rules"},
 		}, results)
 	})
 
@@ -1218,8 +1218,8 @@ func TestTrackingPlanSemanticValid_DuplicatePropertiesV0(t *testing.T) {
 
 		results := validateDuplicatePropertiesV0(spec)
 		assert.Equal(t, []rules.ValidationResult{
-			{Reference: "/rules/0/properties/0/$ref", Message: "duplicate property reference '#property:email' (appears 2 times)"},
-			{Reference: "/rules/0/properties/2/$ref", Message: "duplicate property reference '#property:email' (appears 2 times)"},
+			{Reference: "/rules/0/properties/0/$ref", Message: "duplicate property reference in tracking plan rules"},
+			{Reference: "/rules/0/properties/2/$ref", Message: "duplicate property reference in tracking plan rules"},
 		}, results)
 	})
 
@@ -1248,8 +1248,8 @@ func TestTrackingPlanSemanticValid_DuplicatePropertiesV0(t *testing.T) {
 
 		results := validateDuplicatePropertiesV0(spec)
 		assert.Equal(t, []rules.ValidationResult{
-			{Reference: "/rules/0/properties/0/properties/0/$ref", Message: "duplicate property reference '#property:city' (appears 2 times)"},
-			{Reference: "/rules/0/properties/0/properties/1/$ref", Message: "duplicate property reference '#property:city' (appears 2 times)"},
+			{Reference: "/rules/0/properties/0/properties/0/$ref", Message: "duplicate property reference in tracking plan rules"},
+			{Reference: "/rules/0/properties/0/properties/1/$ref", Message: "duplicate property reference in tracking plan rules"},
 		}, results)
 	})
 
@@ -1342,8 +1342,8 @@ func TestTrackingPlanSemanticValid_DuplicatePropertiesV0(t *testing.T) {
 
 		results := validateDuplicatePropertiesV0(spec)
 		assert.Equal(t, []rules.ValidationResult{
-			{Reference: "/rules/0/variants/0/cases/0/properties/0/$ref", Message: "duplicate property reference '#property:email' (appears 2 times)"},
-			{Reference: "/rules/0/variants/0/cases/0/properties/1/$ref", Message: "duplicate property reference '#property:email' (appears 2 times)"},
+			{Reference: "/rules/0/variants/0/cases/0/properties/0/$ref", Message: "duplicate property reference in tracking plan rules"},
+			{Reference: "/rules/0/variants/0/cases/0/properties/1/$ref", Message: "duplicate property reference in tracking plan rules"},
 		}, results)
 	})
 
@@ -1381,8 +1381,8 @@ func TestTrackingPlanSemanticValid_DuplicatePropertiesV0(t *testing.T) {
 
 		results := validateDuplicatePropertiesV0(spec)
 		assert.Equal(t, []rules.ValidationResult{
-			{Reference: "/rules/0/variants/0/default/0/$ref", Message: "duplicate property reference '#property:user_id' (appears 2 times)"},
-			{Reference: "/rules/0/variants/0/default/1/$ref", Message: "duplicate property reference '#property:user_id' (appears 2 times)"},
+			{Reference: "/rules/0/variants/0/default/0/$ref", Message: "duplicate property reference in tracking plan rules"},
+			{Reference: "/rules/0/variants/0/default/1/$ref", Message: "duplicate property reference in tracking plan rules"},
 		}, results)
 	})
 
@@ -1456,9 +1456,9 @@ func TestTrackingPlanSemanticValid_DuplicateEventsV1(t *testing.T) {
 
 		results := validateDuplicateEventsV1(spec)
 		assert.Equal(t, []rules.ValidationResult{
-			{Reference: "/rules/0/event", Message: "duplicate event reference '#event:signup' (appears 3 times)"},
-			{Reference: "/rules/1/event", Message: "duplicate event reference '#event:signup' (appears 3 times)"},
-			{Reference: "/rules/2/event", Message: "duplicate event reference '#event:signup' (appears 3 times)"},
+			{Reference: "/rules/0/event", Message: "duplicate event reference in tracking plan rules"},
+			{Reference: "/rules/1/event", Message: "duplicate event reference in tracking plan rules"},
+			{Reference: "/rules/2/event", Message: "duplicate event reference in tracking plan rules"},
 		}, results)
 	})
 }
@@ -1508,8 +1508,8 @@ func TestTrackingPlanSemanticValid_DuplicatePropertiesV1(t *testing.T) {
 
 		results := validateDuplicatePropertiesV1(spec)
 		assert.Equal(t, []rules.ValidationResult{
-			{Reference: "/rules/0/properties/0/property", Message: "duplicate property reference '#property:email' (appears 2 times)"},
-			{Reference: "/rules/0/properties/1/property", Message: "duplicate property reference '#property:email' (appears 2 times)"},
+			{Reference: "/rules/0/properties/0/property", Message: "duplicate property reference in tracking plan rules"},
+			{Reference: "/rules/0/properties/1/property", Message: "duplicate property reference in tracking plan rules"},
 		}, results)
 	})
 
@@ -1538,8 +1538,8 @@ func TestTrackingPlanSemanticValid_DuplicatePropertiesV1(t *testing.T) {
 
 		results := validateDuplicatePropertiesV1(spec)
 		assert.Equal(t, []rules.ValidationResult{
-			{Reference: "/rules/0/properties/0/properties/0/property", Message: "duplicate property reference '#property:city' (appears 2 times)"},
-			{Reference: "/rules/0/properties/0/properties/1/property", Message: "duplicate property reference '#property:city' (appears 2 times)"},
+			{Reference: "/rules/0/properties/0/properties/0/property", Message: "duplicate property reference in tracking plan rules"},
+			{Reference: "/rules/0/properties/0/properties/1/property", Message: "duplicate property reference in tracking plan rules"},
 		}, results)
 	})
 
@@ -1601,8 +1601,8 @@ func TestTrackingPlanSemanticValid_DuplicatePropertiesV1(t *testing.T) {
 
 		results := validateDuplicatePropertiesV1(spec)
 		assert.Equal(t, []rules.ValidationResult{
-			{Reference: "/rules/0/variants/0/cases/0/properties/0/property", Message: "duplicate property reference '#property:email' (appears 2 times)"},
-			{Reference: "/rules/0/variants/0/cases/0/properties/1/property", Message: "duplicate property reference '#property:email' (appears 2 times)"},
+			{Reference: "/rules/0/variants/0/cases/0/properties/0/property", Message: "duplicate property reference in tracking plan rules"},
+			{Reference: "/rules/0/variants/0/cases/0/properties/1/property", Message: "duplicate property reference in tracking plan rules"},
 		}, results)
 	})
 
@@ -1643,8 +1643,8 @@ func TestTrackingPlanSemanticValid_DuplicatePropertiesV1(t *testing.T) {
 
 		results := validateDuplicatePropertiesV1(spec)
 		assert.Equal(t, []rules.ValidationResult{
-			{Reference: "/rules/0/variants/0/default/properties/0/property", Message: "duplicate property reference '#property:user_id' (appears 2 times)"},
-			{Reference: "/rules/0/variants/0/default/properties/1/property", Message: "duplicate property reference '#property:user_id' (appears 2 times)"},
+			{Reference: "/rules/0/variants/0/default/properties/0/property", Message: "duplicate property reference in tracking plan rules"},
+			{Reference: "/rules/0/variants/0/default/properties/1/property", Message: "duplicate property reference in tracking plan rules"},
 		}, results)
 	})
 

--- a/cli/internal/providers/datacatalog/rules/trackingplan/trackingplan_semantic_validation_test.go
+++ b/cli/internal/providers/datacatalog/rules/trackingplan/trackingplan_semantic_validation_test.go
@@ -1218,8 +1218,8 @@ func TestTrackingPlanSemanticValid_DuplicatePropertiesV0(t *testing.T) {
 
 		results := validateDuplicatePropertiesV0(spec)
 		assert.Equal(t, []rules.ValidationResult{
-			{Reference: "/rules/0/properties/0/$ref", Message: "duplicate property reference in tracking plan rules"},
-			{Reference: "/rules/0/properties/2/$ref", Message: "duplicate property reference in tracking plan rules"},
+			{Reference: "/rules/0/properties/0/$ref", Message: "duplicate property reference in tracking plan event rule"},
+			{Reference: "/rules/0/properties/2/$ref", Message: "duplicate property reference in tracking plan event rule"},
 		}, results)
 	})
 
@@ -1248,8 +1248,8 @@ func TestTrackingPlanSemanticValid_DuplicatePropertiesV0(t *testing.T) {
 
 		results := validateDuplicatePropertiesV0(spec)
 		assert.Equal(t, []rules.ValidationResult{
-			{Reference: "/rules/0/properties/0/properties/0/$ref", Message: "duplicate property reference in tracking plan rules"},
-			{Reference: "/rules/0/properties/0/properties/1/$ref", Message: "duplicate property reference in tracking plan rules"},
+			{Reference: "/rules/0/properties/0/properties/0/$ref", Message: "duplicate property reference in tracking plan event rule"},
+			{Reference: "/rules/0/properties/0/properties/1/$ref", Message: "duplicate property reference in tracking plan event rule"},
 		}, results)
 	})
 
@@ -1342,8 +1342,8 @@ func TestTrackingPlanSemanticValid_DuplicatePropertiesV0(t *testing.T) {
 
 		results := validateDuplicatePropertiesV0(spec)
 		assert.Equal(t, []rules.ValidationResult{
-			{Reference: "/rules/0/variants/0/cases/0/properties/0/$ref", Message: "duplicate property reference in tracking plan rules"},
-			{Reference: "/rules/0/variants/0/cases/0/properties/1/$ref", Message: "duplicate property reference in tracking plan rules"},
+			{Reference: "/rules/0/variants/0/cases/0/properties/0/$ref", Message: "duplicate property reference in tracking plan event rule"},
+			{Reference: "/rules/0/variants/0/cases/0/properties/1/$ref", Message: "duplicate property reference in tracking plan event rule"},
 		}, results)
 	})
 
@@ -1381,8 +1381,8 @@ func TestTrackingPlanSemanticValid_DuplicatePropertiesV0(t *testing.T) {
 
 		results := validateDuplicatePropertiesV0(spec)
 		assert.Equal(t, []rules.ValidationResult{
-			{Reference: "/rules/0/variants/0/default/0/$ref", Message: "duplicate property reference in tracking plan rules"},
-			{Reference: "/rules/0/variants/0/default/1/$ref", Message: "duplicate property reference in tracking plan rules"},
+			{Reference: "/rules/0/variants/0/default/0/$ref", Message: "duplicate property reference in tracking plan event rule"},
+			{Reference: "/rules/0/variants/0/default/1/$ref", Message: "duplicate property reference in tracking plan event rule"},
 		}, results)
 	})
 
@@ -1508,8 +1508,8 @@ func TestTrackingPlanSemanticValid_DuplicatePropertiesV1(t *testing.T) {
 
 		results := validateDuplicatePropertiesV1(spec)
 		assert.Equal(t, []rules.ValidationResult{
-			{Reference: "/rules/0/properties/0/property", Message: "duplicate property reference in tracking plan rules"},
-			{Reference: "/rules/0/properties/1/property", Message: "duplicate property reference in tracking plan rules"},
+			{Reference: "/rules/0/properties/0/property", Message: "duplicate property reference in tracking plan event rule"},
+			{Reference: "/rules/0/properties/1/property", Message: "duplicate property reference in tracking plan event rule"},
 		}, results)
 	})
 
@@ -1538,8 +1538,8 @@ func TestTrackingPlanSemanticValid_DuplicatePropertiesV1(t *testing.T) {
 
 		results := validateDuplicatePropertiesV1(spec)
 		assert.Equal(t, []rules.ValidationResult{
-			{Reference: "/rules/0/properties/0/properties/0/property", Message: "duplicate property reference in tracking plan rules"},
-			{Reference: "/rules/0/properties/0/properties/1/property", Message: "duplicate property reference in tracking plan rules"},
+			{Reference: "/rules/0/properties/0/properties/0/property", Message: "duplicate property reference in tracking plan event rule"},
+			{Reference: "/rules/0/properties/0/properties/1/property", Message: "duplicate property reference in tracking plan event rule"},
 		}, results)
 	})
 
@@ -1601,8 +1601,8 @@ func TestTrackingPlanSemanticValid_DuplicatePropertiesV1(t *testing.T) {
 
 		results := validateDuplicatePropertiesV1(spec)
 		assert.Equal(t, []rules.ValidationResult{
-			{Reference: "/rules/0/variants/0/cases/0/properties/0/property", Message: "duplicate property reference in tracking plan rules"},
-			{Reference: "/rules/0/variants/0/cases/0/properties/1/property", Message: "duplicate property reference in tracking plan rules"},
+			{Reference: "/rules/0/variants/0/cases/0/properties/0/property", Message: "duplicate property reference in tracking plan event rule"},
+			{Reference: "/rules/0/variants/0/cases/0/properties/1/property", Message: "duplicate property reference in tracking plan event rule"},
 		}, results)
 	})
 
@@ -1643,8 +1643,8 @@ func TestTrackingPlanSemanticValid_DuplicatePropertiesV1(t *testing.T) {
 
 		results := validateDuplicatePropertiesV1(spec)
 		assert.Equal(t, []rules.ValidationResult{
-			{Reference: "/rules/0/variants/0/default/properties/0/property", Message: "duplicate property reference in tracking plan rules"},
-			{Reference: "/rules/0/variants/0/default/properties/1/property", Message: "duplicate property reference in tracking plan rules"},
+			{Reference: "/rules/0/variants/0/default/properties/0/property", Message: "duplicate property reference in tracking plan event rule"},
+			{Reference: "/rules/0/variants/0/default/properties/1/property", Message: "duplicate property reference in tracking plan event rule"},
 		}, results)
 	})
 

--- a/cli/internal/providers/datacatalog/rules/trackingplan/trackingplan_semantic_validation_test.go
+++ b/cli/internal/providers/datacatalog/rules/trackingplan/trackingplan_semantic_validation_test.go
@@ -15,6 +15,10 @@ import (
 	_ "github.com/rudderlabs/rudder-iac/cli/internal/providers/datacatalog/rules"
 )
 
+// V0 specs are internally converted to V1 ref style before semantic validation runs.
+// Tests in this file use V1-style refs (e.g. #property:email) for V0 specs,
+// not the legacy format (e.g. #/properties/group/email).
+
 // propertyResourceWithType creates a property resource with a specific type.
 func propertyResourceWithType(id, name, typ string) *resources.Resource {
 	data := resources.ResourceData{"name": name, "type": typ}
@@ -1133,7 +1137,7 @@ func TestTrackingPlanSemanticValid_DuplicateEventsV0(t *testing.T) {
 		assert.Empty(t, results)
 	})
 
-	t.Run("two rules share raw event ref — both reported", func(t *testing.T) {
+	t.Run("duplicate event refs reported at every occurrence", func(t *testing.T) {
 		t.Parallel()
 
 		spec := localcatalog.TrackingPlan{
@@ -1311,8 +1315,22 @@ func TestTrackingPlanSemanticValid_DuplicatePropertiesV0(t *testing.T) {
 		assert.Empty(t, results)
 	})
 
-	t.Run("duplicate in variant case properties", func(t *testing.T) {
+}
+
+func TestTrackingPlanSemanticValid_VariantDuplicatePropertiesV0(t *testing.T) {
+	t.Parallel()
+
+	t.Run("duplicate in case and default properties", func(t *testing.T) {
 		t.Parallel()
+
+		graph := funcs.GraphWith(
+			"signup", "event",
+			"email", "property",
+			"name", "property",
+			"user_id", "property",
+			"method", "property",
+		)
+		graph.AddResource(propertyResourceWithType("method", "Method", "string"))
 
 		spec := localcatalog.TrackingPlan{
 			LocalID: "tp1",
@@ -1320,7 +1338,11 @@ func TestTrackingPlanSemanticValid_DuplicatePropertiesV0(t *testing.T) {
 			Rules: []*localcatalog.TPRule{
 				{
 					LocalID: "r1",
-					Event:   event,
+					Event:   &localcatalog.TPRuleEvent{Ref: "#event:signup"},
+					Properties: []*localcatalog.TPRuleProperty{
+						{Ref: "#property:email"},
+						{Ref: "#property:method"},
+					},
 					Variants: localcatalog.Variants{
 						{
 							Type:          "discriminator",
@@ -1329,49 +1351,22 @@ func TestTrackingPlanSemanticValid_DuplicatePropertiesV0(t *testing.T) {
 								{
 									DisplayName: "Case 1",
 									Properties: []localcatalog.PropertyReference{
-										{Ref: "#property:email"},
-										{Ref: "#property:email"},
+										{Ref: "#/properties/props/email"},
+										{Ref: "#/properties/props/name"},
+										{Ref: "#/properties/props/email"},
 									},
 								},
-							},
-						},
-					},
-				},
-			},
-		}
-
-		results := validateDuplicatePropertiesV0(spec)
-		assert.Equal(t, []rules.ValidationResult{
-			{Reference: "/rules/0/variants/0/cases/0/properties/0/$ref", Message: "duplicate property reference in tracking plan event rule"},
-			{Reference: "/rules/0/variants/0/cases/0/properties/1/$ref", Message: "duplicate property reference in tracking plan event rule"},
-		}, results)
-	})
-
-	t.Run("duplicate in variant default", func(t *testing.T) {
-		t.Parallel()
-
-		spec := localcatalog.TrackingPlan{
-			LocalID: "tp1",
-			Name:    "TP",
-			Rules: []*localcatalog.TPRule{
-				{
-					LocalID: "r1",
-					Event:   event,
-					Variants: localcatalog.Variants{
-						{
-							Type:          "discriminator",
-							Discriminator: "#property:method",
-							Cases: []localcatalog.VariantCase{
 								{
-									DisplayName: "Case 1",
+									DisplayName: "Case 2",
 									Properties: []localcatalog.PropertyReference{
-										{Ref: "#property:email"},
+										{Ref: "#/properties/props/name"},
 									},
 								},
 							},
 							Default: []localcatalog.PropertyReference{
-								{Ref: "#property:user_id"},
-								{Ref: "#property:user_id"},
+								{Ref: "#/properties/props/user_id"},
+								{Ref: "#/properties/props/name"},
+								{Ref: "#/properties/props/user_id"},
 							},
 						},
 					},
@@ -1379,46 +1374,28 @@ func TestTrackingPlanSemanticValid_DuplicatePropertiesV0(t *testing.T) {
 			},
 		}
 
-		results := validateDuplicatePropertiesV0(spec)
-		assert.Equal(t, []rules.ValidationResult{
-			{Reference: "/rules/0/variants/0/default/0/$ref", Message: "duplicate property reference in tracking plan event rule"},
-			{Reference: "/rules/0/variants/0/default/1/$ref", Message: "duplicate property reference in tracking plan event rule"},
-		}, results)
-	})
+		results := validateTrackingPlanSemantic(localcatalog.KindTrackingPlans, specs.SpecVersionV0_1, nil, spec, graph)
 
-	t.Run("same ref in case properties and rule properties is NOT a duplicate", func(t *testing.T) {
-		t.Parallel()
-
-		spec := localcatalog.TrackingPlan{
-			LocalID: "tp1",
-			Name:    "TP",
-			Rules: []*localcatalog.TPRule{
-				{
-					LocalID: "r1",
-					Event:   event,
-					Properties: []*localcatalog.TPRuleProperty{
-						{Ref: "#property:email"},
-					},
-					Variants: localcatalog.Variants{
-						{
-							Type:          "discriminator",
-							Discriminator: "#property:method",
-							Cases: []localcatalog.VariantCase{
-								{
-									DisplayName: "Case 1",
-									Properties: []localcatalog.PropertyReference{
-										{Ref: "#property:email"},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		}
-
-		results := validateDuplicatePropertiesV0(spec)
-		assert.Empty(t, results)
+		assert.Contains(t, results, rules.ValidationResult{
+			Reference: "/rules/0/variants/0/cases/0/properties/0/$ref",
+			Message:   "duplicate property reference in tracking plan event rule",
+		})
+		assert.Contains(t, results, rules.ValidationResult{
+			Reference: "/rules/0/variants/0/cases/0/properties/2/$ref",
+			Message:   "duplicate property reference in tracking plan event rule",
+		})
+		assert.Contains(t, results, rules.ValidationResult{
+			Reference: "/rules/0/variants/0/default/0/$ref",
+			Message:   "duplicate property reference in tracking plan event rule",
+		})
+		assert.Contains(t, results, rules.ValidationResult{
+			Reference: "/rules/0/variants/0/default/2/$ref",
+			Message:   "duplicate property reference in tracking plan event rule",
+		})
+		assert.NotContains(t, results, rules.ValidationResult{
+			Reference: "/rules/0/variants/0/cases/1/properties/0/$ref",
+			Message:   "duplicate property reference in tracking plan event rule",
+		})
 	})
 }
 
@@ -1569,16 +1546,33 @@ func TestTrackingPlanSemanticValid_DuplicatePropertiesV1(t *testing.T) {
 		assert.Empty(t, results)
 	})
 
-	t.Run("duplicate in variant case properties", func(t *testing.T) {
+}
+
+func TestTrackingPlanSemanticValid_VariantDuplicatePropertiesV1(t *testing.T) {
+	t.Parallel()
+
+	t.Run("duplicate in case and default properties", func(t *testing.T) {
 		t.Parallel()
+
+		graph := resources.NewGraph()
+		graph.AddResource(resources.NewResource("signup", "event", resources.ResourceData{}, nil))
+		graph.AddResource(propertyResourceWithType("email", "Email", "string"))
+		graph.AddResource(propertyResourceWithType("name", "Name", "string"))
+		graph.AddResource(propertyResourceWithType("user_id", "User ID", "string"))
+		graph.AddResource(propertyResourceWithType("method", "Method", "string"))
 
 		spec := localcatalog.TrackingPlanV1{
 			LocalID: "tp1",
 			Name:    "TP",
 			Rules: []*localcatalog.TPRuleV1{
 				{
+					Type:    "event_rule",
 					LocalID: "r1",
 					Event:   "#event:signup",
+					Properties: []*localcatalog.TPRulePropertyV1{
+						{Property: "#property:email"},
+						{Property: "#property:method"},
+					},
 					Variants: localcatalog.VariantsV1{
 						{
 							Type:          "discriminator",
@@ -1589,49 +1583,22 @@ func TestTrackingPlanSemanticValid_DuplicatePropertiesV1(t *testing.T) {
 									Match:       []any{"a"},
 									Properties: []localcatalog.PropertyReferenceV1{
 										{Property: "#property:email"},
+										{Property: "#property:name"},
 										{Property: "#property:email"},
 									},
 								},
-							},
-						},
-					},
-				},
-			},
-		}
-
-		results := validateDuplicatePropertiesV1(spec)
-		assert.Equal(t, []rules.ValidationResult{
-			{Reference: "/rules/0/variants/0/cases/0/properties/0/property", Message: "duplicate property reference in tracking plan event rule"},
-			{Reference: "/rules/0/variants/0/cases/0/properties/1/property", Message: "duplicate property reference in tracking plan event rule"},
-		}, results)
-	})
-
-	t.Run("duplicate in variant default.properties", func(t *testing.T) {
-		t.Parallel()
-
-		spec := localcatalog.TrackingPlanV1{
-			LocalID: "tp1",
-			Name:    "TP",
-			Rules: []*localcatalog.TPRuleV1{
-				{
-					LocalID: "r1",
-					Event:   "#event:signup",
-					Variants: localcatalog.VariantsV1{
-						{
-							Type:          "discriminator",
-							Discriminator: "#property:method",
-							Cases: []localcatalog.VariantCaseV1{
 								{
-									DisplayName: "Case 1",
-									Match:       []any{"a"},
+									DisplayName: "Case 2",
+									Match:       []any{"b"},
 									Properties: []localcatalog.PropertyReferenceV1{
-										{Property: "#property:email"},
+										{Property: "#property:name"},
 									},
 								},
 							},
 							Default: localcatalog.DefaultPropertiesV1{
 								Properties: []localcatalog.PropertyReferenceV1{
 									{Property: "#property:user_id"},
+									{Property: "#property:name"},
 									{Property: "#property:user_id"},
 								},
 							},
@@ -1641,50 +1608,27 @@ func TestTrackingPlanSemanticValid_DuplicatePropertiesV1(t *testing.T) {
 			},
 		}
 
-		results := validateDuplicatePropertiesV1(spec)
-		assert.Equal(t, []rules.ValidationResult{
-			{Reference: "/rules/0/variants/0/default/properties/0/property", Message: "duplicate property reference in tracking plan event rule"},
-			{Reference: "/rules/0/variants/0/default/properties/1/property", Message: "duplicate property reference in tracking plan event rule"},
-		}, results)
-	})
+		results := validateTrackingPlanSemanticV1(localcatalog.KindTrackingPlansV1, specs.SpecVersionV1, nil, spec, graph)
 
-	t.Run("case A vs case B with same ref — NOT a duplicate", func(t *testing.T) {
-		t.Parallel()
-
-		spec := localcatalog.TrackingPlanV1{
-			LocalID: "tp1",
-			Name:    "TP",
-			Rules: []*localcatalog.TPRuleV1{
-				{
-					LocalID: "r1",
-					Event:   "#event:signup",
-					Variants: localcatalog.VariantsV1{
-						{
-							Type:          "discriminator",
-							Discriminator: "#property:method",
-							Cases: []localcatalog.VariantCaseV1{
-								{
-									DisplayName: "Case A",
-									Match:       []any{"a"},
-									Properties: []localcatalog.PropertyReferenceV1{
-										{Property: "#property:email"},
-									},
-								},
-								{
-									DisplayName: "Case B",
-									Match:       []any{"b"},
-									Properties: []localcatalog.PropertyReferenceV1{
-										{Property: "#property:email"},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		}
-
-		results := validateDuplicatePropertiesV1(spec)
-		assert.Empty(t, results)
+		assert.Contains(t, results, rules.ValidationResult{
+			Reference: "/rules/0/variants/0/cases/0/properties/0/property",
+			Message:   "duplicate property reference in tracking plan event rule",
+		})
+		assert.Contains(t, results, rules.ValidationResult{
+			Reference: "/rules/0/variants/0/cases/0/properties/2/property",
+			Message:   "duplicate property reference in tracking plan event rule",
+		})
+		assert.Contains(t, results, rules.ValidationResult{
+			Reference: "/rules/0/variants/0/default/properties/0/property",
+			Message:   "duplicate property reference in tracking plan event rule",
+		})
+		assert.Contains(t, results, rules.ValidationResult{
+			Reference: "/rules/0/variants/0/default/properties/2/property",
+			Message:   "duplicate property reference in tracking plan event rule",
+		})
+		assert.NotContains(t, results, rules.ValidationResult{
+			Reference: "/rules/0/variants/0/cases/1/properties/0/property",
+			Message:   "duplicate property reference in tracking plan event rule",
+		})
 	})
 }

--- a/cli/internal/providers/datacatalog/rules/trackingplan/trackingplan_semantic_validation_test.go
+++ b/cli/internal/providers/datacatalog/rules/trackingplan/trackingplan_semantic_validation_test.go
@@ -1113,3 +1113,578 @@ func TestTrackingPlanSemanticValid_V1VariantDiscriminator(t *testing.T) {
 		assert.Empty(t, results, "custom type ref with valid underlying string type — no errors")
 	})
 }
+
+func TestTrackingPlanSemanticValid_DuplicateEventsV0(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no duplicates", func(t *testing.T) {
+		t.Parallel()
+
+		spec := localcatalog.TrackingPlan{
+			LocalID: "tp1",
+			Name:    "TP",
+			Rules: []*localcatalog.TPRule{
+				{LocalID: "r1", Event: &localcatalog.TPRuleEvent{Ref: "#event:signup"}},
+				{LocalID: "r2", Event: &localcatalog.TPRuleEvent{Ref: "#event:login"}},
+			},
+		}
+
+		results := validateDuplicateEventsV0(spec)
+		assert.Empty(t, results)
+	})
+
+	t.Run("two rules share raw event ref — both reported", func(t *testing.T) {
+		t.Parallel()
+
+		spec := localcatalog.TrackingPlan{
+			LocalID: "tp1",
+			Name:    "TP",
+			Rules: []*localcatalog.TPRule{
+				{LocalID: "r1", Event: &localcatalog.TPRuleEvent{Ref: "#event:signup"}},
+				{LocalID: "r2", Event: &localcatalog.TPRuleEvent{Ref: "#event:login"}},
+				{LocalID: "r3", Event: &localcatalog.TPRuleEvent{Ref: "#event:signup"}},
+			},
+		}
+
+		results := validateDuplicateEventsV0(spec)
+		assert.Equal(t, []rules.ValidationResult{
+			{Reference: "/rules/0/event/$ref", Message: "duplicate event reference '#event:signup' (appears 2 times)"},
+			{Reference: "/rules/2/event/$ref", Message: "duplicate event reference '#event:signup' (appears 2 times)"},
+		}, results)
+	})
+
+	t.Run("same id across different V0 group paths is not a duplicate", func(t *testing.T) {
+		t.Parallel()
+
+		spec := localcatalog.TrackingPlan{
+			LocalID: "tp1",
+			Name:    "TP",
+			Rules: []*localcatalog.TPRule{
+				{LocalID: "r1", Event: &localcatalog.TPRuleEvent{Ref: "#/events/group-a/signup"}},
+				{LocalID: "r2", Event: &localcatalog.TPRuleEvent{Ref: "#/events/group-b/signup"}},
+			},
+		}
+
+		results := validateDuplicateEventsV0(spec)
+		assert.Empty(t, results)
+	})
+}
+
+func TestTrackingPlanSemanticValid_DuplicatePropertiesV0(t *testing.T) {
+	t.Parallel()
+
+	event := &localcatalog.TPRuleEvent{Ref: "#event:signup"}
+
+	t.Run("no duplicates", func(t *testing.T) {
+		t.Parallel()
+
+		spec := localcatalog.TrackingPlan{
+			LocalID: "tp1",
+			Name:    "TP",
+			Rules: []*localcatalog.TPRule{
+				{
+					LocalID: "r1",
+					Event:   event,
+					Properties: []*localcatalog.TPRuleProperty{
+						{Ref: "#property:email"},
+						{Ref: "#property:name"},
+					},
+				},
+			},
+		}
+
+		results := validateDuplicatePropertiesV0(spec)
+		assert.Empty(t, results)
+	})
+
+	t.Run("duplicate at top-level rule properties", func(t *testing.T) {
+		t.Parallel()
+
+		spec := localcatalog.TrackingPlan{
+			LocalID: "tp1",
+			Name:    "TP",
+			Rules: []*localcatalog.TPRule{
+				{
+					LocalID: "r1",
+					Event:   event,
+					Properties: []*localcatalog.TPRuleProperty{
+						{Ref: "#property:email"},
+						{Ref: "#property:name"},
+						{Ref: "#property:email"},
+					},
+				},
+			},
+		}
+
+		results := validateDuplicatePropertiesV0(spec)
+		assert.Equal(t, []rules.ValidationResult{
+			{Reference: "/rules/0/properties/0/$ref", Message: "duplicate property reference '#property:email' (appears 2 times)"},
+			{Reference: "/rules/0/properties/2/$ref", Message: "duplicate property reference '#property:email' (appears 2 times)"},
+		}, results)
+	})
+
+	t.Run("duplicate inside nested properties of same parent", func(t *testing.T) {
+		t.Parallel()
+
+		spec := localcatalog.TrackingPlan{
+			LocalID: "tp1",
+			Name:    "TP",
+			Rules: []*localcatalog.TPRule{
+				{
+					LocalID: "r1",
+					Event:   event,
+					Properties: []*localcatalog.TPRuleProperty{
+						{
+							Ref: "#property:address",
+							Properties: []*localcatalog.TPRuleProperty{
+								{Ref: "#property:city"},
+								{Ref: "#property:city"},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		results := validateDuplicatePropertiesV0(spec)
+		assert.Equal(t, []rules.ValidationResult{
+			{Reference: "/rules/0/properties/0/properties/0/$ref", Message: "duplicate property reference '#property:city' (appears 2 times)"},
+			{Reference: "/rules/0/properties/0/properties/1/$ref", Message: "duplicate property reference '#property:city' (appears 2 times)"},
+		}, results)
+	})
+
+	t.Run("same ref at parent and child level is NOT a duplicate", func(t *testing.T) {
+		t.Parallel()
+
+		spec := localcatalog.TrackingPlan{
+			LocalID: "tp1",
+			Name:    "TP",
+			Rules: []*localcatalog.TPRule{
+				{
+					LocalID: "r1",
+					Event:   event,
+					Properties: []*localcatalog.TPRuleProperty{
+						{
+							Ref: "#property:address",
+							Properties: []*localcatalog.TPRuleProperty{
+								{Ref: "#property:address"},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		results := validateDuplicatePropertiesV0(spec)
+		assert.Empty(t, results)
+	})
+
+	t.Run("same ref across different sibling parents is NOT a duplicate", func(t *testing.T) {
+		t.Parallel()
+
+		spec := localcatalog.TrackingPlan{
+			LocalID: "tp1",
+			Name:    "TP",
+			Rules: []*localcatalog.TPRule{
+				{
+					LocalID: "r1",
+					Event:   event,
+					Properties: []*localcatalog.TPRuleProperty{
+						{
+							Ref: "#property:address_home",
+							Properties: []*localcatalog.TPRuleProperty{
+								{Ref: "#property:city"},
+							},
+						},
+						{
+							Ref: "#property:address_work",
+							Properties: []*localcatalog.TPRuleProperty{
+								{Ref: "#property:city"},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		results := validateDuplicatePropertiesV0(spec)
+		assert.Empty(t, results)
+	})
+
+	t.Run("duplicate in variant case properties", func(t *testing.T) {
+		t.Parallel()
+
+		spec := localcatalog.TrackingPlan{
+			LocalID: "tp1",
+			Name:    "TP",
+			Rules: []*localcatalog.TPRule{
+				{
+					LocalID: "r1",
+					Event:   event,
+					Variants: localcatalog.Variants{
+						{
+							Type:          "discriminator",
+							Discriminator: "#property:method",
+							Cases: []localcatalog.VariantCase{
+								{
+									DisplayName: "Case 1",
+									Properties: []localcatalog.PropertyReference{
+										{Ref: "#property:email"},
+										{Ref: "#property:email"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		results := validateDuplicatePropertiesV0(spec)
+		assert.Equal(t, []rules.ValidationResult{
+			{Reference: "/rules/0/variants/0/cases/0/properties/0/$ref", Message: "duplicate property reference '#property:email' (appears 2 times)"},
+			{Reference: "/rules/0/variants/0/cases/0/properties/1/$ref", Message: "duplicate property reference '#property:email' (appears 2 times)"},
+		}, results)
+	})
+
+	t.Run("duplicate in variant default", func(t *testing.T) {
+		t.Parallel()
+
+		spec := localcatalog.TrackingPlan{
+			LocalID: "tp1",
+			Name:    "TP",
+			Rules: []*localcatalog.TPRule{
+				{
+					LocalID: "r1",
+					Event:   event,
+					Variants: localcatalog.Variants{
+						{
+							Type:          "discriminator",
+							Discriminator: "#property:method",
+							Cases: []localcatalog.VariantCase{
+								{
+									DisplayName: "Case 1",
+									Properties: []localcatalog.PropertyReference{
+										{Ref: "#property:email"},
+									},
+								},
+							},
+							Default: []localcatalog.PropertyReference{
+								{Ref: "#property:user_id"},
+								{Ref: "#property:user_id"},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		results := validateDuplicatePropertiesV0(spec)
+		assert.Equal(t, []rules.ValidationResult{
+			{Reference: "/rules/0/variants/0/default/0/$ref", Message: "duplicate property reference '#property:user_id' (appears 2 times)"},
+			{Reference: "/rules/0/variants/0/default/1/$ref", Message: "duplicate property reference '#property:user_id' (appears 2 times)"},
+		}, results)
+	})
+
+	t.Run("same ref in case properties and rule properties is NOT a duplicate", func(t *testing.T) {
+		t.Parallel()
+
+		spec := localcatalog.TrackingPlan{
+			LocalID: "tp1",
+			Name:    "TP",
+			Rules: []*localcatalog.TPRule{
+				{
+					LocalID: "r1",
+					Event:   event,
+					Properties: []*localcatalog.TPRuleProperty{
+						{Ref: "#property:email"},
+					},
+					Variants: localcatalog.Variants{
+						{
+							Type:          "discriminator",
+							Discriminator: "#property:method",
+							Cases: []localcatalog.VariantCase{
+								{
+									DisplayName: "Case 1",
+									Properties: []localcatalog.PropertyReference{
+										{Ref: "#property:email"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		results := validateDuplicatePropertiesV0(spec)
+		assert.Empty(t, results)
+	})
+}
+
+func TestTrackingPlanSemanticValid_DuplicateEventsV1(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no duplicates", func(t *testing.T) {
+		t.Parallel()
+
+		spec := localcatalog.TrackingPlanV1{
+			LocalID: "tp1",
+			Name:    "TP",
+			Rules: []*localcatalog.TPRuleV1{
+				{LocalID: "r1", Event: "#event:signup"},
+				{LocalID: "r2", Event: "#event:login"},
+			},
+		}
+
+		results := validateDuplicateEventsV1(spec)
+		assert.Empty(t, results)
+	})
+
+	t.Run("three rules share event ref — all three reported", func(t *testing.T) {
+		t.Parallel()
+
+		spec := localcatalog.TrackingPlanV1{
+			LocalID: "tp1",
+			Name:    "TP",
+			Rules: []*localcatalog.TPRuleV1{
+				{LocalID: "r1", Event: "#event:signup"},
+				{LocalID: "r2", Event: "#event:signup"},
+				{LocalID: "r3", Event: "#event:signup"},
+			},
+		}
+
+		results := validateDuplicateEventsV1(spec)
+		assert.Equal(t, []rules.ValidationResult{
+			{Reference: "/rules/0/event", Message: "duplicate event reference '#event:signup' (appears 3 times)"},
+			{Reference: "/rules/1/event", Message: "duplicate event reference '#event:signup' (appears 3 times)"},
+			{Reference: "/rules/2/event", Message: "duplicate event reference '#event:signup' (appears 3 times)"},
+		}, results)
+	})
+}
+
+func TestTrackingPlanSemanticValid_DuplicatePropertiesV1(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no duplicates", func(t *testing.T) {
+		t.Parallel()
+
+		spec := localcatalog.TrackingPlanV1{
+			LocalID: "tp1",
+			Name:    "TP",
+			Rules: []*localcatalog.TPRuleV1{
+				{
+					LocalID: "r1",
+					Event:   "#event:signup",
+					Properties: []*localcatalog.TPRulePropertyV1{
+						{Property: "#property:email"},
+						{Property: "#property:name"},
+					},
+				},
+			},
+		}
+
+		results := validateDuplicatePropertiesV1(spec)
+		assert.Empty(t, results)
+	})
+
+	t.Run("duplicate at top-level rule properties", func(t *testing.T) {
+		t.Parallel()
+
+		spec := localcatalog.TrackingPlanV1{
+			LocalID: "tp1",
+			Name:    "TP",
+			Rules: []*localcatalog.TPRuleV1{
+				{
+					LocalID: "r1",
+					Event:   "#event:signup",
+					Properties: []*localcatalog.TPRulePropertyV1{
+						{Property: "#property:email"},
+						{Property: "#property:email"},
+					},
+				},
+			},
+		}
+
+		results := validateDuplicatePropertiesV1(spec)
+		assert.Equal(t, []rules.ValidationResult{
+			{Reference: "/rules/0/properties/0/property", Message: "duplicate property reference '#property:email' (appears 2 times)"},
+			{Reference: "/rules/0/properties/1/property", Message: "duplicate property reference '#property:email' (appears 2 times)"},
+		}, results)
+	})
+
+	t.Run("duplicate inside nested properties", func(t *testing.T) {
+		t.Parallel()
+
+		spec := localcatalog.TrackingPlanV1{
+			LocalID: "tp1",
+			Name:    "TP",
+			Rules: []*localcatalog.TPRuleV1{
+				{
+					LocalID: "r1",
+					Event:   "#event:signup",
+					Properties: []*localcatalog.TPRulePropertyV1{
+						{
+							Property: "#property:address",
+							Properties: []*localcatalog.TPRulePropertyV1{
+								{Property: "#property:city"},
+								{Property: "#property:city"},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		results := validateDuplicatePropertiesV1(spec)
+		assert.Equal(t, []rules.ValidationResult{
+			{Reference: "/rules/0/properties/0/properties/0/property", Message: "duplicate property reference '#property:city' (appears 2 times)"},
+			{Reference: "/rules/0/properties/0/properties/1/property", Message: "duplicate property reference '#property:city' (appears 2 times)"},
+		}, results)
+	})
+
+	t.Run("parent and nested share ref — NOT a duplicate", func(t *testing.T) {
+		t.Parallel()
+
+		spec := localcatalog.TrackingPlanV1{
+			LocalID: "tp1",
+			Name:    "TP",
+			Rules: []*localcatalog.TPRuleV1{
+				{
+					LocalID: "r1",
+					Event:   "#event:signup",
+					Properties: []*localcatalog.TPRulePropertyV1{
+						{
+							Property: "#property:address",
+							Properties: []*localcatalog.TPRulePropertyV1{
+								{Property: "#property:address"},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		results := validateDuplicatePropertiesV1(spec)
+		assert.Empty(t, results)
+	})
+
+	t.Run("duplicate in variant case properties", func(t *testing.T) {
+		t.Parallel()
+
+		spec := localcatalog.TrackingPlanV1{
+			LocalID: "tp1",
+			Name:    "TP",
+			Rules: []*localcatalog.TPRuleV1{
+				{
+					LocalID: "r1",
+					Event:   "#event:signup",
+					Variants: localcatalog.VariantsV1{
+						{
+							Type:          "discriminator",
+							Discriminator: "#property:method",
+							Cases: []localcatalog.VariantCaseV1{
+								{
+									DisplayName: "Case 1",
+									Match:       []any{"a"},
+									Properties: []localcatalog.PropertyReferenceV1{
+										{Property: "#property:email"},
+										{Property: "#property:email"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		results := validateDuplicatePropertiesV1(spec)
+		assert.Equal(t, []rules.ValidationResult{
+			{Reference: "/rules/0/variants/0/cases/0/properties/0/property", Message: "duplicate property reference '#property:email' (appears 2 times)"},
+			{Reference: "/rules/0/variants/0/cases/0/properties/1/property", Message: "duplicate property reference '#property:email' (appears 2 times)"},
+		}, results)
+	})
+
+	t.Run("duplicate in variant default.properties", func(t *testing.T) {
+		t.Parallel()
+
+		spec := localcatalog.TrackingPlanV1{
+			LocalID: "tp1",
+			Name:    "TP",
+			Rules: []*localcatalog.TPRuleV1{
+				{
+					LocalID: "r1",
+					Event:   "#event:signup",
+					Variants: localcatalog.VariantsV1{
+						{
+							Type:          "discriminator",
+							Discriminator: "#property:method",
+							Cases: []localcatalog.VariantCaseV1{
+								{
+									DisplayName: "Case 1",
+									Match:       []any{"a"},
+									Properties: []localcatalog.PropertyReferenceV1{
+										{Property: "#property:email"},
+									},
+								},
+							},
+							Default: localcatalog.DefaultPropertiesV1{
+								Properties: []localcatalog.PropertyReferenceV1{
+									{Property: "#property:user_id"},
+									{Property: "#property:user_id"},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		results := validateDuplicatePropertiesV1(spec)
+		assert.Equal(t, []rules.ValidationResult{
+			{Reference: "/rules/0/variants/0/default/properties/0/property", Message: "duplicate property reference '#property:user_id' (appears 2 times)"},
+			{Reference: "/rules/0/variants/0/default/properties/1/property", Message: "duplicate property reference '#property:user_id' (appears 2 times)"},
+		}, results)
+	})
+
+	t.Run("case A vs case B with same ref — NOT a duplicate", func(t *testing.T) {
+		t.Parallel()
+
+		spec := localcatalog.TrackingPlanV1{
+			LocalID: "tp1",
+			Name:    "TP",
+			Rules: []*localcatalog.TPRuleV1{
+				{
+					LocalID: "r1",
+					Event:   "#event:signup",
+					Variants: localcatalog.VariantsV1{
+						{
+							Type:          "discriminator",
+							Discriminator: "#property:method",
+							Cases: []localcatalog.VariantCaseV1{
+								{
+									DisplayName: "Case A",
+									Match:       []any{"a"},
+									Properties: []localcatalog.PropertyReferenceV1{
+										{Property: "#property:email"},
+									},
+								},
+								{
+									DisplayName: "Case B",
+									Match:       []any{"b"},
+									Properties: []localcatalog.PropertyReferenceV1{
+										{Property: "#property:email"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		results := validateDuplicatePropertiesV1(spec)
+		assert.Empty(t, results)
+	})
+}

--- a/cli/internal/providers/datacatalog/rules/trackingplan/trackingplan_spec_valid.go
+++ b/cli/internal/providers/datacatalog/rules/trackingplan/trackingplan_spec_valid.go
@@ -171,11 +171,10 @@ func validateDuplicateRuleIDs[T any](tpRules []T, idOf func(T) string) []rules.V
 
 	var results []rules.ValidationResult
 	for i, rule := range tpRules {
-		id := idOf(rule)
-		if counts[id] > 1 {
+		if counts[idOf(rule)] > 1 {
 			results = append(results, rules.ValidationResult{
 				Reference: fmt.Sprintf("/rules/%d/id", i),
-				Message:   fmt.Sprintf("duplicate rule id '%s' (appears %d times)", id, counts[id]),
+				Message:   "duplicate rule id in tracking plan rules",
 			})
 		}
 	}

--- a/cli/internal/providers/datacatalog/rules/trackingplan/trackingplan_spec_valid.go
+++ b/cli/internal/providers/datacatalog/rules/trackingplan/trackingplan_spec_valid.go
@@ -166,7 +166,11 @@ func validateRulesV1(tpRules []*localcatalog.TPRuleV1) []rules.ValidationResult 
 func validateDuplicateRuleIDs[T any](tpRules []T, idOf func(T) string) []rules.ValidationResult {
 	counts := make(map[string]int)
 	for _, rule := range tpRules {
-		counts[idOf(rule)]++
+		id := idOf(rule)
+		if id == "" {
+			continue
+		}
+		counts[id]++
 	}
 
 	var results []rules.ValidationResult

--- a/cli/internal/providers/datacatalog/rules/trackingplan/trackingplan_spec_valid.go
+++ b/cli/internal/providers/datacatalog/rules/trackingplan/trackingplan_spec_valid.go
@@ -116,7 +116,10 @@ var validateTrackingPlanSpecV1 = func(
 func validateRules(tpRules []*localcatalog.TPRule) []rules.ValidationResult {
 	var results []rules.ValidationResult
 
-	results = append(results, validateDuplicateRuleIDsV0(tpRules)...)
+	results = append(
+		results,
+		validateDuplicateRuleIDs(tpRules, func(r *localcatalog.TPRule) string { return r.LocalID })...,
+	)
 
 	for i, rule := range tpRules {
 		for j, prop := range rule.Properties {
@@ -139,7 +142,10 @@ func validateRules(tpRules []*localcatalog.TPRule) []rules.ValidationResult {
 func validateRulesV1(tpRules []*localcatalog.TPRuleV1) []rules.ValidationResult {
 	var results []rules.ValidationResult
 
-	results = append(results, validateDuplicateRuleIDsV1(tpRules)...)
+	results = append(
+		results,
+		validateDuplicateRuleIDs(tpRules, func(r *localcatalog.TPRuleV1) string { return r.LocalID })...,
+	)
 
 	for i, rule := range tpRules {
 		for j, prop := range rule.Properties {
@@ -157,40 +163,19 @@ func validateRulesV1(tpRules []*localcatalog.TPRuleV1) []rules.ValidationResult 
 	return results
 }
 
-// validateDuplicateRuleIDsV0 emits one error per occurrence of any rule id that
-// appears more than once within a single tracking plan. Comparison is
-// case-sensitive raw-string equality. Empty ids are not checked here — struct
-// tag `required` already rejects them.
-func validateDuplicateRuleIDsV0(tpRules []*localcatalog.TPRule) []rules.ValidationResult {
+func validateDuplicateRuleIDs[T any](tpRules []T, idOf func(T) string) []rules.ValidationResult {
 	counts := make(map[string]int)
 	for _, rule := range tpRules {
-		counts[rule.LocalID]++
+		counts[idOf(rule)]++
 	}
 
 	var results []rules.ValidationResult
 	for i, rule := range tpRules {
-		if counts[rule.LocalID] > 1 {
+		id := idOf(rule)
+		if counts[id] > 1 {
 			results = append(results, rules.ValidationResult{
 				Reference: fmt.Sprintf("/rules/%d/id", i),
-				Message:   fmt.Sprintf("duplicate rule id '%s' (appears %d times)", rule.LocalID, counts[rule.LocalID]),
-			})
-		}
-	}
-	return results
-}
-
-func validateDuplicateRuleIDsV1(tpRules []*localcatalog.TPRuleV1) []rules.ValidationResult {
-	counts := make(map[string]int)
-	for _, rule := range tpRules {
-		counts[rule.LocalID]++
-	}
-
-	var results []rules.ValidationResult
-	for i, rule := range tpRules {
-		if counts[rule.LocalID] > 1 {
-			results = append(results, rules.ValidationResult{
-				Reference: fmt.Sprintf("/rules/%d/id", i),
-				Message:   fmt.Sprintf("duplicate rule id '%s' (appears %d times)", rule.LocalID, counts[rule.LocalID]),
+				Message:   fmt.Sprintf("duplicate rule id '%s' (appears %d times)", id, counts[id]),
 			})
 		}
 	}

--- a/cli/internal/providers/datacatalog/rules/trackingplan/trackingplan_spec_valid.go
+++ b/cli/internal/providers/datacatalog/rules/trackingplan/trackingplan_spec_valid.go
@@ -116,6 +116,8 @@ var validateTrackingPlanSpecV1 = func(
 func validateRules(tpRules []*localcatalog.TPRule) []rules.ValidationResult {
 	var results []rules.ValidationResult
 
+	results = append(results, validateDuplicateRuleIDsV0(tpRules)...)
+
 	for i, rule := range tpRules {
 		for j, prop := range rule.Properties {
 			if len(prop.Properties) == 0 {
@@ -137,6 +139,8 @@ func validateRules(tpRules []*localcatalog.TPRule) []rules.ValidationResult {
 func validateRulesV1(tpRules []*localcatalog.TPRuleV1) []rules.ValidationResult {
 	var results []rules.ValidationResult
 
+	results = append(results, validateDuplicateRuleIDsV1(tpRules)...)
+
 	for i, rule := range tpRules {
 		for j, prop := range rule.Properties {
 			ref := fmt.Sprintf("/rules/%d/properties/%d", i, j)
@@ -150,6 +154,46 @@ func validateRulesV1(tpRules []*localcatalog.TPRuleV1) []rules.ValidationResult 
 		}
 	}
 
+	return results
+}
+
+// validateDuplicateRuleIDsV0 emits one error per occurrence of any rule id that
+// appears more than once within a single tracking plan. Comparison is
+// case-sensitive raw-string equality. Empty ids are not checked here — struct
+// tag `required` already rejects them.
+func validateDuplicateRuleIDsV0(tpRules []*localcatalog.TPRule) []rules.ValidationResult {
+	counts := make(map[string]int)
+	for _, rule := range tpRules {
+		counts[rule.LocalID]++
+	}
+
+	var results []rules.ValidationResult
+	for i, rule := range tpRules {
+		if counts[rule.LocalID] > 1 {
+			results = append(results, rules.ValidationResult{
+				Reference: fmt.Sprintf("/rules/%d/id", i),
+				Message:   fmt.Sprintf("duplicate rule id '%s' (appears %d times)", rule.LocalID, counts[rule.LocalID]),
+			})
+		}
+	}
+	return results
+}
+
+func validateDuplicateRuleIDsV1(tpRules []*localcatalog.TPRuleV1) []rules.ValidationResult {
+	counts := make(map[string]int)
+	for _, rule := range tpRules {
+		counts[rule.LocalID]++
+	}
+
+	var results []rules.ValidationResult
+	for i, rule := range tpRules {
+		if counts[rule.LocalID] > 1 {
+			results = append(results, rules.ValidationResult{
+				Reference: fmt.Sprintf("/rules/%d/id", i),
+				Message:   fmt.Sprintf("duplicate rule id '%s' (appears %d times)", rule.LocalID, counts[rule.LocalID]),
+			})
+		}
+	}
 	return results
 }
 

--- a/cli/internal/providers/datacatalog/rules/trackingplan/trackingplan_spec_valid_test.go
+++ b/cli/internal/providers/datacatalog/rules/trackingplan/trackingplan_spec_valid_test.go
@@ -1411,8 +1411,8 @@ func TestTrackingPlanSpecSyntaxValidRule_DuplicateRuleIDsV0(t *testing.T) {
 		results := validateTrackingPlanSpec(localcatalog.KindTrackingPlans, specs.SpecVersionV0_1, map[string]any{}, spec)
 		require.Len(t, results, 2)
 		assert.Equal(t, []rules.ValidationResult{
-			{Reference: "/rules/0/id", Message: "duplicate rule id 'dup_rule' (appears 2 times)"},
-			{Reference: "/rules/2/id", Message: "duplicate rule id 'dup_rule' (appears 2 times)"},
+			{Reference: "/rules/0/id", Message: "duplicate rule id in tracking plan rules"},
+			{Reference: "/rules/2/id", Message: "duplicate rule id in tracking plan rules"},
 		}, results)
 	})
 
@@ -1432,7 +1432,7 @@ func TestTrackingPlanSpecSyntaxValidRule_DuplicateRuleIDsV0(t *testing.T) {
 		results := validateTrackingPlanSpec(localcatalog.KindTrackingPlans, specs.SpecVersionV0_1, map[string]any{}, spec)
 		require.Len(t, results, 3)
 		for _, r := range results {
-			assert.Equal(t, "duplicate rule id 'dup' (appears 3 times)", r.Message)
+			assert.Equal(t, "duplicate rule id in tracking plan rules", r.Message)
 		}
 		assert.ElementsMatch(t,
 			[]string{"/rules/0/id", "/rules/1/id", "/rules/2/id"},
@@ -1491,8 +1491,8 @@ func TestTrackingPlanSpecSyntaxValidRule_DuplicateRuleIDsV1(t *testing.T) {
 		results := validateTrackingPlanSpecV1(localcatalog.KindTrackingPlansV1, specs.SpecVersionV1, map[string]any{}, spec)
 		require.Len(t, results, 2)
 		assert.Equal(t, []rules.ValidationResult{
-			{Reference: "/rules/0/id", Message: "duplicate rule id 'dup_rule' (appears 2 times)"},
-			{Reference: "/rules/1/id", Message: "duplicate rule id 'dup_rule' (appears 2 times)"},
+			{Reference: "/rules/0/id", Message: "duplicate rule id in tracking plan rules"},
+			{Reference: "/rules/1/id", Message: "duplicate rule id in tracking plan rules"},
 		}, results)
 	})
 
@@ -1512,7 +1512,7 @@ func TestTrackingPlanSpecSyntaxValidRule_DuplicateRuleIDsV1(t *testing.T) {
 		results := validateTrackingPlanSpecV1(localcatalog.KindTrackingPlansV1, specs.SpecVersionV1, map[string]any{}, spec)
 		require.Len(t, results, 3)
 		for _, r := range results {
-			assert.Equal(t, "duplicate rule id 'dup' (appears 3 times)", r.Message)
+			assert.Equal(t, "duplicate rule id in tracking plan rules", r.Message)
 		}
 	})
 

--- a/cli/internal/providers/datacatalog/rules/trackingplan/trackingplan_spec_valid_test.go
+++ b/cli/internal/providers/datacatalog/rules/trackingplan/trackingplan_spec_valid_test.go
@@ -1455,6 +1455,31 @@ func TestTrackingPlanSpecSyntaxValidRule_DuplicateRuleIDsV0(t *testing.T) {
 		results := validateTrackingPlanSpec(localcatalog.KindTrackingPlans, specs.SpecVersionV0_1, map[string]any{}, spec)
 		assert.Empty(t, results)
 	})
+
+	t.Run("empty ids report required errors, non-empty duplicates report dedup errors", func(t *testing.T) {
+		t.Parallel()
+
+		spec := localcatalog.TrackingPlan{
+			LocalID: "test_tp",
+			Name:    "Test TP",
+			Rules: []*localcatalog.TPRule{
+				{Type: "event_rule", LocalID: "", Event: event},
+				{Type: "event_rule", LocalID: "dup", Event: event},
+				{Type: "event_rule", LocalID: "", Event: event},
+				{Type: "event_rule", LocalID: "unique", Event: event},
+				{Type: "event_rule", LocalID: "dup", Event: event},
+			},
+		}
+
+		results := validateTrackingPlanSpec(localcatalog.KindTrackingPlans, specs.SpecVersionV0_1, map[string]any{}, spec)
+
+		assert.ElementsMatch(t, []rules.ValidationResult{
+			{Reference: "/rules/0/id", Message: "'id' is required"},
+			{Reference: "/rules/2/id", Message: "'id' is required"},
+			{Reference: "/rules/1/id", Message: "duplicate rule id in tracking plan rules"},
+			{Reference: "/rules/4/id", Message: "duplicate rule id in tracking plan rules"},
+		}, results)
+	})
 }
 
 func TestTrackingPlanSpecSyntaxValidRule_DuplicateRuleIDsV1(t *testing.T) {
@@ -1530,6 +1555,31 @@ func TestTrackingPlanSpecSyntaxValidRule_DuplicateRuleIDsV1(t *testing.T) {
 
 		results := validateTrackingPlanSpecV1(localcatalog.KindTrackingPlansV1, specs.SpecVersionV1, map[string]any{}, spec)
 		assert.Empty(t, results)
+	})
+
+	t.Run("empty ids report required errors, non-empty duplicates report dedup errors", func(t *testing.T) {
+		t.Parallel()
+
+		spec := localcatalog.TrackingPlanV1{
+			LocalID: "tp_v1",
+			Name:    "Test Plan",
+			Rules: []*localcatalog.TPRuleV1{
+				{Type: "event_rule", LocalID: "", Event: "#event:signup"},
+				{Type: "event_rule", LocalID: "dup", Event: "#event:signup"},
+				{Type: "event_rule", LocalID: "", Event: "#event:signup"},
+				{Type: "event_rule", LocalID: "unique", Event: "#event:signup"},
+				{Type: "event_rule", LocalID: "dup", Event: "#event:signup"},
+			},
+		}
+
+		results := validateTrackingPlanSpecV1(localcatalog.KindTrackingPlansV1, specs.SpecVersionV1, map[string]any{}, spec)
+
+		assert.ElementsMatch(t, []rules.ValidationResult{
+			{Reference: "/rules/0/id", Message: "'id' is required"},
+			{Reference: "/rules/2/id", Message: "'id' is required"},
+			{Reference: "/rules/1/id", Message: "duplicate rule id in tracking plan rules"},
+			{Reference: "/rules/4/id", Message: "duplicate rule id in tracking plan rules"},
+		}, results)
 	})
 }
 

--- a/cli/internal/providers/datacatalog/rules/trackingplan/trackingplan_spec_valid_test.go
+++ b/cli/internal/providers/datacatalog/rules/trackingplan/trackingplan_spec_valid_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/rudderlabs/rudder-iac/cli/internal/providers/datacatalog/localcatalog"
 	"github.com/rudderlabs/rudder-iac/cli/internal/validation/rules"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	// Trigger pattern registration (legacy_event_ref, legacy_property_ref, display_name, etc.) from parent rules package
 	_ "github.com/rudderlabs/rudder-iac/cli/internal/providers/datacatalog/rules"
@@ -1370,6 +1371,165 @@ func TestTrackingPlanSpecSyntaxValidRule_V1NestingDepth(t *testing.T) {
 		assert.Len(t, results, 1)
 		assert.Equal(t, "/rules/0/properties/0", extractRefs(results)[0])
 		assert.Equal(t, "maximum property nesting depth of 3 levels exceeded", extractMsgs(results)[0])
+	})
+}
+
+func TestTrackingPlanSpecSyntaxValidRule_DuplicateRuleIDsV0(t *testing.T) {
+	t.Parallel()
+
+	event := &localcatalog.TPRuleEvent{Ref: "#/events/user-events/signup"}
+
+	t.Run("no duplicates", func(t *testing.T) {
+		t.Parallel()
+
+		spec := localcatalog.TrackingPlan{
+			LocalID: "test_tp",
+			Name:    "Test TP",
+			Rules: []*localcatalog.TPRule{
+				{Type: "event_rule", LocalID: "rule1", Event: event},
+				{Type: "event_rule", LocalID: "rule2", Event: event},
+			},
+		}
+
+		results := validateTrackingPlanSpec(localcatalog.KindTrackingPlans, specs.SpecVersionV0_1, map[string]any{}, spec)
+		assert.Empty(t, results)
+	})
+
+	t.Run("two rules share an id — both reported", func(t *testing.T) {
+		t.Parallel()
+
+		spec := localcatalog.TrackingPlan{
+			LocalID: "test_tp",
+			Name:    "Test TP",
+			Rules: []*localcatalog.TPRule{
+				{Type: "event_rule", LocalID: "dup_rule", Event: event},
+				{Type: "event_rule", LocalID: "unique_rule", Event: event},
+				{Type: "event_rule", LocalID: "dup_rule", Event: event},
+			},
+		}
+
+		results := validateTrackingPlanSpec(localcatalog.KindTrackingPlans, specs.SpecVersionV0_1, map[string]any{}, spec)
+		require.Len(t, results, 2)
+		assert.Equal(t, []rules.ValidationResult{
+			{Reference: "/rules/0/id", Message: "duplicate rule id 'dup_rule' (appears 2 times)"},
+			{Reference: "/rules/2/id", Message: "duplicate rule id 'dup_rule' (appears 2 times)"},
+		}, results)
+	})
+
+	t.Run("three occurrences — all three reported with count 3", func(t *testing.T) {
+		t.Parallel()
+
+		spec := localcatalog.TrackingPlan{
+			LocalID: "test_tp",
+			Name:    "Test TP",
+			Rules: []*localcatalog.TPRule{
+				{Type: "event_rule", LocalID: "dup", Event: event},
+				{Type: "event_rule", LocalID: "dup", Event: event},
+				{Type: "event_rule", LocalID: "dup", Event: event},
+			},
+		}
+
+		results := validateTrackingPlanSpec(localcatalog.KindTrackingPlans, specs.SpecVersionV0_1, map[string]any{}, spec)
+		require.Len(t, results, 3)
+		for _, r := range results {
+			assert.Equal(t, "duplicate rule id 'dup' (appears 3 times)", r.Message)
+		}
+		assert.ElementsMatch(t,
+			[]string{"/rules/0/id", "/rules/1/id", "/rules/2/id"},
+			extractRefs(results),
+		)
+	})
+
+	t.Run("rule ids are case-sensitive", func(t *testing.T) {
+		t.Parallel()
+
+		spec := localcatalog.TrackingPlan{
+			LocalID: "test_tp",
+			Name:    "Test TP",
+			Rules: []*localcatalog.TPRule{
+				{Type: "event_rule", LocalID: "signup_rule", Event: event},
+				{Type: "event_rule", LocalID: "Signup_Rule", Event: event},
+			},
+		}
+
+		results := validateTrackingPlanSpec(localcatalog.KindTrackingPlans, specs.SpecVersionV0_1, map[string]any{}, spec)
+		assert.Empty(t, results)
+	})
+}
+
+func TestTrackingPlanSpecSyntaxValidRule_DuplicateRuleIDsV1(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no duplicates", func(t *testing.T) {
+		t.Parallel()
+
+		spec := localcatalog.TrackingPlanV1{
+			LocalID: "tp_v1",
+			Name:    "Test Plan",
+			Rules: []*localcatalog.TPRuleV1{
+				{Type: "event_rule", LocalID: "rule1", Event: "#event:signup"},
+				{Type: "event_rule", LocalID: "rule2", Event: "#event:signup"},
+			},
+		}
+
+		results := validateTrackingPlanSpecV1(localcatalog.KindTrackingPlansV1, specs.SpecVersionV1, map[string]any{}, spec)
+		assert.Empty(t, results)
+	})
+
+	t.Run("two rules share an id — both reported", func(t *testing.T) {
+		t.Parallel()
+
+		spec := localcatalog.TrackingPlanV1{
+			LocalID: "tp_v1",
+			Name:    "Test Plan",
+			Rules: []*localcatalog.TPRuleV1{
+				{Type: "event_rule", LocalID: "dup_rule", Event: "#event:signup"},
+				{Type: "event_rule", LocalID: "dup_rule", Event: "#event:signup"},
+			},
+		}
+
+		results := validateTrackingPlanSpecV1(localcatalog.KindTrackingPlansV1, specs.SpecVersionV1, map[string]any{}, spec)
+		require.Len(t, results, 2)
+		assert.Equal(t, []rules.ValidationResult{
+			{Reference: "/rules/0/id", Message: "duplicate rule id 'dup_rule' (appears 2 times)"},
+			{Reference: "/rules/1/id", Message: "duplicate rule id 'dup_rule' (appears 2 times)"},
+		}, results)
+	})
+
+	t.Run("three occurrences — all three reported with count 3", func(t *testing.T) {
+		t.Parallel()
+
+		spec := localcatalog.TrackingPlanV1{
+			LocalID: "tp_v1",
+			Name:    "Test Plan",
+			Rules: []*localcatalog.TPRuleV1{
+				{Type: "event_rule", LocalID: "dup", Event: "#event:signup"},
+				{Type: "event_rule", LocalID: "dup", Event: "#event:signup"},
+				{Type: "event_rule", LocalID: "dup", Event: "#event:signup"},
+			},
+		}
+
+		results := validateTrackingPlanSpecV1(localcatalog.KindTrackingPlansV1, specs.SpecVersionV1, map[string]any{}, spec)
+		require.Len(t, results, 3)
+		for _, r := range results {
+			assert.Equal(t, "duplicate rule id 'dup' (appears 3 times)", r.Message)
+		}
+	})
+
+	t.Run("rule ids are case-sensitive", func(t *testing.T) {
+		t.Parallel()
+
+		spec := localcatalog.TrackingPlanV1{
+			LocalID: "tp_v1",
+			Name:    "Test Plan",
+			Rules: []*localcatalog.TPRuleV1{
+				{Type: "event_rule", LocalID: "signup_rule", Event: "#event:signup"},
+				{Type: "event_rule", LocalID: "Signup_Rule", Event: "#event:signup"},
+			},
+		}
+
+		results := validateTrackingPlanSpecV1(localcatalog.KindTrackingPlansV1, specs.SpecVersionV1, map[string]any{}, spec)
+		assert.Empty(t, results)
 	})
 }
 

--- a/cli/internal/providers/datacatalog/rules/variant/variant_v0_validation.go
+++ b/cli/internal/providers/datacatalog/rules/variant/variant_v0_validation.go
@@ -15,11 +15,11 @@ import (
 // validDiscriminatorTypes are the primitive types allowed for discriminator properties.
 var validDiscriminatorTypes = []string{"string", "integer", "boolean"}
 
-// ValidateVariantDiscriminators checks all variants' discriminators for:
-//  1. Type validity — discriminator property must be string, integer, or boolean.
-//     For custom type refs, the referenced custom type's own type is validated.
-//  2. Ownership — discriminator must reference a property in the parent's own properties.
-func ValidateVariantDiscriminatorsV0(
+// ValidateVariantSemanticV0 runs all semantic checks on V0 variants:
+//  1. Discriminator type validity — must be string, integer, or boolean.
+//  2. Discriminator ownership — must reference a property in the parent's own properties.
+//  3. Duplicate property refs — within each case and default property list.
+func ValidateVariantSemanticV0(
 	variants localcatalog.Variants,
 	ownPropertyRefs []string,
 	basePath string,
@@ -27,11 +27,10 @@ func ValidateVariantDiscriminatorsV0(
 ) []rules.ValidationResult {
 	var results []rules.ValidationResult
 
-	for i, variant := range variants {
+	for i, vt := range variants {
 		discriminatorPath := fmt.Sprintf("%s/variants/%d/discriminator", basePath, i)
 
-		// discriminator must be in the parent's own properties
-		if !slices.Contains(ownPropertyRefs, variant.Discriminator) {
+		if !slices.Contains(ownPropertyRefs, vt.Discriminator) {
 			results = append(results, rules.ValidationResult{
 				Reference: discriminatorPath,
 				Message:   "discriminator must reference a property defined in the parent's own properties",
@@ -41,10 +40,22 @@ func ValidateVariantDiscriminatorsV0(
 		results = append(
 			results,
 			validateDiscriminatorType(
-				variant.Discriminator,
+				vt.Discriminator,
 				discriminatorPath,
 				graph,
 			)...)
+
+		for c, vCase := range vt.Cases {
+			caseRef := fmt.Sprintf("%s/variants/%d/cases/%d/properties", basePath, i, c)
+			results = append(
+				results,
+				CheckDuplicatePropertyRefsV0(vCase.Properties, caseRef)...)
+		}
+
+		defaultRef := fmt.Sprintf("%s/variants/%d/default", basePath, i)
+		results = append(
+			results,
+			CheckDuplicatePropertyRefsV0(vt.Default, defaultRef)...)
 	}
 
 	return results
@@ -109,6 +120,26 @@ func validateDiscriminatorType(discriminator, jsonPointer string, graph *resourc
 	default:
 		return nil
 	}
+}
+
+// CheckDuplicatePropertyRefsV0 dedupes a flat list of V0 variant property refs
+// and emits one error per occurrence of any ref that appears more than once.
+func CheckDuplicatePropertyRefsV0(props []localcatalog.PropertyReference, parentRef string) []rules.ValidationResult {
+	counts := make(map[string]int)
+	for _, prop := range props {
+		counts[prop.Ref]++
+	}
+
+	var results []rules.ValidationResult
+	for i, prop := range props {
+		if counts[prop.Ref] > 1 {
+			results = append(results, rules.ValidationResult{
+				Reference: fmt.Sprintf("%s/%d/$ref", parentRef, i),
+				Message:   "duplicate property reference in tracking plan event rule",
+			})
+		}
+	}
+	return results
 }
 
 func isAllowedDiscriminatorType(input string) bool {

--- a/cli/internal/providers/datacatalog/rules/variant/variant_v0_validation.go
+++ b/cli/internal/providers/datacatalog/rules/variant/variant_v0_validation.go
@@ -49,13 +49,13 @@ func ValidateVariantSemanticV0(
 			caseRef := fmt.Sprintf("%s/variants/%d/cases/%d/properties", basePath, i, c)
 			results = append(
 				results,
-				CheckDuplicatePropertyRefsV0(vCase.Properties, caseRef)...)
+				checkDuplicatePropertyRefsV0(vCase.Properties, caseRef)...)
 		}
 
 		defaultRef := fmt.Sprintf("%s/variants/%d/default", basePath, i)
 		results = append(
 			results,
-			CheckDuplicatePropertyRefsV0(vt.Default, defaultRef)...)
+			checkDuplicatePropertyRefsV0(vt.Default, defaultRef)...)
 	}
 
 	return results
@@ -122,9 +122,9 @@ func validateDiscriminatorType(discriminator, jsonPointer string, graph *resourc
 	}
 }
 
-// CheckDuplicatePropertyRefsV0 dedupes a flat list of V0 variant property refs
+// checkDuplicatePropertyRefsV0 dedupes a flat list of V0 variant property refs
 // and emits one error per occurrence of any ref that appears more than once.
-func CheckDuplicatePropertyRefsV0(props []localcatalog.PropertyReference, parentRef string) []rules.ValidationResult {
+func checkDuplicatePropertyRefsV0(props []localcatalog.PropertyReference, parentRef string) []rules.ValidationResult {
 	counts := make(map[string]int)
 	for _, prop := range props {
 		counts[prop.Ref]++

--- a/cli/internal/providers/datacatalog/rules/variant/variant_v0_validation_test.go
+++ b/cli/internal/providers/datacatalog/rules/variant/variant_v0_validation_test.go
@@ -46,7 +46,7 @@ func TestValidateVariantDiscriminators_TypeCheck(t *testing.T) {
 			},
 		}
 
-		results := ValidateVariantDiscriminatorsV0(variants, []string{"#property:signup_method"}, "/types/0", graph)
+		results := ValidateVariantSemanticV0(variants, []string{"#property:signup_method"}, "/types/0", graph)
 		assert.Empty(t, results, "string type should be valid for discriminator")
 	})
 
@@ -66,7 +66,7 @@ func TestValidateVariantDiscriminators_TypeCheck(t *testing.T) {
 			},
 		}
 
-		results := ValidateVariantDiscriminatorsV0(variants, []string{"#property:level"}, "/types/0", graph)
+		results := ValidateVariantSemanticV0(variants, []string{"#property:level"}, "/types/0", graph)
 		assert.Empty(t, results, "integer type should be valid for discriminator")
 	})
 
@@ -86,7 +86,7 @@ func TestValidateVariantDiscriminators_TypeCheck(t *testing.T) {
 			},
 		}
 
-		results := ValidateVariantDiscriminatorsV0(variants, []string{"#property:is_active"}, "/types/0", graph)
+		results := ValidateVariantSemanticV0(variants, []string{"#property:is_active"}, "/types/0", graph)
 		assert.Empty(t, results, "boolean type should be valid for discriminator")
 	})
 
@@ -106,7 +106,7 @@ func TestValidateVariantDiscriminators_TypeCheck(t *testing.T) {
 			},
 		}
 
-		results := ValidateVariantDiscriminatorsV0(variants, []string{"#property:address"}, "/types/0", graph)
+		results := ValidateVariantSemanticV0(variants, []string{"#property:address"}, "/types/0", graph)
 
 		require.Len(t, results, 1)
 		assert.Equal(t, "/types/0/variants/0/discriminator", results[0].Reference)
@@ -129,7 +129,7 @@ func TestValidateVariantDiscriminators_TypeCheck(t *testing.T) {
 			},
 		}
 
-		results := ValidateVariantDiscriminatorsV0(variants, []string{"#property:tags"}, "/types/0", graph)
+		results := ValidateVariantSemanticV0(variants, []string{"#property:tags"}, "/types/0", graph)
 
 		require.Len(t, results, 1)
 		assert.Contains(t, results[0].Message, "discriminator property type 'array' must contain one of: string, integer, boolean")
@@ -155,7 +155,7 @@ func TestValidateVariantDiscriminators_TypeCheck(t *testing.T) {
 			},
 		}
 
-		results := ValidateVariantDiscriminatorsV0(variants, []string{"#property:payment_method"}, "/types/0", graph)
+		results := ValidateVariantSemanticV0(variants, []string{"#property:payment_method"}, "/types/0", graph)
 		assert.Empty(t, results, "custom type ref with valid underlying type should be allowed")
 	})
 
@@ -179,7 +179,7 @@ func TestValidateVariantDiscriminators_TypeCheck(t *testing.T) {
 			},
 		}
 
-		results := ValidateVariantDiscriminatorsV0(variants, []string{"#property:address_field"}, "/types/0", graph)
+		results := ValidateVariantSemanticV0(variants, []string{"#property:address_field"}, "/types/0", graph)
 
 		require.Len(t, results, 1)
 		assert.Equal(t, "/types/0/variants/0/discriminator", results[0].Reference)
@@ -208,7 +208,7 @@ func TestValidateVariantDiscriminators_TypeCheck(t *testing.T) {
 			},
 		}
 
-		results := ValidateVariantDiscriminatorsV0(variants, []string{"#property:payment_method"}, "/types/0", graph)
+		results := ValidateVariantSemanticV0(variants, []string{"#property:payment_method"}, "/types/0", graph)
 		assert.Empty(t, results, "custom type not in graph should be skipped gracefully")
 	})
 
@@ -228,7 +228,7 @@ func TestValidateVariantDiscriminators_TypeCheck(t *testing.T) {
 		}
 
 		// Ownership error expected, but no type check error (ref resolution handled by ValidateReferences)
-		results := ValidateVariantDiscriminatorsV0(variants, []string{"#property:missing_prop"}, "/types/0", graph)
+		results := ValidateVariantSemanticV0(variants, []string{"#property:missing_prop"}, "/types/0", graph)
 		assert.Empty(t, results, "missing ref should be skipped for type check — reported by ValidateReferences")
 	})
 }
@@ -253,7 +253,7 @@ func TestValidateVariantDiscriminators_Ownership(t *testing.T) {
 		}
 
 		ownRefs := []string{"#property:email", "#property:signup_method"}
-		results := ValidateVariantDiscriminatorsV0(variants, ownRefs, "/types/0", graph)
+		results := ValidateVariantSemanticV0(variants, ownRefs, "/types/0", graph)
 		assert.Empty(t, results, "discriminator found in own properties — no error")
 	})
 
@@ -275,7 +275,7 @@ func TestValidateVariantDiscriminators_Ownership(t *testing.T) {
 
 		// ownRefs does NOT contain signup_method
 		ownRefs := []string{"#property:email", "#property:phone"}
-		results := ValidateVariantDiscriminatorsV0(variants, ownRefs, "/types/0", graph)
+		results := ValidateVariantSemanticV0(variants, ownRefs, "/types/0", graph)
 
 		require.Len(t, results, 1)
 		assert.Equal(t, "/types/0/variants/0/discriminator", results[0].Reference)
@@ -298,9 +298,42 @@ func TestValidateVariantDiscriminators_Ownership(t *testing.T) {
 			},
 		}
 
-		results := ValidateVariantDiscriminatorsV0(variants, nil, "/types/0", graph)
+		results := ValidateVariantSemanticV0(variants, nil, "/types/0", graph)
 
 		require.Len(t, results, 1)
 		assert.Contains(t, results[0].Message, "must reference a property defined in the parent's own properties")
+	})
+}
+
+func TestCheckDuplicatePropertyRefsV0(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no duplicates", func(t *testing.T) {
+		t.Parallel()
+
+		props := []localcatalog.PropertyReference{
+			{Ref: "#/properties/signup-props/email"},
+			{Ref: "#/properties/signup-props/name"},
+		}
+
+		results := CheckDuplicatePropertyRefsV0(props, "/rules/0/variants/0/cases/0/properties")
+		assert.Empty(t, results)
+	})
+
+	t.Run("duplicates reported at every occurrence", func(t *testing.T) {
+		t.Parallel()
+
+		props := []localcatalog.PropertyReference{
+			{Ref: "#/properties/signup-props/email"},
+			{Ref: "#/properties/signup-props/name"},
+			{Ref: "#/properties/signup-props/email"},
+		}
+
+		results := CheckDuplicatePropertyRefsV0(props, "/rules/0/variants/0/cases/0/properties")
+		require.Len(t, results, 2)
+		assert.Equal(t, "/rules/0/variants/0/cases/0/properties/0/$ref", results[0].Reference)
+		assert.Contains(t, results[0].Message, "duplicate property reference in tracking plan event rule")
+		assert.Equal(t, "/rules/0/variants/0/cases/0/properties/2/$ref", results[1].Reference)
+		assert.Contains(t, results[1].Message, "duplicate property reference in tracking plan event rule")
 	})
 }

--- a/cli/internal/providers/datacatalog/rules/variant/variant_v0_validation_test.go
+++ b/cli/internal/providers/datacatalog/rules/variant/variant_v0_validation_test.go
@@ -316,7 +316,7 @@ func TestCheckDuplicatePropertyRefsV0(t *testing.T) {
 			{Ref: "#/properties/signup-props/name"},
 		}
 
-		results := CheckDuplicatePropertyRefsV0(props, "/rules/0/variants/0/cases/0/properties")
+		results := checkDuplicatePropertyRefsV0(props, "/rules/0/variants/0/cases/0/properties")
 		assert.Empty(t, results)
 	})
 
@@ -329,7 +329,7 @@ func TestCheckDuplicatePropertyRefsV0(t *testing.T) {
 			{Ref: "#/properties/signup-props/email"},
 		}
 
-		results := CheckDuplicatePropertyRefsV0(props, "/rules/0/variants/0/cases/0/properties")
+		results := checkDuplicatePropertyRefsV0(props, "/rules/0/variants/0/cases/0/properties")
 		require.Len(t, results, 2)
 		assert.Equal(t, "/rules/0/variants/0/cases/0/properties/0/$ref", results[0].Reference)
 		assert.Contains(t, results[0].Message, "duplicate property reference in tracking plan event rule")

--- a/cli/internal/providers/datacatalog/rules/variant/variant_v1_validation.go
+++ b/cli/internal/providers/datacatalog/rules/variant/variant_v1_validation.go
@@ -43,21 +43,21 @@ func ValidateVariantSemanticV1(
 			caseRef := fmt.Sprintf("%s/variants/%d/cases/%d/properties", basePath, i, c)
 			results = append(
 				results,
-				CheckDuplicatePropertyRefsV1(vCase.Properties, caseRef)...)
+				checkDuplicatePropertyRefsV1(vCase.Properties, caseRef)...)
 		}
 
 		defaultRef := fmt.Sprintf("%s/variants/%d/default/properties", basePath, i)
 		results = append(
 			results,
-			CheckDuplicatePropertyRefsV1(vt.Default.Properties, defaultRef)...)
+			checkDuplicatePropertyRefsV1(vt.Default.Properties, defaultRef)...)
 	}
 
 	return results
 }
 
-// CheckDuplicatePropertyRefsV1 dedupes a flat list of V1 variant property refs
+// checkDuplicatePropertyRefsV1 dedupes a flat list of V1 variant property refs
 // and emits one error per occurrence of any ref that appears more than once.
-func CheckDuplicatePropertyRefsV1(props []localcatalog.PropertyReferenceV1, parentRef string) []rules.ValidationResult {
+func checkDuplicatePropertyRefsV1(props []localcatalog.PropertyReferenceV1, parentRef string) []rules.ValidationResult {
 	counts := make(map[string]int)
 	for _, prop := range props {
 		counts[prop.Property]++

--- a/cli/internal/providers/datacatalog/rules/variant/variant_v1_validation.go
+++ b/cli/internal/providers/datacatalog/rules/variant/variant_v1_validation.go
@@ -9,11 +9,11 @@ import (
 	"github.com/rudderlabs/rudder-iac/cli/internal/validation/rules"
 )
 
-// ValidateVariantDiscriminatorsV1 checks all V1 variants' discriminators for:
-//  1. Type validity — discriminator property must be string, integer, or boolean.
-//     For custom type refs, the referenced custom type's own type is validated.
-//  2. Ownership — discriminator must reference a property in the parent's own properties.
-func ValidateVariantDiscriminatorsV1(
+// ValidateVariantSemanticV1 runs all semantic checks on V1 variants:
+//  1. Discriminator type validity — must be string, integer, or boolean.
+//  2. Discriminator ownership — must reference a property in the parent's own properties.
+//  3. Duplicate property refs — within each case and default property list.
+func ValidateVariantSemanticV1(
 	variants localcatalog.VariantsV1,
 	ownPropertyRefs []string,
 	basePath string,
@@ -21,10 +21,10 @@ func ValidateVariantDiscriminatorsV1(
 ) []rules.ValidationResult {
 	var results []rules.ValidationResult
 
-	for i, v := range variants {
+	for i, vt := range variants {
 		discriminatorPath := fmt.Sprintf("%s/variants/%d/discriminator", basePath, i)
 
-		if !slices.Contains(ownPropertyRefs, v.Discriminator) {
+		if !slices.Contains(ownPropertyRefs, vt.Discriminator) {
 			results = append(results, rules.ValidationResult{
 				Reference: discriminatorPath,
 				Message:   "discriminator must reference a property defined in the parent's own properties",
@@ -34,11 +34,43 @@ func ValidateVariantDiscriminatorsV1(
 		results = append(
 			results,
 			validateDiscriminatorType(
-				v.Discriminator,
+				vt.Discriminator,
 				discriminatorPath,
 				graph,
 			)...)
+
+		for c, vCase := range vt.Cases {
+			caseRef := fmt.Sprintf("%s/variants/%d/cases/%d/properties", basePath, i, c)
+			results = append(
+				results,
+				CheckDuplicatePropertyRefsV1(vCase.Properties, caseRef)...)
+		}
+
+		defaultRef := fmt.Sprintf("%s/variants/%d/default/properties", basePath, i)
+		results = append(
+			results,
+			CheckDuplicatePropertyRefsV1(vt.Default.Properties, defaultRef)...)
 	}
 
+	return results
+}
+
+// CheckDuplicatePropertyRefsV1 dedupes a flat list of V1 variant property refs
+// and emits one error per occurrence of any ref that appears more than once.
+func CheckDuplicatePropertyRefsV1(props []localcatalog.PropertyReferenceV1, parentRef string) []rules.ValidationResult {
+	counts := make(map[string]int)
+	for _, prop := range props {
+		counts[prop.Property]++
+	}
+
+	var results []rules.ValidationResult
+	for i, prop := range props {
+		if counts[prop.Property] > 1 {
+			results = append(results, rules.ValidationResult{
+				Reference: fmt.Sprintf("%s/%d/property", parentRef, i),
+				Message:   "duplicate property reference in tracking plan event rule",
+			})
+		}
+	}
 	return results
 }

--- a/cli/internal/providers/datacatalog/rules/variant/variant_v1_validation_test.go
+++ b/cli/internal/providers/datacatalog/rules/variant/variant_v1_validation_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestValidateVariantDiscriminatorsV1_TypeCheck(t *testing.T) {
+func TestValidateVariantSemanticV1_TypeCheck(t *testing.T) {
 	t.Parallel()
 
 	t.Run("valid discriminator type — string", func(t *testing.T) {
@@ -32,7 +32,7 @@ func TestValidateVariantDiscriminatorsV1_TypeCheck(t *testing.T) {
 			},
 		}
 
-		results := ValidateVariantDiscriminatorsV1(variants, []string{"#property:signup_method"}, "/types/0", graph)
+		results := ValidateVariantSemanticV1(variants, []string{"#property:signup_method"}, "/types/0", graph)
 		assert.Empty(t, results, "string type should be valid for discriminator")
 	})
 
@@ -56,7 +56,7 @@ func TestValidateVariantDiscriminatorsV1_TypeCheck(t *testing.T) {
 			},
 		}
 
-		results := ValidateVariantDiscriminatorsV1(variants, []string{"#property:level"}, "/types/0", graph)
+		results := ValidateVariantSemanticV1(variants, []string{"#property:level"}, "/types/0", graph)
 		assert.Empty(t, results, "integer type should be valid for discriminator")
 	})
 
@@ -80,7 +80,7 @@ func TestValidateVariantDiscriminatorsV1_TypeCheck(t *testing.T) {
 			},
 		}
 
-		results := ValidateVariantDiscriminatorsV1(variants, []string{"#property:is_active"}, "/types/0", graph)
+		results := ValidateVariantSemanticV1(variants, []string{"#property:is_active"}, "/types/0", graph)
 		assert.Empty(t, results, "boolean type should be valid for discriminator")
 	})
 
@@ -104,7 +104,7 @@ func TestValidateVariantDiscriminatorsV1_TypeCheck(t *testing.T) {
 			},
 		}
 
-		results := ValidateVariantDiscriminatorsV1(variants, []string{"#property:address"}, "/types/0", graph)
+		results := ValidateVariantSemanticV1(variants, []string{"#property:address"}, "/types/0", graph)
 
 		require.Len(t, results, 1)
 		assert.Equal(t, "/types/0/variants/0/discriminator", results[0].Reference)
@@ -131,7 +131,7 @@ func TestValidateVariantDiscriminatorsV1_TypeCheck(t *testing.T) {
 			},
 		}
 
-		results := ValidateVariantDiscriminatorsV1(variants, []string{"#property:tags"}, "/types/0", graph)
+		results := ValidateVariantSemanticV1(variants, []string{"#property:tags"}, "/types/0", graph)
 
 		require.Len(t, results, 1)
 		assert.Contains(t, results[0].Message, "discriminator property type 'array' must contain one of: string, integer, boolean")
@@ -161,7 +161,7 @@ func TestValidateVariantDiscriminatorsV1_TypeCheck(t *testing.T) {
 			},
 		}
 
-		results := ValidateVariantDiscriminatorsV1(variants, []string{"#property:payment_method"}, "/types/0", graph)
+		results := ValidateVariantSemanticV1(variants, []string{"#property:payment_method"}, "/types/0", graph)
 		assert.Empty(t, results, "custom type ref with valid underlying type should be allowed")
 	})
 
@@ -189,7 +189,7 @@ func TestValidateVariantDiscriminatorsV1_TypeCheck(t *testing.T) {
 			},
 		}
 
-		results := ValidateVariantDiscriminatorsV1(variants, []string{"#property:address_field"}, "/types/0", graph)
+		results := ValidateVariantSemanticV1(variants, []string{"#property:address_field"}, "/types/0", graph)
 
 		require.Len(t, results, 1)
 		assert.Equal(t, "/types/0/variants/0/discriminator", results[0].Reference)
@@ -217,12 +217,12 @@ func TestValidateVariantDiscriminatorsV1_TypeCheck(t *testing.T) {
 			},
 		}
 
-		results := ValidateVariantDiscriminatorsV1(variants, []string{"#property:missing_prop"}, "/types/0", graph)
+		results := ValidateVariantSemanticV1(variants, []string{"#property:missing_prop"}, "/types/0", graph)
 		assert.Empty(t, results, "missing ref should be skipped for type check — reported by ValidateReferences")
 	})
 }
 
-func TestValidateVariantDiscriminatorsV1_Ownership(t *testing.T) {
+func TestValidateVariantSemanticV1_Ownership(t *testing.T) {
 	t.Parallel()
 
 	t.Run("discriminator exists in own properties", func(t *testing.T) {
@@ -246,7 +246,7 @@ func TestValidateVariantDiscriminatorsV1_Ownership(t *testing.T) {
 		}
 
 		ownRefs := []string{"#property:email", "#property:signup_method"}
-		results := ValidateVariantDiscriminatorsV1(variants, ownRefs, "/types/0", graph)
+		results := ValidateVariantSemanticV1(variants, ownRefs, "/types/0", graph)
 		assert.Empty(t, results, "discriminator found in own properties — no error")
 	})
 
@@ -271,7 +271,7 @@ func TestValidateVariantDiscriminatorsV1_Ownership(t *testing.T) {
 		}
 
 		ownRefs := []string{"#property:email", "#property:phone"}
-		results := ValidateVariantDiscriminatorsV1(variants, ownRefs, "/types/0", graph)
+		results := ValidateVariantSemanticV1(variants, ownRefs, "/types/0", graph)
 
 		require.Len(t, results, 1)
 		assert.Equal(t, "/types/0/variants/0/discriminator", results[0].Reference)
@@ -298,9 +298,42 @@ func TestValidateVariantDiscriminatorsV1_Ownership(t *testing.T) {
 			},
 		}
 
-		results := ValidateVariantDiscriminatorsV1(variants, nil, "/types/0", graph)
+		results := ValidateVariantSemanticV1(variants, nil, "/types/0", graph)
 
 		require.Len(t, results, 1)
 		assert.Contains(t, results[0].Message, "must reference a property defined in the parent's own properties")
+	})
+}
+
+func TestCheckDuplicatePropertyRefsV1(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no duplicates", func(t *testing.T) {
+		t.Parallel()
+
+		props := []localcatalog.PropertyReferenceV1{
+			{Property: "#property:email"},
+			{Property: "#property:name"},
+		}
+
+		results := CheckDuplicatePropertyRefsV1(props, "/rules/0/variants/0/cases/0/properties")
+		assert.Empty(t, results)
+	})
+
+	t.Run("duplicates reported at every occurrence", func(t *testing.T) {
+		t.Parallel()
+
+		props := []localcatalog.PropertyReferenceV1{
+			{Property: "#property:email"},
+			{Property: "#property:name"},
+			{Property: "#property:email"},
+		}
+
+		results := CheckDuplicatePropertyRefsV1(props, "/rules/0/variants/0/cases/0/properties")
+		require.Len(t, results, 2)
+		assert.Equal(t, "/rules/0/variants/0/cases/0/properties/0/property", results[0].Reference)
+		assert.Contains(t, results[0].Message, "duplicate property reference in tracking plan event rule")
+		assert.Equal(t, "/rules/0/variants/0/cases/0/properties/2/property", results[1].Reference)
+		assert.Contains(t, results[1].Message, "duplicate property reference in tracking plan event rule")
 	})
 }

--- a/cli/internal/providers/datacatalog/rules/variant/variant_v1_validation_test.go
+++ b/cli/internal/providers/datacatalog/rules/variant/variant_v1_validation_test.go
@@ -316,7 +316,7 @@ func TestCheckDuplicatePropertyRefsV1(t *testing.T) {
 			{Property: "#property:name"},
 		}
 
-		results := CheckDuplicatePropertyRefsV1(props, "/rules/0/variants/0/cases/0/properties")
+		results := checkDuplicatePropertyRefsV1(props, "/rules/0/variants/0/cases/0/properties")
 		assert.Empty(t, results)
 	})
 
@@ -329,7 +329,7 @@ func TestCheckDuplicatePropertyRefsV1(t *testing.T) {
 			{Property: "#property:email"},
 		}
 
-		results := CheckDuplicatePropertyRefsV1(props, "/rules/0/variants/0/cases/0/properties")
+		results := checkDuplicatePropertyRefsV1(props, "/rules/0/variants/0/cases/0/properties")
 		require.Len(t, results, 2)
 		assert.Equal(t, "/rules/0/variants/0/cases/0/properties/0/property", results[0].Reference)
 		assert.Contains(t, results[0].Message, "duplicate property reference in tracking plan event rule")


### PR DESCRIPTION
## 🔗 Ticket

resolves [DEX-313](https://linear.app/rudderstack/issue/DEX-313/tracking-plan-duplicate-validations-rule-ids-events-properties)

---

## Summary

Tracking plan specs previously accepted duplicates silently — repeated rule IDs, repeated event refs, and the same property listed twice at the same level would all pass validation. This adds three duplicate checks across both V0 (`tp`) and V1 (`tracking-plan`) spec formats. Variant property dedup is implemented in the shared `variant/` package via `ValidateVariantSemanticV0/V1`, which consolidates discriminator checks and duplicate property ref checks into a single entry point — reused by both tracking plans and custom types.

---

## Changes

* **Duplicate rule IDs** — syntactic layer (`trackingplan_spec_valid.go`). Generic `validateDuplicateRuleIDs[T any]` with key extractor, shared across V0/V1. Skips empty IDs to avoid double-reporting with `required` struct-tag validation.
* **Duplicate events** — semantic layer. Raw-string dedup on event refs for both V0 and V1.
* **Duplicate properties at same sibling level** — semantic layer. Walks `rules[*].properties` recursively via `checkDuplicateSiblingPropsV0/V1`.
* **Variant semantic validation** — `ValidateVariantDiscriminatorsV0/V1` renamed to `ValidateVariantSemanticV0/V1`. Now includes both discriminator checks (type + ownership) and duplicate property ref checks (`cases[*].properties` and `default`). Each sibling list is an independent scope.
* **Custom types** — callers updated to `ValidateVariantSemanticV0/V1`, gaining variant property dedup for free.
* Static error messages: `duplicate rule id in tracking plan rules`, `duplicate event reference in tracking plan rules`, `duplicate property reference in tracking plan event rule`.
* Every duplicate occurrence emits its own error at its own JSON-pointer location.

---

## Testing

* **Syntactic tests** (`trackingplan_spec_valid_test.go`): duplicate rule IDs V0/V1 — no-dup, two-dup, three-dup, case-sensitivity, empty-id-with-duplicate mix through full pipeline.
* **Semantic tests** (`trackingplan_semantic_validation_test.go`): duplicate events V0/V1, duplicate properties at top-level/nested/parent-vs-child/sibling-parents, variant dedup integration through `validateTrackingPlanSemantic/V1` covering case dup + default dup + cross-case non-dup.
* **Variant package tests** (`variant_v0/v1_validation_test.go`): exhaustive `CheckDuplicatePropertyRefsV0/V1` — no-dup and dup-reported-at-every-occurrence.
* **Custom type tests** (`customtype_semantic_validation_test.go`, `customtype_v1_validation_test.go`): variant duplicate properties V0/V1 through `validateCustomTypeSemantic/V1` entry points — dup in case + default, and no-dup.
* `make test` — all packages pass.
* `make lint` — 0 issues.

---

## Risk / Impact

Low

Validation-only change with no apply-cycle behavior changes. Existing valid specs remain valid. Previously silently-accepted duplicate-containing specs will now fail validation with clear errors pointing to each duplicate location.

---

## Checklist

* [x] Ticket linked
* [x] Tests added/updated
* [x] No breaking changes (or documented)