### PR TITLE
feat(api): parallelize GetTrackingPlansWithIdentifiers using tasker framework

### DIFF
--- a/api/client/catalog/trackingplan_fetch_task.go
+++ b/api/client/catalog/trackingplan_fetch_task.go
@@ -1,0 +1,53 @@
+package catalog
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/rudderlabs/rudder-iac/cli/pkg/tasker"
+)
+
+type TrackingPlanIdentifiersFetcher interface {
+	GetTrackingPlanWithIdentifiers(ctx context.Context, id string, rebuildSchemas bool) (*TrackingPlanWithIdentifiers, error)
+}
+
+type TrackingPlanWithIdentifiersFetchTask struct {
+	trackingPlanID string
+	rebuildSchemas bool
+}
+
+func NewTrackingPlanWithIdentifiersFetchTask(trackingPlanID string, rebuildSchemas bool) *TrackingPlanWithIdentifiersFetchTask {
+	return &TrackingPlanWithIdentifiersFetchTask{
+		trackingPlanID: trackingPlanID,
+		rebuildSchemas: rebuildSchemas,
+	}
+}
+
+func (t *TrackingPlanWithIdentifiersFetchTask) Id() string {
+	return t.trackingPlanID
+}
+
+func (t *TrackingPlanWithIdentifiersFetchTask) Dependencies() []string {
+	return nil
+}
+
+func RunTrackingPlanWithIdentifiersFetchTask(
+	ctx context.Context,
+	fetcher TrackingPlanIdentifiersFetcher,
+	results *tasker.Results[*TrackingPlanWithIdentifiers],
+) func(task tasker.Task) error {
+	return func(task tasker.Task) error {
+		fetchTask, ok := task.(*TrackingPlanWithIdentifiersFetchTask)
+		if !ok {
+			return fmt.Errorf("task is not a TrackingPlanWithIdentifiersFetchTask")
+		}
+
+		tp, err := fetcher.GetTrackingPlanWithIdentifiers(ctx, fetchTask.trackingPlanID, fetchTask.rebuildSchemas)
+		if err != nil {
+			return fmt.Errorf("fetching tracking plan %s: %w", fetchTask.trackingPlanID, err)
+		}
+
+		results.Store(fetchTask.Id(), tp)
+		return nil
+	}
+}

--- a/api/client/catalog/trackingplan_fetch_task_test.go
+++ b/api/client/catalog/trackingplan_fetch_task_test.go
@@ -1,0 +1,101 @@
+package catalog
+
+import (
+	"context"
+	"testing"
+
+	"github.com/rudderlabs/rudder-iac/cli/pkg/tasker"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mockTrackingPlanIdentifiersFetcher struct {
+	calls []fetchCall
+}
+
+type fetchCall struct {
+	id             string
+	rebuildSchemas bool
+}
+
+func (m *mockTrackingPlanIdentifiersFetcher) GetTrackingPlanWithIdentifiers(
+	_ context.Context,
+	id string,
+	rebuildSchemas bool,
+) (*TrackingPlanWithIdentifiers, error) {
+	m.calls = append(m.calls, fetchCall{id: id, rebuildSchemas: rebuildSchemas})
+	return &TrackingPlanWithIdentifiers{
+		TrackingPlan: TrackingPlan{ID: id},
+	}, nil
+}
+
+func TestTrackingPlanWithIdentifiersFetchTask(t *testing.T) {
+	t.Run("satisfies tasker.Task interface with nil dependencies", func(t *testing.T) {
+		task := NewTrackingPlanWithIdentifiersFetchTask("tp-1", true)
+
+		assert.Equal(t, "tp-1", task.Id())
+		assert.Nil(t, task.Dependencies())
+	})
+
+	t.Run("calls GetTrackingPlanWithIdentifiers for each tracking plan with correct params", func(t *testing.T) {
+		var (
+			ctx     = context.Background()
+			fetcher = &mockTrackingPlanIdentifiersFetcher{}
+		)
+
+		tasks := []tasker.Task{
+			NewTrackingPlanWithIdentifiersFetchTask("tp-1", true),
+			NewTrackingPlanWithIdentifiersFetchTask("tp-2", true),
+		}
+
+		results := tasker.NewResults[*TrackingPlanWithIdentifiers]()
+		errs := tasker.RunTasks(
+			ctx,
+			tasks,
+			1,
+			false,
+			RunTrackingPlanWithIdentifiersFetchTask(ctx, fetcher, results),
+		)
+
+		require.Empty(t, errs)
+		require.Len(t, fetcher.calls, 2)
+
+		expectedCalls := []fetchCall{
+			{id: "tp-1", rebuildSchemas: true},
+			{id: "tp-2", rebuildSchemas: true},
+		}
+		assert.ElementsMatch(t, expectedCalls, fetcher.calls)
+
+		tp1, ok := results.Get("tp-1")
+		require.True(t, ok)
+		assert.Equal(t, "tp-1", tp1.ID)
+
+		tp2, ok := results.Get("tp-2")
+		require.True(t, ok)
+		assert.Equal(t, "tp-2", tp2.ID)
+	})
+
+	t.Run("passes rebuildSchemas=false correctly", func(t *testing.T) {
+		var (
+			ctx     = context.Background()
+			fetcher = &mockTrackingPlanIdentifiersFetcher{}
+		)
+
+		tasks := []tasker.Task{
+			NewTrackingPlanWithIdentifiersFetchTask("tp-1", false),
+		}
+
+		results := tasker.NewResults[*TrackingPlanWithIdentifiers]()
+		errs := tasker.RunTasks(
+			ctx,
+			tasks,
+			1,
+			false,
+			RunTrackingPlanWithIdentifiersFetchTask(ctx, fetcher, results),
+		)
+
+		require.Empty(t, errs)
+		require.Len(t, fetcher.calls, 1)
+		assert.Equal(t, fetchCall{id: "tp-1", rebuildSchemas: false}, fetcher.calls[0])
+	})
+}

--- a/api/client/catalog/trackingplans.go
+++ b/api/client/catalog/trackingplans.go
@@ -384,19 +384,34 @@ func (c *RudderDataCatalog) GetTrackingPlansWithIdentifiers(ctx context.Context,
 		return nil, fmt.Errorf("decoding tracking plans response: %w", err)
 	}
 
-	// Convert to slice of pointers and fetch full details
-	result := make([]*TrackingPlanWithIdentifiers, len(trackingPlansResp.TrackingPlans))
+	tasks := make([]tasker.Task, len(trackingPlansResp.TrackingPlans))
 	for i := range trackingPlansResp.TrackingPlans {
-		// Get full tracking plan details with events
-		trackingPlan, err := c.GetTrackingPlanWithIdentifiers(
-			ctx,
+		tasks[i] = NewTrackingPlanWithIdentifiersFetchTask(
 			trackingPlansResp.TrackingPlans[i].ID,
 			options.RebuildSchemas,
 		)
-		if err != nil {
-			return nil, fmt.Errorf("fetching tracking plan %s: %w", trackingPlansResp.TrackingPlans[i].ID, err)
+	}
+
+	results := tasker.NewResults[*TrackingPlanWithIdentifiers]()
+	errs := tasker.RunTasks(
+		ctx,
+		tasks,
+		c.concurrency,
+		false,
+		RunTrackingPlanWithIdentifiersFetchTask(ctx, c, results),
+	)
+
+	if len(errs) > 0 {
+		return nil, fmt.Errorf("fetching tracking plans with identifiers: %w", errors.Join(errs...))
+	}
+
+	result := make([]*TrackingPlanWithIdentifiers, len(trackingPlansResp.TrackingPlans))
+	for i, tp := range trackingPlansResp.TrackingPlans {
+		plan, ok := results.Get(tp.ID)
+		if !ok {
+			return nil, fmt.Errorf("tracking plan %s not found in results", tp.ID)
 		}
-		result[i] = trackingPlan
+		result[i] = plan
 	}
 
 	return result, nil


### PR DESCRIPTION
## 🔗 Ticket

Resolves [DEX-327](https://linear.app/rudderstack/issue/DEX-327/trackingplan-loading-in-parallel-in-cli)
---

## Summary

Parallelizes `GetTrackingPlansWithIdentifiers` by introducing a new `TrackingPlanWithIdentifiersFetchTask` that satisfies the `tasker.Task` interface. Previously, the function fetched each tracking plan's full details (with identifiers) sequentially in a loop. Now it creates a task per tracking plan and executes them through the tasker framework, respecting the configured concurrency level.

---

## Changes

- **New file `api/client/catalog/trackingplan_fetch_task.go`**: Introduces `TrackingPlanWithIdentifiersFetchTask` struct that captures a tracking plan ID and `rebuildSchemas` flag, satisfies `tasker.Task` with nil dependencies, and a `RunTrackingPlanWithIdentifiersFetchTask` command function that encapsulates calling `GetTrackingPlanWithIdentifiers` and storing the result.
- **New interface `TrackingPlanIdentifiersFetcher`**: Decouples the fetch task from the concrete `RudderDataCatalog` implementation for testability.
- **Refactored `GetTrackingPlansWithIdentifiers`**: Replaced the sequential for-loop with task creation + `tasker.RunTasks` for parallel execution.
- **New test file `api/client/catalog/trackingplan_fetch_task_test.go`**: Verifies the task satisfies the interface, calls `GetTrackingPlanWithIdentifiers` the correct number of times with correct params, and correctly stores results.

---

## Testing

- Unit tests added verifying:
  - Task satisfies `tasker.Task` interface with nil dependencies
  - With concurrency 1 and 2 tracking plans, `GetTrackingPlanWithIdentifiers` is called exactly 2 times with correct IDs and `rebuildSchemas` flag
  - `rebuildSchemas=false` is propagated correctly
- `make lint` passes
- All API tests pass (`go test ./api/...`)

---

## Risk / Impact

Low — The change replaces a sequential loop with parallel task execution using the existing tasker framework. The behavior is functionally equivalent, with the added benefit of concurrent fetching when `concurrency > 1`.

---

## Checklist

- [x] Ticket linked
- [x] Tests added/updated
- [x] No breaking changes (or documented)


