### PR TITLE
doc: extract the variants into a separate section outside of trackingplan and custom-types combined

### DIFF
--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -252,7 +252,7 @@ spec:
 
 **Scope:** spec
 
-**Why:** `$ref` is a JSON Schema artifact that carries no semantic meaning in this context; `property` is clearer. Config keys follow the same snake_case convention as properties. The variant `default` restructuring removes an awkward array-of-objects pattern in favour of an explicit `properties` wrapper that matches the shape used in rules.
+**Why:** `$ref` is a JSON Schema artifact that carries no semantic meaning in this context; `property` is clearer. Config keys follow the same snake_case convention as properties.
 
 **a) `$ref` renamed to `property` in type properties**
 
@@ -290,32 +290,13 @@ config:
   max_length: 255
 ```
 
-**c) Variant `default` restructured from array to object**
-
-```yaml
-# Before (v0.1)
-variants:
-  - type: discriminator
-    default:
-      - $ref: "#/properties/group/prop_a"
-        required: true
-
-# After (v1)
-variants:
-  - type: discriminator
-    default:
-      properties:
-        - property: "#property:prop_a"
-          required: true
-```
-
 ### 6. Tracking plan rule changes
 
 **Scope:** spec
 
-**Why:** The event object wrapper was redundant — `event` now holds a direct reference string, consistent with how other references are expressed. `allow_unplanned` is renamed to `additional_properties` and moved to rule level for clarity. `$ref` is replaced by `property` for the same reasons as in custom types.
+**Why:** The event object wrapper was redundant — `event` now holds a direct reference string, consistent with how other references are expressed. `allow_unplanned` is renamed to `additional_properties` and moved to rule level for clarity. Rule property references follow the same `$ref` → `property` rename as custom types, using compact URNs.
 
-Three structural changes to tracking plan rules:
+Two structural changes to tracking plan rules:
 
 **a) `event` changes from object to direct reference string**
 
@@ -358,32 +339,6 @@ properties:
     required: true
   - property: "#property:password"
     required: true
-```
-
-**c) Variant discriminator and case properties follow the same `$ref` → `property` change**
-
-```yaml
-# Before (v0.1)
-variants:
-  - type: discriminator
-    discriminator: "#/properties/api_tracking/api_method"
-    cases:
-      - display_name: "Create Entity"
-        match: ["POST"]
-        properties:
-          - $ref: "#/properties/api_tracking/user_agent"
-            required: true
-
-# After (v1)
-variants:
-  - type: discriminator
-    discriminator: "#property:api_method"
-    cases:
-      - display_name: "Create Entity"
-        match: ["POST"]
-        properties:
-          - property: "#property:user_agent"
-            required: true
 ```
 
 **Full before/after example:**
@@ -431,7 +386,60 @@ spec:
           required: true
 ```
 
-### 7. Import metadata: `local_id` → `urn`
+### 7. Variant changes
+
+**Scope:** spec
+
+**Why:** Variants appear in both custom types and tracking plan rules. The `default` field is restructured from an array-of-objects pattern to an explicit `properties` wrapper that matches the shape used in rules. All `$ref` fields within variant discriminators and cases follow the same rename to `property` with compact URN references.
+
+Two changes to variant definitions:
+
+**a) Variant `default` restructured from array to object**
+
+```yaml
+# Before (v0.1)
+variants:
+  - type: discriminator
+    default:
+      - $ref: "#/properties/group/prop_a"
+        required: true
+
+# After (v1)
+variants:
+  - type: discriminator
+    default:
+      properties:
+        - property: "#property:prop_a"
+          required: true
+```
+
+**b) Variant discriminator and case properties: `$ref` → `property` with compact URN**
+
+```yaml
+# Before (v0.1)
+variants:
+  - type: discriminator
+    discriminator: "#/properties/api_tracking/api_method"
+    cases:
+      - display_name: "Create Entity"
+        match: ["POST"]
+        properties:
+          - $ref: "#/properties/api_tracking/user_agent"
+            required: true
+
+# After (v1)
+variants:
+  - type: discriminator
+    discriminator: "#property:api_method"
+    cases:
+      - display_name: "Create Entity"
+        match: ["POST"]
+        properties:
+          - property: "#property:user_agent"
+            required: true
+```
+
+### 8. Import metadata: `local_id` → `urn`
 
 **Scope:** spec, import
 
@@ -467,7 +475,7 @@ metadata:
 
 URN format is `<resource-type>:<local-id>`. Resource types include: `property`, `event`, `category`, `custom-type`, `tracking-plan`, `event-stream-source`, `retl-source-sql-model`.
 
-### 8. Event stream source: tracking plan reference
+### 9. Event stream source: tracking plan reference
 
 **Scope:** spec, event-stream
 

--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -25,7 +25,7 @@ Below sections enumerate the changes in the spec format one by one providing the
 
 **Scope:** spec
 
-**Why:** Standardizes the version identifier to a semver-style prefix, eliminating the ambiguous `0.1` / `v0.1` variants.
+**Why:** The field-name, convention, and reference changes in `rudder/v1` break the existing spec contract. The version is bumped to signal the new contract, so tooling and validation can distinguish it from legacy `rudder/0.1`.
 
 All spec files must update the `version` field.
 


### PR DESCRIPTION
Scanned-by: gitleaks 8.30.0

## 🔗 Ticket

<!-- Required for traceability -->

Resolves [DEX-312](https://linear.app/rudderstack/issue/DEX-316/separate-the-variant-sections-from-the-customtype-and-trackingplans)

---

## Summary

Extract the variants outside of trackingplan and customtypes section into it's own section in the BREAKING_CHANGES.md

---

## Changes

- BREAKING_CHANGES.md

---

## Testing

How was this tested?

- Unit tests / Integration tests / Manual testing

---

## Risk / Impact

Low / Medium / High
Notes (if any):

---

## Checklist

- [x] Ticket linked
- [x] Tests added/updated
- [x] No breaking changes (or documented)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only restructuring of `BREAKING_CHANGES.md` with no code or behavior changes; risk is limited to potential reader confusion if the re-org missed or duplicated guidance.
> 
> **Overview**
> Clarifies the `rudder/v1` migration docs by **moving all variant-related breaking changes into a dedicated “Variant changes” section**, instead of describing them partially under custom types and tracking plan rules.
> 
> Updates the surrounding rationale text and section numbering to reflect the extraction, removing the duplicated/misplaced variant examples from the earlier sections while keeping the same migration guidance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5bfadc3378009ece9d06716fc6b350d7d52b39a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->