### PR TITLE
feat(typer/swift): add Swift validator skeleton + identify smoke test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,4 +75,4 @@ typer-swift-validate: ## Validate generated Swift code against the RudderStack S
 	mkdir -p cli/internal/typer/generator/platforms/swift/testdata/validator/Sources/RudderTyper
 	cp cli/internal/typer/generator/platforms/swift/testdata/RudderTyper.swift \
 	   cli/internal/typer/generator/platforms/swift/testdata/validator/Sources/RudderTyper/RudderTyper.swift
-	cd cli/internal/typer/generator/platforms/swift/testdata/validator && swift test
+	cd cli/internal/typer/generator/platforms/swift/testdata/validator && swift test --disable-swift-testing

--- a/Makefile
+++ b/Makefile
@@ -69,3 +69,10 @@ typer-kotlin-update-testdata: ## Update test data for Kotlin code generation
 typer-swift-update-testdata: ## Update test data for Swift code generation
 	go run cli/internal/typer/generator/platforms/swift/testutils/generate_reference_plan.go \
 	  > cli/internal/typer/generator/platforms/swift/testdata/RudderTyper.swift
+
+.PHONY: typer-swift-validate
+typer-swift-validate: ## Validate generated Swift code against the RudderStack Swift SDK
+	mkdir -p cli/internal/typer/generator/platforms/swift/testdata/validator/Sources/RudderTyper
+	cp cli/internal/typer/generator/platforms/swift/testdata/RudderTyper.swift \
+	   cli/internal/typer/generator/platforms/swift/testdata/validator/Sources/RudderTyper/RudderTyper.swift
+	cd cli/internal/typer/generator/platforms/swift/testdata/validator && swift test

--- a/cli/internal/typer/generator/platforms/swift/testdata/validator/.gitignore
+++ b/cli/internal/typer/generator/platforms/swift/testdata/validator/.gitignore
@@ -1,0 +1,4 @@
+.build/
+.swiftpm/
+Package.resolved
+Sources/RudderTyper/*.swift

--- a/cli/internal/typer/generator/platforms/swift/testdata/validator/Package.swift
+++ b/cli/internal/typer/generator/platforms/swift/testdata/validator/Package.swift
@@ -1,0 +1,28 @@
+// swift-tools-version:5.9
+import PackageDescription
+
+let package = Package(
+    name: "RudderTyperValidator",
+    platforms: [
+        .macOS(.v13),
+        .iOS(.v13),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/rudderlabs/rudder-sdk-swift.git", exact: "1.2.1"),
+    ],
+    targets: [
+        .target(
+            name: "RudderTyper",
+            dependencies: [
+                .product(name: "RudderStackAnalytics", package: "rudder-sdk-swift"),
+            ]
+        ),
+        .testTarget(
+            name: "RudderTyperTests",
+            dependencies: [
+                "RudderTyper",
+                .product(name: "RudderStackAnalytics", package: "rudder-sdk-swift"),
+            ]
+        ),
+    ]
+)

--- a/cli/internal/typer/generator/platforms/swift/testdata/validator/Sources/RudderTyperTests/EventValidationPlugin.swift
+++ b/cli/internal/typer/generator/platforms/swift/testdata/validator/Sources/RudderTyperTests/EventValidationPlugin.swift
@@ -1,0 +1,138 @@
+import Foundation
+import XCTest
+import RudderStackAnalytics
+
+enum EventValidation {
+    case track(name: String, properties: [String: Any] = [:])
+    case identify(userId: String, traits: [String: Any] = [:])
+    case screen(screenName: String, properties: [String: Any] = [:])
+    case group(groupId: String, traits: [String: Any] = [:])
+}
+
+final class EventValidationPlugin: Plugin {
+    var pluginType: PluginType = .onProcess
+    var analytics: Analytics?
+
+    private let lock = NSLock()
+    private var received: [Event] = []
+    private var validationIndex: Int = 0
+
+    func setup(analytics: Analytics) {
+        self.analytics = analytics
+    }
+
+    func teardown() {
+        analytics = nil
+    }
+
+    func intercept(event: Event) -> Event? {
+        lock.lock()
+        received.append(event)
+        lock.unlock()
+        return nil
+    }
+
+    func validateCount(_ expected: Int, timeout: TimeInterval = 5.0, file: StaticString = #file, line: UInt = #line) {
+        let deadline = Date().addingTimeInterval(timeout)
+        while currentCount() < expected {
+            if Date() >= deadline {
+                XCTFail("Timeout waiting for events. Expected \(expected), got \(currentCount()) after \(timeout)s", file: file, line: line)
+                return
+            }
+            Thread.sleep(forTimeInterval: 0.05)
+        }
+        let actual = currentCount()
+        if actual > expected {
+            XCTFail("Received more events than expected. Expected \(expected), got \(actual)", file: file, line: line)
+        }
+    }
+
+    func validateNext(_ expected: EventValidation, file: StaticString = #file, line: UInt = #line) {
+        lock.lock()
+        let index = validationIndex
+        let event = index < received.count ? received[index] : nil
+        validationIndex += 1
+        lock.unlock()
+
+        guard let event = event else {
+            XCTFail("No event at index \(index)", file: file, line: line)
+            return
+        }
+        validate(event: event, against: expected, file: file, line: line)
+    }
+
+    private func currentCount() -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return received.count
+    }
+
+    private func validate(event: Event, against expected: EventValidation, file: StaticString, line: UInt) {
+        switch expected {
+        case .track(let name, let properties):
+            guard let track = event as? TrackEvent else {
+                XCTFail("Expected TrackEvent, got \(type(of: event))", file: file, line: line)
+                return
+            }
+            XCTAssertEqual(track.event, name, "Track event name mismatch", file: file, line: line)
+            assertJSONEqual(track.properties, properties, label: "Track properties", file: file, line: line)
+
+        case .identify(let userId, let traits):
+            guard let identify = event as? IdentifyEvent else {
+                XCTFail("Expected IdentifyEvent, got \(type(of: event))", file: file, line: line)
+                return
+            }
+            XCTAssertEqual(identify.userId, userId, "Identify userId mismatch", file: file, line: line)
+            // Traits live under context["traits"] after the SDK processes the event.
+            let contextTraits = identify.context?["traits"]?.value
+            assertJSONEqual(contextTraits, traits, label: "Identify traits", file: file, line: line)
+
+        case .screen(let screenName, let properties):
+            guard let screen = event as? ScreenEvent else {
+                XCTFail("Expected ScreenEvent, got \(type(of: event))", file: file, line: line)
+                return
+            }
+            XCTAssertEqual(screen.event, screenName, "Screen event name mismatch", file: file, line: line)
+            assertJSONEqual(screen.properties, properties, label: "Screen properties", file: file, line: line)
+
+        case .group(let groupId, let traits):
+            guard let group = event as? GroupEvent else {
+                XCTFail("Expected GroupEvent, got \(type(of: event))", file: file, line: line)
+                return
+            }
+            XCTAssertEqual(group.groupId, groupId, "Group groupId mismatch", file: file, line: line)
+            assertJSONEqual(group.traits, traits, label: "Group traits", file: file, line: line)
+        }
+    }
+
+    private func assertJSONEqual(_ received: Any?, _ expected: [String: Any], label: String, file: StaticString, line: UInt) {
+        let receivedJSON = canonicalJSON(fromCodable: received)
+        let expectedJSON = canonicalJSON(fromDictionary: expected)
+        XCTAssertEqual(receivedJSON, expectedJSON, "\(label) mismatch", file: file, line: line)
+    }
+
+    private func canonicalJSON(fromCodable value: Any?) -> String {
+        guard let value = value else { return "{}" }
+        // If it's a CodableCollection, encode via JSONEncoder; otherwise assume [String: Any].
+        if let collection = value as? CodableCollection {
+            guard let data = try? JSONEncoder().encode(collection),
+                  let obj = try? JSONSerialization.jsonObject(with: data),
+                  let reencoded = try? JSONSerialization.data(withJSONObject: obj, options: [.sortedKeys]) else {
+                return "<encode-failed>"
+            }
+            return String(data: reencoded, encoding: .utf8) ?? "<utf8-failed>"
+        }
+        if let dict = value as? [String: Any] {
+            return canonicalJSON(fromDictionary: dict)
+        }
+        return "<unexpected-type: \(type(of: value))>"
+    }
+
+    private func canonicalJSON(fromDictionary dict: [String: Any]) -> String {
+        guard let data = try? JSONSerialization.data(withJSONObject: dict, options: [.sortedKeys]),
+              let str = String(data: data, encoding: .utf8) else {
+            return "<serialize-failed>"
+        }
+        return str
+    }
+}

--- a/cli/internal/typer/generator/platforms/swift/testdata/validator/Sources/RudderTyperTests/RudderTyperTests.swift
+++ b/cli/internal/typer/generator/platforms/swift/testdata/validator/Sources/RudderTyperTests/RudderTyperTests.swift
@@ -1,0 +1,49 @@
+import XCTest
+import RudderStackAnalytics
+@testable import RudderTyper
+
+final class RudderTyperTests: XCTestCase {
+    var analytics: Analytics!
+    var validations: EventValidationPlugin!
+    var typer: RudderTyperAnalytics!
+
+    override func setUp() {
+        super.setUp()
+        let config = Configuration(
+            writeKey: "test-write-key",
+            dataPlaneUrl: "https://localhost:1234",
+            controlPlaneUrl: "https://localhost:1234",
+            flushPolicies: [CountFlushPolicy(flushAt: 1)],
+            trackApplicationLifecycleEvents: false,
+            sessionConfiguration: SessionConfiguration(automaticSessionTracking: false)
+        )
+        analytics = Analytics(configuration: config)
+        validations = EventValidationPlugin()
+        analytics.add(plugin: validations)
+        typer = RudderTyperAnalytics(analytics: analytics)
+    }
+
+    // MARK: - identify
+
+    func testIdentify() {
+        typer.identify(
+            userId: "user-123-abc",
+            traits: IdentifyTraits(email: "john.doe@example.com", active: true)
+        )
+        typer.identify(
+            userId: "user-456-def",
+            traits: IdentifyTraits(email: "jane.smith@example.com", active: false)
+        )
+        analytics.flush()
+
+        validations.validateCount(2)
+        validations.validateNext(.identify(
+            userId: "user-123-abc",
+            traits: ["active": true, "email": "john.doe@example.com"]
+        ))
+        validations.validateNext(.identify(
+            userId: "user-456-def",
+            traits: ["active": false, "email": "jane.smith@example.com"]
+        ))
+    }
+}


### PR DESCRIPTION
## 🔗 Ticket

Resolves [DEX-319](https://linear.app/rudderstack/issue/DEX-319)

Parent: [DEX-311](https://linear.app/rudderstack/issue/DEX-311) — Add e2e tests for RudderTyper Swift.
Depends on: [DEX-317](https://github.com/rudderlabs/rudder-iac/pull/514) — the generated Swift testdata needs the multi-type union default fix to compile.

---

## Summary

Introduces a SwiftPM-based validator under `cli/internal/typer/generator/platforms/swift/testdata/validator/` that compiles the generated `RudderTyper.swift` against the real `rudder-sdk-swift` (pinned to 1.2.1) and runs XCTest cases asserting the events the typer emits. This PR lands the skeleton plus the `identify` smoke test; follow-up PRs (DEX-320/321/322) add the remaining coverage.

---

## Changes

- `Package.swift` pins `rudder-sdk-swift` at `1.2.1`, declares a `RudderTyper` library target and a `RudderTyperTests` test target.
- `.gitignore` inside the validator excludes `.build/`, `.swiftpm/`, `Package.resolved`, and the copied-in `Sources/RudderTyper/*.swift` — only the test sources are checked in.
- `Sources/RudderTyper/.gitkeep` keeps the directory in git; the generated Swift is copied in by the Makefile target at test time.
- `Sources/RudderTyperTests/EventValidationPlugin.swift` intercepts `onProcess` events, drops them before the network layer, and exposes `validateCount` / `validateNext` helpers that compare events using canonical sorted-key JSON (sidesteps `NSDictionary` / `AnyCodable` deep-equality issues).
- `Sources/RudderTyperTests/RudderTyperTests.swift` sets up `Analytics` with `trackApplicationLifecycleEvents: false` + `SessionConfiguration(automaticSessionTracking: false)` (otherwise the SDK injects lifecycle and session events that pollute the plugin's event list) and asserts the `identify` flow.
- `Makefile`: new `typer-swift-validate` target that copies the generated testdata into the package and runs `swift test`.

---

## Testing

- The validator target is opt-in (`make typer-swift-validate`). It is not wired into CI in this PR — that is a follow-up task.
- Ran `make typer-swift-validate` locally against the DEX-317 branch: `identify` test passes.

Note: on `main` today, `make typer-swift-validate` will fail to compile because the testdata contains invalid multi-type union defaults (`= true`, `= "beta"`). Once DEX-317 lands, the target passes.

---

## Risk / Impact

Low.

Everything new sits under `testdata/validator/` and is exercised only when a developer runs `make typer-swift-validate`. No production code paths or existing tests are touched.

---

## Checklist

- [x] Ticket linked
- [x] Tests added/updated
- [x] No breaking changes (or documented)