### PR TITLE
fix(typer/swift): wrap multi-type union defaults in case constructors

### DIFF
--- a/cli/internal/typer/generator/platforms/swift/generator.go
+++ b/cli/internal/typer/generator/platforms/swift/generator.go
@@ -615,6 +615,27 @@ func createMultiTypeEnum(name, comment string, types []plan.PropertyType) (*Swif
 	return &SwiftMultiTypeEnum{Name: name, Comment: comment, Cases: cases}, nil
 }
 
+// multiTypeLiteral formats a discriminator literal as a multi-type enum case
+// expression (e.g. `.bool(true)`, `.string("beta")`) so it type-checks against
+// the generated union enum.
+func multiTypeLiteral(value any) string {
+	if value == nil {
+		return ".null"
+	}
+	switch value.(type) {
+	case string:
+		return fmt.Sprintf(".string(%s)", FormatSwiftLiteral(value))
+	case int, int32, int64:
+		return fmt.Sprintf(".int(%s)", FormatSwiftLiteral(value))
+	case float32, float64:
+		return fmt.Sprintf(".double(%s)", FormatSwiftLiteral(value))
+	case bool:
+		return fmt.Sprintf(".bool(%s)", FormatSwiftLiteral(value))
+	default:
+		return FormatSwiftLiteral(value)
+	}
+}
+
 func primitiveToMultiTypeCase(t plan.PrimitiveType) (SwiftMultiTypeCase, error) {
 	switch t {
 	case plan.PrimitiveTypeString:
@@ -676,6 +697,10 @@ func createVariantEnum(name, comment string, baseSchema *plan.ObjectSchema, vari
 					// must use enum case syntax (.post) rather than a string literal ("POST").
 					if strings.HasSuffix(prop.SerializeExpr, ".rawValue") {
 						prop.ConstantValue = "." + FormatEnumCaseName(matchStr)
+					} else if strings.HasSuffix(prop.SerializeExpr, ".value") {
+						// Multi-type union enum: wrap the literal in the matching
+						// case constructor so the default type-checks against the union.
+						prop.ConstantValue = multiTypeLiteral(vc.Match[0])
 					} else {
 						prop.ConstantValue = FormatSwiftLiteral(vc.Match[0])
 					}

--- a/cli/internal/typer/generator/platforms/swift/testdata/RudderTyper.swift
+++ b/cli/internal/typer/generator/platforms/swift/testdata/RudderTyper.swift
@@ -82,7 +82,7 @@ public enum CustomTypeFeatureConfig {
         /// User's age
         public let age: CustomTypeAge?
         /// Feature flag that can be boolean or string
-        public let featureFlag: PropertyFeatureFlag = true
+        public let featureFlag: PropertyFeatureFlag = .bool(true)
         public init(age: CustomTypeAge? = nil) {
             self.age = age
         }
@@ -99,7 +99,7 @@ public enum CustomTypeFeatureConfig {
     /// Feature disabled (boolean false)
     public struct CaseDisabled {
         /// Feature flag that can be boolean or string
-        public let featureFlag: PropertyFeatureFlag = false
+        public let featureFlag: PropertyFeatureFlag = .bool(false)
         /// User's first name
         public let firstName: PropertyFirstName?
         public init(firstName: PropertyFirstName? = nil) {
@@ -118,7 +118,7 @@ public enum CustomTypeFeatureConfig {
     /// Feature in beta (string 'beta')
     public struct CaseBeta {
         /// Feature flag that can be boolean or string
-        public let featureFlag: PropertyFeatureFlag = "beta"
+        public let featureFlag: PropertyFeatureFlag = .string("beta")
         /// User tags as array of strings
         public let tags: PropertyTags?
         public init(tags: PropertyTags? = nil) {


### PR DESCRIPTION
## 🔗 Ticket

Resolves [DEX-317](https://linear.app/rudderstack/issue/DEX-317)

---

## Summary

The Swift generator emitted bare literals (`= true`, `= false`, `= "beta"`) as default values for variant-discriminator fields whose type is a multi-type union enum (e.g. `PropertyFeatureFlag` with `.bool(Bool)` / `.string(String)` cases). Those defaults do not type-check — Swift enums are not `ExpressibleByBooleanLiteral`/`ExpressibleByStringLiteral` — so the generated code would fail to compile. The golden-file test only did a string compare on the generator output, so the bug slipped through.

This fix detects the `.value`-suffixed serialize expression (the marker for multi-type enum fields) and wraps the discriminator's match value in the appropriate case constructor, producing `= .bool(true)`, `= .bool(false)`, `= .string("beta")`.

---

## Changes

- Added `multiTypeLiteral` helper in `generator.go` that maps a Go literal to the matching Swift case constructor (`.bool`, `.string`, `.int`, `.double`, `.null`).
- Extended the discriminator-default branch in `createVariantEnum` to call `multiTypeLiteral` when the property's serialize expression ends in `.value` (i.e. the field is a multi-type union enum).
- Regenerated the Swift testdata (`RudderTyper.swift`) so the three `CustomTypeFeatureConfig` cases now emit valid defaults.

---

## Testing

- `go test ./cli/internal/typer/generator/platforms/swift/... -count=1` — passes.
- Manually verified the generated defaults type-check against `PropertyFeatureFlag`.
- End-to-end compilation against the Swift SDK is covered by the upcoming validator work (DEX-319+) which surfaced this bug.

---

## Risk / Impact

Low.

Scope is limited to Swift code generation. The only behavioral change is in the default-value literal for multi-type union discriminator fields — the previous output did not compile, so there are no downstream consumers of the broken form.

---

## Checklist

- [x] Ticket linked
- [x] Tests added/updated
- [x] No breaking changes (or documented)