### PR TITLE
feat(retl): enhance retl api to support sourceType table

### DIFF
--- a/api/client/retl/retl.go
+++ b/api/client/retl/retl.go
@@ -26,8 +26,9 @@ type RETLSourceStore interface {
 	// GetRetlSource retrieves a RETL source by ID
 	GetRetlSource(ctx context.Context, id string) (*RETLSource, error)
 
-	// ListRetlSources lists all RETL sources
-	ListRetlSources(ctx context.Context, hasExternalId *bool) (*RETLSources, error)
+	// ListRetlSources lists RETL sources, optionally filtered by sourceType.
+	// Pass an empty sourceType to return sources of all types.
+	ListRetlSources(ctx context.Context, sourceType string, hasExternalId *bool) (*RETLSources, error)
 
 	// SetExternalId sets the external ID for a RETL source
 	SetExternalId(ctx context.Context, id string, externalId string) error

--- a/api/client/retl/retl.go
+++ b/api/client/retl/retl.go
@@ -12,6 +12,25 @@ type RETLStore interface {
 	PreviewStore
 }
 
+type ListRetlSourcesOption func(*ListRetlSourcesOptions)
+
+func WithSourceType(sourceType string) ListRetlSourcesOption {
+	return func(o *ListRetlSourcesOptions) {
+		o.SourceType = sourceType
+	}
+}
+
+func WithHasExternalId(hasExternalId *bool) ListRetlSourcesOption {
+	return func(o *ListRetlSourcesOptions) {
+		o.HasExternalId = hasExternalId
+	}
+}
+
+type ListRetlSourcesOptions struct {
+	SourceType    string
+	HasExternalId *bool
+}
+
 // RETLSourceStore is the interface for RETL source operations
 type RETLSourceStore interface {
 	// CreateRetlSource creates a new RETL source
@@ -28,7 +47,7 @@ type RETLSourceStore interface {
 
 	// ListRetlSources lists RETL sources, optionally filtered by sourceType.
 	// Pass an empty sourceType to return sources of all types.
-	ListRetlSources(ctx context.Context, sourceType string, hasExternalId *bool) (*RETLSources, error)
+	ListRetlSources(ctx context.Context, opts ...ListRetlSourcesOption) (*RETLSources, error)
 
 	// SetExternalId sets the external ID for a RETL source
 	SetExternalId(ctx context.Context, id string, externalId string) error

--- a/api/client/retl/retl.go
+++ b/api/client/retl/retl.go
@@ -13,8 +13,6 @@ type RETLStore interface {
 	PreviewStore
 }
 
-
-
 // RETLConnectionStore is the interface for RETL connection operations.
 type RETLConnectionStore interface {
 	// CreateConnection creates a new RETL connection.

--- a/api/client/retl/sources.go
+++ b/api/client/retl/sources.go
@@ -89,11 +89,14 @@ func (r *RudderRETLStore) GetRetlSource(ctx context.Context, id string) (*RETLSo
 	return result, nil
 }
 
-// ListRetlSources lists all RETL sources
-func (r *RudderRETLStore) ListRetlSources(ctx context.Context, hasExternalId *bool) (*RETLSources, error) {
+// ListRetlSources lists RETL sources, optionally filtered by sourceType.
+// Pass an empty sourceType to return sources of all types.
+func (r *RudderRETLStore) ListRetlSources(ctx context.Context, sourceType string, hasExternalId *bool) (*RETLSources, error) {
 	path := "/v2/retl-sources"
 	query := url.Values{}
-	query.Add("sourceType", string(ModelSourceType))
+	if sourceType != "" {
+		query.Add("sourceType", sourceType)
+	}
 	if hasExternalId != nil {
 		query.Add("hasExternalId", strconv.FormatBool(*hasExternalId))
 	}

--- a/api/client/retl/sources.go
+++ b/api/client/retl/sources.go
@@ -91,14 +91,19 @@ func (r *RudderRETLStore) GetRetlSource(ctx context.Context, id string) (*RETLSo
 
 // ListRetlSources lists RETL sources, optionally filtered by sourceType.
 // Pass an empty sourceType to return sources of all types.
-func (r *RudderRETLStore) ListRetlSources(ctx context.Context, sourceType string, hasExternalId *bool) (*RETLSources, error) {
+func (r *RudderRETLStore) ListRetlSources(ctx context.Context, opts ...ListRetlSourcesOption) (*RETLSources, error) {
+	options := &ListRetlSourcesOptions{}
+	for _, opt := range opts {
+		opt(options)
+	}
+
 	path := "/v2/retl-sources"
 	query := url.Values{}
-	if sourceType != "" {
-		query.Add("sourceType", sourceType)
+	if options.SourceType != "" {
+		query.Add("sourceType", options.SourceType)
 	}
-	if hasExternalId != nil {
-		query.Add("hasExternalId", strconv.FormatBool(*hasExternalId))
+	if options.HasExternalId != nil {
+		query.Add("hasExternalId", strconv.FormatBool(*options.HasExternalId))
 	}
 	url := fmt.Sprintf("%s?%s", path, query.Encode())
 	resp, err := r.client.Do(ctx, "GET", url, nil)

--- a/api/client/retl/sources_test.go
+++ b/api/client/retl/sources_test.go
@@ -2,7 +2,6 @@ package retl_test
 
 import (
 	"context"
-	"encoding/json"
 	"net/http"
 	"testing"
 
@@ -13,13 +12,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// mustMarshalConfig is a test helper that marshals a typed RETL config into
-// json.RawMessage via retl.MarshalConfig, panicking on failure.
-func mustMarshalConfig[T retl.ConfigType](t *testing.T, cfg T) json.RawMessage {
+// mustMarshalConfig wraps a typed RETL config as a retl.ConfigType for use
+// in test fixtures. Kept as a helper so call sites read consistently.
+func mustMarshalConfig[T retl.ConfigType](t *testing.T, cfg T) retl.ConfigType {
 	t.Helper()
-	raw, err := retl.MarshalConfig(cfg)
-	require.NoError(t, err)
-	return raw
+	return cfg
 }
 
 func TestCreateRetlSource(t *testing.T) {
@@ -787,14 +784,14 @@ func TestUpdateRetlSourceTable(t *testing.T) {
 	httpClient.AssertNumberOfCalls()
 }
 
-func TestDecodeConfigMalformed(t *testing.T) {
+func TestDecodeConfigTypeMismatch(t *testing.T) {
 	source := retl.RETLSource{
-		Config: "not-an-object",
+		Config: retl.RETLTableConfig{Schema: "s", Table: "t"},
 	}
 
 	_, err := retl.DecodeConfig[retl.RETLSQLModelConfig](source.Config)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "unmarshalling RETL config")
+	assert.Contains(t, err.Error(), "RETL config is")
 }
 
 func TestDecodeConfigEmpty(t *testing.T) {

--- a/api/client/retl/sources_test.go
+++ b/api/client/retl/sources_test.go
@@ -14,7 +14,7 @@ import (
 
 // mustMarshalConfig wraps a typed RETL config as a retl.ConfigType for use
 // in test fixtures. Kept as a helper so call sites read consistently.
-func mustMarshalConfig[T retl.ConfigType](t *testing.T, cfg T) retl.ConfigType {
+func mustMarshalConfig[T retl.RETLConfig](t *testing.T, cfg T) retl.RETLConfig {
 	t.Helper()
 	return cfg
 }

--- a/api/client/retl/sources_test.go
+++ b/api/client/retl/sources_test.go
@@ -227,7 +227,7 @@ func TestListRetlSources(t *testing.T) {
 
 	retlClient := retl.NewRudderRETLStore(c)
 
-	sources, err := retlClient.ListRetlSources(context.Background(), "", nil)
+	sources, err := retlClient.ListRetlSources(context.Background())
 	require.NoError(t, err)
 
 	assert.Len(t, sources.Data, 2)
@@ -286,7 +286,11 @@ func TestListRetlSourcesWithExternalID(t *testing.T) {
 	retlClient := retl.NewRudderRETLStore(c)
 
 	hasExternalID := true
-	sources, err := retlClient.ListRetlSources(context.Background(), string(retl.ModelSourceType), &hasExternalID)
+	sources, err := retlClient.ListRetlSources(
+		context.Background(),
+		retl.WithSourceType(string(retl.ModelSourceType)),
+		retl.WithHasExternalId(&hasExternalID),
+	)
 	require.NoError(t, err)
 
 	assert.Len(t, sources.Data, 1)
@@ -408,7 +412,7 @@ func TestListRetlSourcesAPIError(t *testing.T) {
 
 	retlClient := retl.NewRudderRETLStore(c)
 
-	_, err = retlClient.ListRetlSources(context.Background(), "", nil)
+	_, err = retlClient.ListRetlSources(context.Background())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "listing RETL sources")
 
@@ -456,7 +460,7 @@ func TestListRetlSourcesMalformedResponse(t *testing.T) {
 
 	retlClient := retl.NewRudderRETLStore(c)
 
-	_, err = retlClient.ListRetlSources(context.Background(), "", nil)
+	_, err = retlClient.ListRetlSources(context.Background())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unmarshalling response")
 
@@ -818,7 +822,7 @@ func TestListRetlSourcesFilterByTable(t *testing.T) {
 
 	retlClient := retl.NewRudderRETLStore(c)
 
-	_, err = retlClient.ListRetlSources(context.Background(), string(retl.TableSourceType), nil)
+	_, err = retlClient.ListRetlSources(context.Background(), retl.WithSourceType(string(retl.TableSourceType)))
 	require.NoError(t, err)
 
 	httpClient.AssertNumberOfCalls()
@@ -842,7 +846,7 @@ func TestListRetlSourcesNoFilter(t *testing.T) {
 
 	retlClient := retl.NewRudderRETLStore(c)
 
-	_, err = retlClient.ListRetlSources(context.Background(), "", nil)
+	_, err = retlClient.ListRetlSources(context.Background())
 	require.NoError(t, err)
 
 	httpClient.AssertNumberOfCalls()

--- a/api/client/retl/sources_test.go
+++ b/api/client/retl/sources_test.go
@@ -2,6 +2,7 @@ package retl_test
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"testing"
 
@@ -11,6 +12,15 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// mustMarshalConfig is a test helper that marshals a typed RETL config into
+// json.RawMessage via retl.MarshalConfig, panicking on failure.
+func mustMarshalConfig[T retl.ConfigType](t *testing.T, cfg T) json.RawMessage {
+	t.Helper()
+	raw, err := retl.MarshalConfig(cfg)
+	require.NoError(t, err)
+	return raw
+}
 
 func TestCreateRetlSource(t *testing.T) {
 	sourceConfig := retl.RETLSQLModelConfig{
@@ -47,7 +57,7 @@ func TestCreateRetlSource(t *testing.T) {
 
 	source := &retl.RETLSourceCreateRequest{
 		Name:                 "Test Source",
-		Config:               sourceConfig,
+		Config:               mustMarshalConfig(t, sourceConfig),
 		SourceType:           retl.ModelSourceType,
 		SourceDefinitionName: "postgres",
 		AccountID:            "acc123",
@@ -60,7 +70,9 @@ func TestCreateRetlSource(t *testing.T) {
 
 	assert.Equal(t, "src1", created.ID)
 	assert.Equal(t, "Test Source", created.Name)
-	assert.Equal(t, sourceConfig, created.Config)
+	decodedConfig, err := retl.DecodeConfig[retl.RETLSQLModelConfig](created.Config)
+	require.NoError(t, err)
+	assert.Equal(t, sourceConfig, decodedConfig)
 	assert.Equal(t, true, created.IsEnabled)
 	assert.Equal(t, retl.ModelSourceType, created.SourceType)
 	assert.Equal(t, "postgres", created.SourceDefinitionName)
@@ -104,7 +116,7 @@ func TestUpdateRetlSource(t *testing.T) {
 
 	source := &retl.RETLSourceUpdateRequest{
 		Name:      "Updated Source",
-		Config:    sourceConfig,
+		Config:    mustMarshalConfig(t, sourceConfig),
 		IsEnabled: true,
 		AccountID: "acc123",
 	}
@@ -114,7 +126,9 @@ func TestUpdateRetlSource(t *testing.T) {
 
 	assert.Equal(t, "src1", updated.ID)
 	assert.Equal(t, "Updated Source", updated.Name)
-	assert.Equal(t, sourceConfig, updated.Config)
+	decodedConfig, err := retl.DecodeConfig[retl.RETLSQLModelConfig](updated.Config)
+	require.NoError(t, err)
+	assert.Equal(t, sourceConfig, decodedConfig)
 	assert.Equal(t, true, updated.IsEnabled)
 	assert.Equal(t, retl.ModelSourceType, updated.SourceType)
 	assert.Equal(t, "postgres", updated.SourceDefinitionName)
@@ -213,7 +227,7 @@ func TestListRetlSources(t *testing.T) {
 
 	retlClient := retl.NewRudderRETLStore(c)
 
-	sources, err := retlClient.ListRetlSources(context.Background(), nil)
+	sources, err := retlClient.ListRetlSources(context.Background(), "", nil)
 	require.NoError(t, err)
 
 	assert.Len(t, sources.Data, 2)
@@ -272,7 +286,7 @@ func TestListRetlSourcesWithExternalID(t *testing.T) {
 	retlClient := retl.NewRudderRETLStore(c)
 
 	hasExternalID := true
-	sources, err := retlClient.ListRetlSources(context.Background(), &hasExternalID)
+	sources, err := retlClient.ListRetlSources(context.Background(), string(retl.ModelSourceType), &hasExternalID)
 	require.NoError(t, err)
 
 	assert.Len(t, sources.Data, 1)
@@ -346,7 +360,7 @@ func TestCreateRetlSourceAPIError(t *testing.T) {
 
 	source := &retl.RETLSourceCreateRequest{
 		Name:                 "Test Source",
-		Config:               sourceConfig,
+		Config:               mustMarshalConfig(t, sourceConfig),
 		SourceType:           "postgres",
 		SourceDefinitionName: "PostgreSQL",
 		AccountID:            "acc123",
@@ -394,7 +408,7 @@ func TestListRetlSourcesAPIError(t *testing.T) {
 
 	retlClient := retl.NewRudderRETLStore(c)
 
-	_, err = retlClient.ListRetlSources(context.Background(), nil)
+	_, err = retlClient.ListRetlSources(context.Background(), "", nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "listing RETL sources")
 
@@ -442,7 +456,7 @@ func TestListRetlSourcesMalformedResponse(t *testing.T) {
 
 	retlClient := retl.NewRudderRETLStore(c)
 
-	_, err = retlClient.ListRetlSources(context.Background(), nil)
+	_, err = retlClient.ListRetlSources(context.Background(), "", nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unmarshalling response")
 
@@ -491,7 +505,7 @@ func TestCreateRetlSourceMalformedResponse(t *testing.T) {
 
 	source := &retl.RETLSourceCreateRequest{
 		Name:                 "Test Source",
-		Config:               sourceConfig,
+		Config:               mustMarshalConfig(t, sourceConfig),
 		SourceType:           "postgres",
 		SourceDefinitionName: "PostgreSQL",
 		AccountID:            "acc123",
@@ -614,6 +628,223 @@ func TestSetRetlSourceExternalIDAPIError(t *testing.T) {
 	err = retlClient.SetExternalId(context.Background(), "src1", "ext-123")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "setting external ID")
+
+	httpClient.AssertNumberOfCalls()
+}
+
+func TestCreateRetlSourceTable(t *testing.T) {
+	sourceConfig := retl.RETLTableConfig{
+		PrimaryKey: "id",
+		Schema:     "public",
+		Table:      "users",
+	}
+
+	httpClient := testutils.NewMockHTTPClient(t, testutils.Call{
+		Validate: func(req *http.Request) bool {
+			expected := `{"name":"Warehouse Source","config":{"primaryKey":"id","schema":"public","table":"users"},"sourceType":"table","sourceDefinitionName":"snowflake","accountId":"acc123","enabled":true,"externalId":"ext-456"}`
+			return testutils.ValidateRequest(t, req, "POST", "https://api.rudderstack.com/v2/retl-sources", expected)
+		},
+		ResponseStatus: 200,
+		ResponseBody: `{
+			"id": "src-table-1",
+			"name": "Warehouse Source",
+			"config": {"primaryKey":"id","schema":"public","table":"users"},
+			"enabled": true,
+			"sourceType": "table",
+			"sourceDefinitionName": "snowflake",
+			"accountId": "acc123"
+		}`,
+	})
+
+	c, err := client.New("test-token", client.WithHTTPClient(httpClient))
+	require.NoError(t, err)
+
+	retlClient := retl.NewRudderRETLStore(c)
+
+	source := &retl.RETLSourceCreateRequest{
+		Name:                 "Warehouse Source",
+		Config:               mustMarshalConfig(t, sourceConfig),
+		SourceType:           retl.TableSourceType,
+		SourceDefinitionName: "snowflake",
+		AccountID:            "acc123",
+		Enabled:              true,
+		ExternalID:           "ext-456",
+	}
+
+	created, err := retlClient.CreateRetlSource(context.Background(), source)
+	require.NoError(t, err)
+
+	assert.Equal(t, "src-table-1", created.ID)
+	assert.Equal(t, retl.TableSourceType, created.SourceType)
+	assert.Equal(t, "snowflake", created.SourceDefinitionName)
+	decodedConfig, err := retl.DecodeConfig[retl.RETLTableConfig](created.Config)
+	require.NoError(t, err)
+	assert.Equal(t, sourceConfig, decodedConfig)
+
+	httpClient.AssertNumberOfCalls()
+}
+
+func TestCreateRetlSourceS3TableWithoutPrimaryKey(t *testing.T) {
+	sourceConfig := retl.RETLS3TableConfig{
+		BucketName:   "my-bucket",
+		ObjectPrefix: "data/",
+	}
+
+	httpClient := testutils.NewMockHTTPClient(t, testutils.Call{
+		Validate: func(req *http.Request) bool {
+			// primaryKey must NOT be present in the outbound body (omitempty)
+			expected := `{"name":"S3 Source","config":{"bucketName":"my-bucket","objectPrefix":"data/"},"sourceType":"table","sourceDefinitionName":"s3","accountId":"acc123","enabled":true,"externalId":"ext-s3"}`
+			return testutils.ValidateRequest(t, req, "POST", "https://api.rudderstack.com/v2/retl-sources", expected)
+		},
+		ResponseStatus: 200,
+		ResponseBody: `{
+			"id": "src-s3-1",
+			"name": "S3 Source",
+			"config": {"bucketName":"my-bucket","objectPrefix":"data/"},
+			"enabled": true,
+			"sourceType": "table",
+			"sourceDefinitionName": "s3",
+			"accountId": "acc123"
+		}`,
+	})
+
+	c, err := client.New("test-token", client.WithHTTPClient(httpClient))
+	require.NoError(t, err)
+
+	retlClient := retl.NewRudderRETLStore(c)
+
+	source := &retl.RETLSourceCreateRequest{
+		Name:                 "S3 Source",
+		Config:               mustMarshalConfig(t, sourceConfig),
+		SourceType:           retl.TableSourceType,
+		SourceDefinitionName: "s3",
+		AccountID:            "acc123",
+		Enabled:              true,
+		ExternalID:           "ext-s3",
+	}
+
+	created, err := retlClient.CreateRetlSource(context.Background(), source)
+	require.NoError(t, err)
+
+	assert.Equal(t, "src-s3-1", created.ID)
+	assert.Equal(t, retl.TableSourceType, created.SourceType)
+	assert.Equal(t, "s3", created.SourceDefinitionName)
+	decodedConfig, err := retl.DecodeConfig[retl.RETLS3TableConfig](created.Config)
+	require.NoError(t, err)
+	assert.Equal(t, sourceConfig, decodedConfig)
+	assert.Empty(t, decodedConfig.PrimaryKey, "primaryKey should not be set on the S3 config round-trip")
+
+	httpClient.AssertNumberOfCalls()
+}
+
+func TestUpdateRetlSourceTable(t *testing.T) {
+	sourceConfig := retl.RETLTableConfig{
+		PrimaryKey: "id",
+		Schema:     "analytics",
+		Table:      "orders",
+	}
+
+	httpClient := testutils.NewMockHTTPClient(t, testutils.Call{
+		Validate: func(req *http.Request) bool {
+			// Update body must NOT include sourceType (the struct has no such field)
+			expected := `{"name":"Updated Table","config":{"primaryKey":"id","schema":"analytics","table":"orders"},"enabled":true,"accountId":"acc123"}`
+			return testutils.ValidateRequest(t, req, "PUT", "https://api.rudderstack.com/v2/retl-sources/src-table-1", expected)
+		},
+		ResponseStatus: 200,
+		ResponseBody: `{
+			"id": "src-table-1",
+			"name": "Updated Table",
+			"config": {"primaryKey":"id","schema":"analytics","table":"orders"},
+			"enabled": true,
+			"sourceType": "table",
+			"sourceDefinitionName": "snowflake",
+			"accountId": "acc123"
+		}`,
+	})
+
+	c, err := client.New("test-token", client.WithHTTPClient(httpClient))
+	require.NoError(t, err)
+
+	retlClient := retl.NewRudderRETLStore(c)
+
+	source := &retl.RETLSourceUpdateRequest{
+		Name:      "Updated Table",
+		Config:    mustMarshalConfig(t, sourceConfig),
+		IsEnabled: true,
+		AccountID: "acc123",
+	}
+
+	updated, err := retlClient.UpdateRetlSource(context.Background(), "src-table-1", source)
+	require.NoError(t, err)
+
+	decodedConfig, err := retl.DecodeConfig[retl.RETLTableConfig](updated.Config)
+	require.NoError(t, err)
+	assert.Equal(t, sourceConfig, decodedConfig)
+
+	httpClient.AssertNumberOfCalls()
+}
+
+func TestDecodeConfigMalformed(t *testing.T) {
+	source := retl.RETLSource{
+		Config: json.RawMessage("{not-json"),
+	}
+
+	_, err := retl.DecodeConfig[retl.RETLSQLModelConfig](source.Config)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unmarshalling RETL config")
+}
+
+func TestDecodeConfigEmpty(t *testing.T) {
+	source := retl.RETLSource{}
+
+	cfg, err := retl.DecodeConfig[retl.RETLSQLModelConfig](source.Config)
+	require.NoError(t, err)
+	assert.Equal(t, retl.RETLSQLModelConfig{}, cfg)
+}
+
+func TestListRetlSourcesFilterByTable(t *testing.T) {
+	httpClient := testutils.NewMockHTTPClient(t, testutils.Call{
+		Validate: func(req *http.Request) bool {
+			if req.URL.Query().Get("sourceType") != "table" {
+				return false
+			}
+			return testutils.ValidateRequest(t, req, "GET", "https://api.rudderstack.com/v2/retl-sources?sourceType=table", "")
+		},
+		ResponseStatus: 200,
+		ResponseBody:   `{"data":[]}`,
+	})
+
+	c, err := client.New("test-token", client.WithHTTPClient(httpClient))
+	require.NoError(t, err)
+
+	retlClient := retl.NewRudderRETLStore(c)
+
+	_, err = retlClient.ListRetlSources(context.Background(), string(retl.TableSourceType), nil)
+	require.NoError(t, err)
+
+	httpClient.AssertNumberOfCalls()
+}
+
+func TestListRetlSourcesNoFilter(t *testing.T) {
+	httpClient := testutils.NewMockHTTPClient(t, testutils.Call{
+		Validate: func(req *http.Request) bool {
+			// Empty sourceType must not add the query parameter at all
+			if _, present := req.URL.Query()["sourceType"]; present {
+				return false
+			}
+			return testutils.ValidateRequest(t, req, "GET", "https://api.rudderstack.com/v2/retl-sources", "")
+		},
+		ResponseStatus: 200,
+		ResponseBody:   `{"data":[]}`,
+	})
+
+	c, err := client.New("test-token", client.WithHTTPClient(httpClient))
+	require.NoError(t, err)
+
+	retlClient := retl.NewRudderRETLStore(c)
+
+	_, err = retlClient.ListRetlSources(context.Background(), "", nil)
+	require.NoError(t, err)
 
 	httpClient.AssertNumberOfCalls()
 }

--- a/api/client/retl/sources_test.go
+++ b/api/client/retl/sources_test.go
@@ -789,7 +789,7 @@ func TestUpdateRetlSourceTable(t *testing.T) {
 
 func TestDecodeConfigMalformed(t *testing.T) {
 	source := retl.RETLSource{
-		Config: json.RawMessage("{not-json"),
+		Config: "not-an-object",
 	}
 
 	_, err := retl.DecodeConfig[retl.RETLSQLModelConfig](source.Config)

--- a/api/client/retl/sources_test.go
+++ b/api/client/retl/sources_test.go
@@ -732,7 +732,6 @@ func TestCreateRetlSourceS3TableWithoutPrimaryKey(t *testing.T) {
 	decodedConfig, err := retl.DecodeConfig[retl.RETLS3TableConfig](created.Config)
 	require.NoError(t, err)
 	assert.Equal(t, sourceConfig, decodedConfig)
-	assert.Empty(t, decodedConfig.PrimaryKey, "primaryKey should not be set on the S3 config round-trip")
 
 	httpClient.AssertNumberOfCalls()
 }

--- a/api/client/retl/types.go
+++ b/api/client/retl/types.go
@@ -1,6 +1,8 @@
 package retl
 
 import (
+	"encoding/json"
+	"fmt"
 	"time"
 )
 
@@ -10,6 +12,7 @@ type AsyncStatus string
 
 const (
 	ModelSourceType SourceType = "model"
+	TableSourceType SourceType = "table"
 
 	Pending   AsyncStatus = "pending"
 	Failed    AsyncStatus = "failed"
@@ -18,41 +21,86 @@ const (
 
 // RETLSource represents a RETL source in the API
 type RETLSource struct {
-	ID                   string             `json:"id"`
-	Name                 string             `json:"name"`
-	Config               RETLSQLModelConfig `json:"config"`
-	IsEnabled            bool               `json:"enabled"`
-	SourceType           SourceType         `json:"sourceType"`
-	SourceDefinitionName string             `json:"sourceDefinitionName"`
-	AccountID            string             `json:"accountId"`
-	CreatedAt            *time.Time         `json:"createdAt"`
-	UpdatedAt            *time.Time         `json:"updatedAt"`
-	WorkspaceID          string             `json:"workspaceId"`
-	ExternalID           string             `json:"externalId"`
+	ID                   string          `json:"id"`
+	Name                 string          `json:"name"`
+	Config               json.RawMessage `json:"config"`
+	IsEnabled            bool            `json:"enabled"`
+	SourceType           SourceType      `json:"sourceType"`
+	SourceDefinitionName string          `json:"sourceDefinitionName"`
+	AccountID            string          `json:"accountId"`
+	CreatedAt            *time.Time      `json:"createdAt"`
+	UpdatedAt            *time.Time      `json:"updatedAt"`
+	WorkspaceID          string          `json:"workspaceId"`
+	ExternalID           string          `json:"externalId"`
 }
 
 type RETLSourceCreateRequest struct {
-	Name                 string             `json:"name"`
-	Config               RETLSQLModelConfig `json:"config"`
-	SourceType           SourceType         `json:"sourceType"`
-	SourceDefinitionName string             `json:"sourceDefinitionName"`
-	AccountID            string             `json:"accountId"`
-	Enabled              bool               `json:"enabled"`
-	ExternalID           string             `json:"externalId"`
+	Name                 string          `json:"name"`
+	Config               json.RawMessage `json:"config"`
+	SourceType           SourceType      `json:"sourceType"`
+	SourceDefinitionName string          `json:"sourceDefinitionName"`
+	AccountID            string          `json:"accountId"`
+	Enabled              bool            `json:"enabled"`
+	ExternalID           string          `json:"externalId"`
 }
 
 type RETLSourceUpdateRequest struct {
-	Name      string             `json:"name"`
-	Config    RETLSQLModelConfig `json:"config"`
-	IsEnabled bool               `json:"enabled"`
-	AccountID string             `json:"accountId"`
+	Name      string          `json:"name"`
+	Config    json.RawMessage `json:"config"`
+	IsEnabled bool            `json:"enabled"`
+	AccountID string          `json:"accountId"`
 }
 
-// RETLSourceConfig represents the config of a RETL SQL model source
+// RETLSQLModelConfig is the config shape for SQL MODEL sources.
 type RETLSQLModelConfig struct {
 	PrimaryKey  string `json:"primaryKey"`
 	Sql         string `json:"sql"`
 	Description string `json:"description,omitempty"`
+}
+
+// RETLTableConfig is the config shape for warehouse TABLE sources
+// (sourceDefinitionName = snowflake/bigquery/postgres/etc.).
+type RETLTableConfig struct {
+	PrimaryKey string `json:"primaryKey"`
+	Schema     string `json:"schema"`
+	Table      string `json:"table"`
+}
+
+// RETLS3TableConfig is the config shape for S3 TABLE sources
+// (sourceDefinitionName = s3). primaryKey is optional on S3.
+type RETLS3TableConfig struct {
+	PrimaryKey   string `json:"primaryKey,omitempty"`
+	BucketName   string `json:"bucketName"`
+	ObjectPrefix string `json:"objectPrefix,omitempty"`
+}
+
+// ConfigType enumerates the RETL source config shapes supported by
+// MarshalConfig / DecodeConfig. Add new config types here.
+type ConfigType interface {
+	RETLSQLModelConfig | RETLTableConfig | RETLS3TableConfig
+}
+
+// MarshalConfig encodes a typed RETL source config into the json.RawMessage
+// shape expected by RETLSourceCreateRequest.Config / RETLSourceUpdateRequest.Config.
+func MarshalConfig[T ConfigType](cfg T) (json.RawMessage, error) {
+	raw, err := json.Marshal(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("marshalling RETL config: %w", err)
+	}
+	return raw, nil
+}
+
+// DecodeConfig decodes a RETLSource.Config into the caller-supplied typed config.
+// Empty input returns a zero-value T and no error.
+func DecodeConfig[T ConfigType](raw json.RawMessage) (T, error) {
+	var cfg T
+	if len(raw) == 0 {
+		return cfg, nil
+	}
+	if err := json.Unmarshal(raw, &cfg); err != nil {
+		return cfg, fmt.Errorf("unmarshalling RETL config: %w", err)
+	}
+	return cfg, nil
 }
 
 // RETLSources represents a response of RETL sources

--- a/api/client/retl/types.go
+++ b/api/client/retl/types.go
@@ -14,16 +14,53 @@ const (
 	ModelSourceType SourceType = "model"
 	TableSourceType SourceType = "table"
 
+	s3SourceDefinition = "s3"
+
 	Pending   AsyncStatus = "pending"
 	Failed    AsyncStatus = "failed"
 	Completed AsyncStatus = "completed"
 )
 
+// ConfigType is the sealed union of RETL source config shapes. Implementations
+// are confined to this package via the unexported marker method, so the
+// dispatch in RETLSource.UnmarshalJSON stays exhaustive.
+type ConfigType interface {
+	isRETLConfig()
+}
+
+// RETLSQLModelConfig is the config shape for SQL MODEL sources.
+type RETLSQLModelConfig struct {
+	PrimaryKey  string `json:"primaryKey"`
+	Sql         string `json:"sql"`
+	Description string `json:"description,omitempty"`
+}
+
+func (RETLSQLModelConfig) isRETLConfig() {}
+
+// RETLTableConfig is the config shape for warehouse TABLE sources
+// (sourceDefinitionName = snowflake/bigquery/postgres/etc.).
+type RETLTableConfig struct {
+	PrimaryKey string `json:"primaryKey"`
+	Schema     string `json:"schema"`
+	Table      string `json:"table"`
+}
+
+func (RETLTableConfig) isRETLConfig() {}
+
+// RETLS3TableConfig is the config shape for S3 TABLE sources
+// (sourceDefinitionName = s3). primaryKey is optional on S3.
+type RETLS3TableConfig struct {
+	BucketName   string `json:"bucketName"`
+	ObjectPrefix string `json:"objectPrefix,omitempty"`
+}
+
+func (RETLS3TableConfig) isRETLConfig() {}
+
 // RETLSource represents a RETL source in the API
 type RETLSource struct {
 	ID                   string     `json:"id"`
 	Name                 string     `json:"name"`
-	Config               any        `json:"config"`
+	Config               ConfigType `json:"config"`
 	IsEnabled            bool       `json:"enabled"`
 	SourceType           SourceType `json:"sourceType"`
 	SourceDefinitionName string     `json:"sourceDefinitionName"`
@@ -34,9 +71,79 @@ type RETLSource struct {
 	ExternalID           string     `json:"externalId"`
 }
 
+// retlSourceWire mirrors RETLSource but keeps Config as raw JSON so we can
+// pick the concrete config type from sourceType + sourceDefinitionName.
+type retlSourceWire struct {
+	ID                   string          `json:"id"`
+	Name                 string          `json:"name"`
+	Config               json.RawMessage `json:"config"`
+	IsEnabled            bool            `json:"enabled"`
+	SourceType           SourceType      `json:"sourceType"`
+	SourceDefinitionName string          `json:"sourceDefinitionName"`
+	AccountID            string          `json:"accountId"`
+	CreatedAt            *time.Time      `json:"createdAt"`
+	UpdatedAt            *time.Time      `json:"updatedAt"`
+	WorkspaceID          string          `json:"workspaceId"`
+	ExternalID           string          `json:"externalId"`
+}
+
+func (s *RETLSource) UnmarshalJSON(data []byte) error {
+	var wire retlSourceWire
+	if err := json.Unmarshal(data, &wire); err != nil {
+		return err
+	}
+	*s = RETLSource{
+		ID:                   wire.ID,
+		Name:                 wire.Name,
+		IsEnabled:            wire.IsEnabled,
+		SourceType:           wire.SourceType,
+		SourceDefinitionName: wire.SourceDefinitionName,
+		AccountID:            wire.AccountID,
+		CreatedAt:            wire.CreatedAt,
+		UpdatedAt:            wire.UpdatedAt,
+		WorkspaceID:          wire.WorkspaceID,
+		ExternalID:           wire.ExternalID,
+	}
+	if len(wire.Config) == 0 || string(wire.Config) == "null" {
+		return nil
+	}
+	cfg, err := decodeConfigFor(wire.SourceType, wire.SourceDefinitionName, wire.Config)
+	if err != nil {
+		return err
+	}
+	s.Config = cfg
+	return nil
+}
+
+func decodeConfigFor(sourceType SourceType, sourceDefinitionName string, raw json.RawMessage) (ConfigType, error) {
+	switch sourceType {
+	case ModelSourceType:
+		var cfg RETLSQLModelConfig
+		if err := json.Unmarshal(raw, &cfg); err != nil {
+			return nil, fmt.Errorf("unmarshalling RETL model config: %w", err)
+		}
+		return cfg, nil
+	case TableSourceType:
+		if sourceDefinitionName == s3SourceDefinition {
+			var cfg RETLS3TableConfig
+			if err := json.Unmarshal(raw, &cfg); err != nil {
+				return nil, fmt.Errorf("unmarshalling RETL s3 table config: %w", err)
+			}
+			return cfg, nil
+		}
+		var cfg RETLTableConfig
+		if err := json.Unmarshal(raw, &cfg); err != nil {
+			return nil, fmt.Errorf("unmarshalling RETL table config: %w", err)
+		}
+		return cfg, nil
+	default:
+		return nil, fmt.Errorf("unsupported RETL source type %q", sourceType)
+	}
+}
+
 type RETLSourceCreateRequest struct {
 	Name                 string     `json:"name"`
-	Config               any        `json:"config"`
+	Config               ConfigType `json:"config"`
 	SourceType           SourceType `json:"sourceType"`
 	SourceDefinitionName string     `json:"sourceDefinitionName"`
 	AccountID            string     `json:"accountId"`
@@ -45,68 +152,25 @@ type RETLSourceCreateRequest struct {
 }
 
 type RETLSourceUpdateRequest struct {
-	Name      string `json:"name"`
-	Config    any    `json:"config"`
-	IsEnabled bool   `json:"enabled"`
-	AccountID string `json:"accountId"`
+	Name      string     `json:"name"`
+	Config    ConfigType `json:"config"`
+	IsEnabled bool       `json:"enabled"`
+	AccountID string     `json:"accountId"`
 }
 
-// RETLSQLModelConfig is the config shape for SQL MODEL sources.
-type RETLSQLModelConfig struct {
-	PrimaryKey  string `json:"primaryKey"`
-	Sql         string `json:"sql"`
-	Description string `json:"description,omitempty"`
-}
-
-// RETLTableConfig is the config shape for warehouse TABLE sources
-// (sourceDefinitionName = snowflake/bigquery/postgres/etc.).
-type RETLTableConfig struct {
-	PrimaryKey string `json:"primaryKey"`
-	Schema     string `json:"schema"`
-	Table      string `json:"table"`
-}
-
-// RETLS3TableConfig is the config shape for S3 TABLE sources
-// (sourceDefinitionName = s3). primaryKey is optional on S3.
-type RETLS3TableConfig struct {
-	BucketName   string `json:"bucketName"`
-	ObjectPrefix string `json:"objectPrefix,omitempty"`
-}
-
-// ConfigType enumerates the RETL source config shapes supported by
-// MarshalConfig / DecodeConfig. Add new config types here.
-type ConfigType interface {
-	RETLSQLModelConfig | RETLTableConfig | RETLS3TableConfig
-}
-
-// MarshalConfig encodes a typed RETL source config into the json.RawMessage
-// shape expected by RETLSourceCreateRequest.Config / RETLSourceUpdateRequest.Config.
-func MarshalConfig[T ConfigType](cfg T) (json.RawMessage, error) {
-	raw, err := json.Marshal(cfg)
-	if err != nil {
-		return nil, fmt.Errorf("marshalling RETL config: %w", err)
-	}
-	return raw, nil
-}
-
-// DecodeConfig decodes a RETLSource.Config into the caller-supplied typed config.
-// Nil input returns a zero-value T and no error.
-func DecodeConfig[T ConfigType](raw any) (T, error) {
-	var cfg T
+// DecodeConfig narrows a RETLSource.Config (held as the ConfigType interface)
+// to a specific config type. Returns the zero value and no error when the
+// interface is nil. Returns an error when the held concrete type doesn't match T.
+func DecodeConfig[T ConfigType](raw ConfigType) (T, error) {
+	var zero T
 	if raw == nil {
-		return cfg, nil
+		return zero, nil
 	}
-	if typed, ok := raw.(T); ok {
-		return typed, nil
+	typed, ok := raw.(T)
+	if !ok {
+		return zero, fmt.Errorf("RETL config is %T, not %T", raw, zero)
 	}
-	buf, err := json.Marshal(raw)
-	if err != nil {
-		return cfg, fmt.Errorf("marshalling RETL config: %w", err)
-	}
-	if err := json.Unmarshal(buf, &cfg); err != nil {
-		return cfg, fmt.Errorf("unmarshalling RETL config: %w", err)
-	}
-	return cfg, nil
+	return typed, nil
 }
 
 // RETLSources represents a response of RETL sources

--- a/api/client/retl/types.go
+++ b/api/client/retl/types.go
@@ -21,34 +21,34 @@ const (
 
 // RETLSource represents a RETL source in the API
 type RETLSource struct {
-	ID                   string          `json:"id"`
-	Name                 string          `json:"name"`
-	Config               json.RawMessage `json:"config"`
-	IsEnabled            bool            `json:"enabled"`
-	SourceType           SourceType      `json:"sourceType"`
-	SourceDefinitionName string          `json:"sourceDefinitionName"`
-	AccountID            string          `json:"accountId"`
-	CreatedAt            *time.Time      `json:"createdAt"`
-	UpdatedAt            *time.Time      `json:"updatedAt"`
-	WorkspaceID          string          `json:"workspaceId"`
-	ExternalID           string          `json:"externalId"`
+	ID                   string     `json:"id"`
+	Name                 string     `json:"name"`
+	Config               any        `json:"config"`
+	IsEnabled            bool       `json:"enabled"`
+	SourceType           SourceType `json:"sourceType"`
+	SourceDefinitionName string     `json:"sourceDefinitionName"`
+	AccountID            string     `json:"accountId"`
+	CreatedAt            *time.Time `json:"createdAt"`
+	UpdatedAt            *time.Time `json:"updatedAt"`
+	WorkspaceID          string     `json:"workspaceId"`
+	ExternalID           string     `json:"externalId"`
 }
 
 type RETLSourceCreateRequest struct {
-	Name                 string          `json:"name"`
-	Config               json.RawMessage `json:"config"`
-	SourceType           SourceType      `json:"sourceType"`
-	SourceDefinitionName string          `json:"sourceDefinitionName"`
-	AccountID            string          `json:"accountId"`
-	Enabled              bool            `json:"enabled"`
-	ExternalID           string          `json:"externalId"`
+	Name                 string     `json:"name"`
+	Config               any        `json:"config"`
+	SourceType           SourceType `json:"sourceType"`
+	SourceDefinitionName string     `json:"sourceDefinitionName"`
+	AccountID            string     `json:"accountId"`
+	Enabled              bool       `json:"enabled"`
+	ExternalID           string     `json:"externalId"`
 }
 
 type RETLSourceUpdateRequest struct {
-	Name      string          `json:"name"`
-	Config    json.RawMessage `json:"config"`
-	IsEnabled bool            `json:"enabled"`
-	AccountID string          `json:"accountId"`
+	Name      string `json:"name"`
+	Config    any    `json:"config"`
+	IsEnabled bool   `json:"enabled"`
+	AccountID string `json:"accountId"`
 }
 
 // RETLSQLModelConfig is the config shape for SQL MODEL sources.
@@ -90,13 +90,20 @@ func MarshalConfig[T ConfigType](cfg T) (json.RawMessage, error) {
 }
 
 // DecodeConfig decodes a RETLSource.Config into the caller-supplied typed config.
-// Empty input returns a zero-value T and no error.
-func DecodeConfig[T ConfigType](raw json.RawMessage) (T, error) {
+// Nil input returns a zero-value T and no error.
+func DecodeConfig[T ConfigType](raw any) (T, error) {
 	var cfg T
-	if len(raw) == 0 {
+	if raw == nil {
 		return cfg, nil
 	}
-	if err := json.Unmarshal(raw, &cfg); err != nil {
+	if typed, ok := raw.(T); ok {
+		return typed, nil
+	}
+	buf, err := json.Marshal(raw)
+	if err != nil {
+		return cfg, fmt.Errorf("marshalling RETL config: %w", err)
+	}
+	if err := json.Unmarshal(buf, &cfg); err != nil {
 		return cfg, fmt.Errorf("unmarshalling RETL config: %w", err)
 	}
 	return cfg, nil

--- a/api/client/retl/types.go
+++ b/api/client/retl/types.go
@@ -69,7 +69,6 @@ type RETLTableConfig struct {
 // RETLS3TableConfig is the config shape for S3 TABLE sources
 // (sourceDefinitionName = s3). primaryKey is optional on S3.
 type RETLS3TableConfig struct {
-	PrimaryKey   string `json:"primaryKey,omitempty"`
 	BucketName   string `json:"bucketName"`
 	ObjectPrefix string `json:"objectPrefix,omitempty"`
 }

--- a/api/client/retl/types.go
+++ b/api/client/retl/types.go
@@ -21,10 +21,10 @@ const (
 	Completed AsyncStatus = "completed"
 )
 
-// ConfigType is the sealed union of RETL source config shapes. Implementations
+// RETLConfig is the sealed union of RETL source config shapes. Implementations
 // are confined to this package via the unexported marker method, so the
 // dispatch in RETLSource.UnmarshalJSON stays exhaustive.
-type ConfigType interface {
+type RETLConfig interface {
 	isRETLConfig()
 }
 
@@ -60,7 +60,7 @@ func (RETLS3TableConfig) isRETLConfig() {}
 type RETLSource struct {
 	ID                   string     `json:"id"`
 	Name                 string     `json:"name"`
-	Config               ConfigType `json:"config"`
+	Config               RETLConfig `json:"config"`
 	IsEnabled            bool       `json:"enabled"`
 	SourceType           SourceType `json:"sourceType"`
 	SourceDefinitionName string     `json:"sourceDefinitionName"`
@@ -115,7 +115,7 @@ func (s *RETLSource) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func decodeConfigFor(sourceType SourceType, sourceDefinitionName string, raw json.RawMessage) (ConfigType, error) {
+func decodeConfigFor(sourceType SourceType, sourceDefinitionName string, raw json.RawMessage) (RETLConfig, error) {
 	switch sourceType {
 	case ModelSourceType:
 		var cfg RETLSQLModelConfig
@@ -143,7 +143,7 @@ func decodeConfigFor(sourceType SourceType, sourceDefinitionName string, raw jso
 
 type RETLSourceCreateRequest struct {
 	Name                 string     `json:"name"`
-	Config               ConfigType `json:"config"`
+	Config               RETLConfig `json:"config"`
 	SourceType           SourceType `json:"sourceType"`
 	SourceDefinitionName string     `json:"sourceDefinitionName"`
 	AccountID            string     `json:"accountId"`
@@ -153,7 +153,7 @@ type RETLSourceCreateRequest struct {
 
 type RETLSourceUpdateRequest struct {
 	Name      string     `json:"name"`
-	Config    ConfigType `json:"config"`
+	Config    RETLConfig `json:"config"`
 	IsEnabled bool       `json:"enabled"`
 	AccountID string     `json:"accountId"`
 }
@@ -161,7 +161,7 @@ type RETLSourceUpdateRequest struct {
 // DecodeConfig narrows a RETLSource.Config (held as the ConfigType interface)
 // to a specific config type. Returns the zero value and no error when the
 // interface is nil. Returns an error when the held concrete type doesn't match T.
-func DecodeConfig[T ConfigType](raw ConfigType) (T, error) {
+func DecodeConfig[T RETLConfig](raw RETLConfig) (T, error) {
 	var zero T
 	if raw == nil {
 		return zero, nil

--- a/cli/internal/providers/retl/provider_test.go
+++ b/cli/internal/providers/retl/provider_test.go
@@ -40,7 +40,7 @@ type mockRETLStore struct {
 	updateRetlSourceFunc func(ctx context.Context, sourceID string, source *retlClient.RETLSourceUpdateRequest) (*retlClient.RETLSource, error)
 	deleteRetlSourceFunc func(ctx context.Context, id string) error
 	getRetlSourceFunc    func(ctx context.Context, id string) (*retlClient.RETLSource, error)
-	listRetlSourcesFunc  func(ctx context.Context, sourceType string, hasExternalID *bool) (*retlClient.RETLSources, error)
+	listRetlSourcesFunc  func(ctx context.Context, opts ...retlClient.ListRetlSourcesOption) (*retlClient.RETLSources, error)
 	// Preview functions
 	submitPreviewFunc    func(ctx context.Context, request *retlClient.PreviewSubmitRequest) (*retlClient.PreviewSubmitResponse, error)
 	getPreviewResultFunc func(ctx context.Context, resultID string) (*retlClient.PreviewResultResponse, error)
@@ -76,9 +76,9 @@ func (m *mockRETLStore) GetRetlSource(ctx context.Context, id string) (*retlClie
 	return nil, nil
 }
 
-func (m *mockRETLStore) ListRetlSources(ctx context.Context, sourceType string, hasExternalID *bool) (*retlClient.RETLSources, error) {
+func (m *mockRETLStore) ListRetlSources(ctx context.Context, opts ...retlClient.ListRetlSourcesOption) (*retlClient.RETLSources, error) {
 	if m.listRetlSourcesFunc != nil {
-		return m.listRetlSourcesFunc(ctx, sourceType, hasExternalID)
+		return m.listRetlSourcesFunc(ctx, opts...)
 	}
 	return &retlClient.RETLSources{}, nil
 }
@@ -125,7 +125,6 @@ func newDefaultMockClient() *mockRETLStore {
 			return nil
 		},
 		getRetlSourceFunc: func(ctx context.Context, id string) (*retlClient.RETLSource, error) {
-
 			if id == "remote-id-not-found" {
 				return nil, fmt.Errorf("retl source not found")
 			}
@@ -417,7 +416,7 @@ func TestProviderList(t *testing.T) {
 			provider := retl.New(mockClient)
 
 			// Mock successful listing in the client that the handler will use
-			mockClient.listRetlSourcesFunc = func(ctx context.Context, sourceType string, hasExternalID *bool) (*retlClient.RETLSources, error) {
+			mockClient.listRetlSourcesFunc = func(ctx context.Context, opts ...retlClient.ListRetlSourcesOption) (*retlClient.RETLSources, error) {
 				return &retlClient.RETLSources{
 					Data: []retlClient.RETLSource{
 						{
@@ -457,8 +456,13 @@ func TestProviderList(t *testing.T) {
 			provider := retl.New(mockClient)
 
 			// Mock successful listing in the client that the handler will use
-			mockClient.listRetlSourcesFunc = func(ctx context.Context, sourceType string, hasExternalID *bool) (*retlClient.RETLSources, error) {
-				if !assert.True(t, *hasExternalID) {
+			mockClient.listRetlSourcesFunc = func(ctx context.Context, opts ...retlClient.ListRetlSourcesOption) (*retlClient.RETLSources, error) {
+				resolved := retlClient.ListRetlSourcesOptions{}
+				for _, opt := range opts {
+					opt(&resolved)
+				}
+				hasExternalID := resolved.HasExternalId
+				if !assert.NotNil(t, hasExternalID) || !assert.True(t, *hasExternalID) {
 					return nil, fmt.Errorf("hasExternalID is not true")
 				}
 				externalId := "ext-123"
@@ -495,7 +499,7 @@ func TestProviderList(t *testing.T) {
 			provider := retl.New(mockClient)
 
 			// Mock error from client that the handler will encounter
-			mockClient.listRetlSourcesFunc = func(ctx context.Context, sourceType string, hasExternalID *bool) (*retlClient.RETLSources, error) {
+			mockClient.listRetlSourcesFunc = func(ctx context.Context, opts ...retlClient.ListRetlSourcesOption) (*retlClient.RETLSources, error) {
 				return nil, fmt.Errorf("API error")
 			}
 
@@ -681,7 +685,12 @@ func TestProviderLoadResourcesFromRemote(t *testing.T) {
 
 		// Prepare two sources: one with ExternalID (should be included), one without (should be skipped)
 		externalID := "ext-123"
-		mockClient.listRetlSourcesFunc = func(ctx context.Context, sourceType string, hasExternalID *bool) (*retlClient.RETLSources, error) {
+		mockClient.listRetlSourcesFunc = func(ctx context.Context, opts ...retlClient.ListRetlSourcesOption) (*retlClient.RETLSources, error) {
+			resolved := retlClient.ListRetlSourcesOptions{}
+			for _, opt := range opts {
+				opt(&resolved)
+			}
+			hasExternalID := resolved.HasExternalId
 			if hasExternalID == nil || !*hasExternalID {
 				return nil, fmt.Errorf("expected hasExternalID=true filter")
 			}
@@ -727,7 +736,7 @@ func TestProviderLoadResourcesFromRemote(t *testing.T) {
 		t.Parallel()
 		mockClient := newDefaultMockClient()
 		provider := retl.New(mockClient)
-		mockClient.listRetlSourcesFunc = func(ctx context.Context, sourceType string, hasExternalID *bool) (*retlClient.RETLSources, error) {
+		mockClient.listRetlSourcesFunc = func(ctx context.Context, opts ...retlClient.ListRetlSourcesOption) (*retlClient.RETLSources, error) {
 			return nil, fmt.Errorf("API error")
 		}
 
@@ -825,8 +834,13 @@ func TestProviderLoadImportable(t *testing.T) {
 		provider := retl.New(mockClient)
 
 		// Mock list to return sources that do NOT have ExternalID yet
-		mockClient.listRetlSourcesFunc = func(ctx context.Context, sourceType string, hasExternalID *bool) (*retlClient.RETLSources, error) {
+		mockClient.listRetlSourcesFunc = func(ctx context.Context, opts ...retlClient.ListRetlSourcesOption) (*retlClient.RETLSources, error) {
 			// Expect false for hasExternalID
+			resolved := retlClient.ListRetlSourcesOptions{}
+			for _, opt := range opts {
+				opt(&resolved)
+			}
+			hasExternalID := resolved.HasExternalId
 			require.NotNil(t, hasExternalID)
 			require.False(t, *hasExternalID)
 			return &retlClient.RETLSources{
@@ -887,7 +901,7 @@ func TestProviderLoadImportable(t *testing.T) {
 		t.Parallel()
 		mockClient := newDefaultMockClient()
 		provider := retl.New(mockClient)
-		mockClient.listRetlSourcesFunc = func(ctx context.Context, sourceType string, hasExternalID *bool) (*retlClient.RETLSources, error) {
+		mockClient.listRetlSourcesFunc = func(ctx context.Context, opts ...retlClient.ListRetlSourcesOption) (*retlClient.RETLSources, error) {
 			return nil, fmt.Errorf("API error")
 		}
 

--- a/cli/internal/providers/retl/provider_test.go
+++ b/cli/internal/providers/retl/provider_test.go
@@ -20,12 +20,6 @@ import (
 	vrules "github.com/rudderlabs/rudder-iac/cli/internal/validation/rules"
 )
 
-// mustMarshalSQLModelConfig wraps a typed SQL model config as a
-// retlClient.ConfigType for use in test fixtures.
-func mustMarshalSQLModelConfig(cfg retlClient.RETLSQLModelConfig) retlClient.ConfigType {
-	return cfg
-}
-
 // mockRETLStore mocks the RETL client for testing
 type mockRETLStore struct {
 	retlClient.RETLStore
@@ -132,7 +126,7 @@ func newDefaultMockClient() *mockRETLStore {
 				AccountID:            "acc123",
 				IsEnabled:            true,
 				WorkspaceID:          "test-workspace-id",
-				Config:               mustMarshalSQLModelConfig(retlClient.RETLSQLModelConfig{Description: "desc", PrimaryKey: "id", Sql: "SELECT * FROM t"}),
+				Config:               retlClient.RETLSQLModelConfig{Description: "desc", PrimaryKey: "id", Sql: "SELECT * FROM t"},
 			}, nil
 		},
 		submitPreviewFunc: func(ctx context.Context, request *retlClient.PreviewSubmitRequest) (*retlClient.PreviewSubmitResponse, error) {
@@ -421,11 +415,11 @@ func TestProviderList(t *testing.T) {
 							SourceType:           retlClient.ModelSourceType,
 							SourceDefinitionName: "postgres",
 							AccountID:            "account-1",
-							Config: mustMarshalSQLModelConfig(retlClient.RETLSQLModelConfig{
+							Config: retlClient.RETLSQLModelConfig{
 								Description: "Test description 1",
 								PrimaryKey:  "id",
 								Sql:         "SELECT * FROM table1",
-							}),
+							},
 						},
 					},
 				}, nil
@@ -471,11 +465,11 @@ func TestProviderList(t *testing.T) {
 							SourceDefinitionName: "postgres",
 							AccountID:            "account-1",
 							ExternalID:           externalId,
-							Config: mustMarshalSQLModelConfig(retlClient.RETLSQLModelConfig{
+							Config: retlClient.RETLSQLModelConfig{
 								Description: "Test description 1",
 								PrimaryKey:  "id",
 								Sql:         "SELECT * FROM table1",
-							}),
+							},
 						},
 					},
 				}, nil
@@ -698,11 +692,11 @@ func TestProviderLoadResourcesFromRemote(t *testing.T) {
 						SourceDefinitionName: "postgres",
 						AccountID:            "acc-1",
 						ExternalID:           externalID,
-						Config: mustMarshalSQLModelConfig(retlClient.RETLSQLModelConfig{
+						Config: retlClient.RETLSQLModelConfig{
 							Description: "d1",
 							PrimaryKey:  "id",
 							Sql:         "SELECT 1",
-						}),
+						},
 					},
 				},
 			}, nil
@@ -760,11 +754,11 @@ func TestProviderMapRemoteToState(t *testing.T) {
 			AccountID:            "acc-1",
 			IsEnabled:            true,
 			ExternalID:           extID,
-			Config: mustMarshalSQLModelConfig(retlClient.RETLSQLModelConfig{
+			Config: retlClient.RETLSQLModelConfig{
 				Description: "desc-1",
 				PrimaryKey:  "id",
 				Sql:         "SELECT 1",
-			}),
+			},
 		}
 		collection := resources.NewRemoteResources()
 		collection.Set(sqlmodel.ResourceType, map[string]*resources.RemoteResource{
@@ -847,11 +841,11 @@ func TestProviderLoadImportable(t *testing.T) {
 						SourceDefinitionName: "postgres",
 						AccountID:            "acc-1",
 						WorkspaceID:          "ws-1",
-						Config: mustMarshalSQLModelConfig(retlClient.RETLSQLModelConfig{
+						Config: retlClient.RETLSQLModelConfig{
 							Description: "desc-1",
 							PrimaryKey:  "id",
 							Sql:         "SELECT 1",
-						}),
+						},
 					},
 					{
 						ID:                   "source-2",
@@ -860,11 +854,11 @@ func TestProviderLoadImportable(t *testing.T) {
 						SourceDefinitionName: "postgres",
 						AccountID:            "acc-1",
 						WorkspaceID:          "ws-1",
-						Config: mustMarshalSQLModelConfig(retlClient.RETLSQLModelConfig{
+						Config: retlClient.RETLSQLModelConfig{
 							Description: "desc-2",
 							PrimaryKey:  "user_id",
 							Sql:         "SELECT 2",
-						}),
+						},
 					},
 				},
 			}, nil
@@ -931,11 +925,11 @@ func TestProviderFormatForExport(t *testing.T) {
 			AccountID:            "acc-1",
 			WorkspaceID:          "ws-1",
 			IsEnabled:            true,
-			Config: mustMarshalSQLModelConfig(retlClient.RETLSQLModelConfig{
+			Config: retlClient.RETLSQLModelConfig{
 				Description: "desc-1",
 				PrimaryKey:  "id",
 				Sql:         "SELECT 1",
-			}),
+			},
 		}
 		collection := resources.NewRemoteResources()
 		collection.Set(sqlmodel.ResourceType, map[string]*resources.RemoteResource{

--- a/cli/internal/providers/retl/provider_test.go
+++ b/cli/internal/providers/retl/provider_test.go
@@ -2,7 +2,6 @@ package retl_test
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"path/filepath"
 	"testing"
@@ -21,14 +20,10 @@ import (
 	vrules "github.com/rudderlabs/rudder-iac/cli/internal/validation/rules"
 )
 
-// mustMarshalSQLModelConfig encodes a SQL model config into json.RawMessage,
-// panicking on failure. Only for use inside test fixtures.
-func mustMarshalSQLModelConfig(cfg retlClient.RETLSQLModelConfig) json.RawMessage {
-	raw, err := retlClient.MarshalConfig(cfg)
-	if err != nil {
-		panic(fmt.Sprintf("marshalling test SQL model config: %v", err))
-	}
-	return raw
+// mustMarshalSQLModelConfig wraps a typed SQL model config as a
+// retlClient.ConfigType for use in test fixtures.
+func mustMarshalSQLModelConfig(cfg retlClient.RETLSQLModelConfig) retlClient.ConfigType {
+	return cfg
 }
 
 // mockRETLStore mocks the RETL client for testing

--- a/cli/internal/providers/retl/provider_test.go
+++ b/cli/internal/providers/retl/provider_test.go
@@ -2,6 +2,7 @@ package retl_test
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"path/filepath"
 	"testing"
@@ -20,6 +21,16 @@ import (
 	vrules "github.com/rudderlabs/rudder-iac/cli/internal/validation/rules"
 )
 
+// mustMarshalSQLModelConfig encodes a SQL model config into json.RawMessage,
+// panicking on failure. Only for use inside test fixtures.
+func mustMarshalSQLModelConfig(cfg retlClient.RETLSQLModelConfig) json.RawMessage {
+	raw, err := retlClient.MarshalConfig(cfg)
+	if err != nil {
+		panic(fmt.Sprintf("marshalling test SQL model config: %v", err))
+	}
+	return raw
+}
+
 // mockRETLStore mocks the RETL client for testing
 type mockRETLStore struct {
 	retlClient.RETLStore
@@ -29,7 +40,7 @@ type mockRETLStore struct {
 	updateRetlSourceFunc func(ctx context.Context, sourceID string, source *retlClient.RETLSourceUpdateRequest) (*retlClient.RETLSource, error)
 	deleteRetlSourceFunc func(ctx context.Context, id string) error
 	getRetlSourceFunc    func(ctx context.Context, id string) (*retlClient.RETLSource, error)
-	listRetlSourcesFunc  func(ctx context.Context, hasExternalID *bool) (*retlClient.RETLSources, error)
+	listRetlSourcesFunc  func(ctx context.Context, sourceType string, hasExternalID *bool) (*retlClient.RETLSources, error)
 	// Preview functions
 	submitPreviewFunc    func(ctx context.Context, request *retlClient.PreviewSubmitRequest) (*retlClient.PreviewSubmitResponse, error)
 	getPreviewResultFunc func(ctx context.Context, resultID string) (*retlClient.PreviewResultResponse, error)
@@ -65,9 +76,9 @@ func (m *mockRETLStore) GetRetlSource(ctx context.Context, id string) (*retlClie
 	return nil, nil
 }
 
-func (m *mockRETLStore) ListRetlSources(ctx context.Context, hasExternalID *bool) (*retlClient.RETLSources, error) {
+func (m *mockRETLStore) ListRetlSources(ctx context.Context, sourceType string, hasExternalID *bool) (*retlClient.RETLSources, error) {
 	if m.listRetlSourcesFunc != nil {
-		return m.listRetlSourcesFunc(ctx, hasExternalID)
+		return m.listRetlSourcesFunc(ctx, sourceType, hasExternalID)
 	}
 	return &retlClient.RETLSources{}, nil
 }
@@ -127,7 +138,7 @@ func newDefaultMockClient() *mockRETLStore {
 				AccountID:            "acc123",
 				IsEnabled:            true,
 				WorkspaceID:          "test-workspace-id",
-				Config:               retlClient.RETLSQLModelConfig{Description: "desc", PrimaryKey: "id", Sql: "SELECT * FROM t"},
+				Config:               mustMarshalSQLModelConfig(retlClient.RETLSQLModelConfig{Description: "desc", PrimaryKey: "id", Sql: "SELECT * FROM t"}),
 			}, nil
 		},
 		submitPreviewFunc: func(ctx context.Context, request *retlClient.PreviewSubmitRequest) (*retlClient.PreviewSubmitResponse, error) {
@@ -406,7 +417,7 @@ func TestProviderList(t *testing.T) {
 			provider := retl.New(mockClient)
 
 			// Mock successful listing in the client that the handler will use
-			mockClient.listRetlSourcesFunc = func(ctx context.Context, hasExternalID *bool) (*retlClient.RETLSources, error) {
+			mockClient.listRetlSourcesFunc = func(ctx context.Context, sourceType string, hasExternalID *bool) (*retlClient.RETLSources, error) {
 				return &retlClient.RETLSources{
 					Data: []retlClient.RETLSource{
 						{
@@ -416,11 +427,11 @@ func TestProviderList(t *testing.T) {
 							SourceType:           retlClient.ModelSourceType,
 							SourceDefinitionName: "postgres",
 							AccountID:            "account-1",
-							Config: retlClient.RETLSQLModelConfig{
+							Config: mustMarshalSQLModelConfig(retlClient.RETLSQLModelConfig{
 								Description: "Test description 1",
 								PrimaryKey:  "id",
 								Sql:         "SELECT * FROM table1",
-							},
+							}),
 						},
 					},
 				}, nil
@@ -446,7 +457,7 @@ func TestProviderList(t *testing.T) {
 			provider := retl.New(mockClient)
 
 			// Mock successful listing in the client that the handler will use
-			mockClient.listRetlSourcesFunc = func(ctx context.Context, hasExternalID *bool) (*retlClient.RETLSources, error) {
+			mockClient.listRetlSourcesFunc = func(ctx context.Context, sourceType string, hasExternalID *bool) (*retlClient.RETLSources, error) {
 				if !assert.True(t, *hasExternalID) {
 					return nil, fmt.Errorf("hasExternalID is not true")
 				}
@@ -461,11 +472,11 @@ func TestProviderList(t *testing.T) {
 							SourceDefinitionName: "postgres",
 							AccountID:            "account-1",
 							ExternalID:           externalId,
-							Config: retlClient.RETLSQLModelConfig{
+							Config: mustMarshalSQLModelConfig(retlClient.RETLSQLModelConfig{
 								Description: "Test description 1",
 								PrimaryKey:  "id",
 								Sql:         "SELECT * FROM table1",
-							},
+							}),
 						},
 					},
 				}, nil
@@ -484,7 +495,7 @@ func TestProviderList(t *testing.T) {
 			provider := retl.New(mockClient)
 
 			// Mock error from client that the handler will encounter
-			mockClient.listRetlSourcesFunc = func(ctx context.Context, hasExternalID *bool) (*retlClient.RETLSources, error) {
+			mockClient.listRetlSourcesFunc = func(ctx context.Context, sourceType string, hasExternalID *bool) (*retlClient.RETLSources, error) {
 				return nil, fmt.Errorf("API error")
 			}
 
@@ -670,7 +681,7 @@ func TestProviderLoadResourcesFromRemote(t *testing.T) {
 
 		// Prepare two sources: one with ExternalID (should be included), one without (should be skipped)
 		externalID := "ext-123"
-		mockClient.listRetlSourcesFunc = func(ctx context.Context, hasExternalID *bool) (*retlClient.RETLSources, error) {
+		mockClient.listRetlSourcesFunc = func(ctx context.Context, sourceType string, hasExternalID *bool) (*retlClient.RETLSources, error) {
 			if hasExternalID == nil || !*hasExternalID {
 				return nil, fmt.Errorf("expected hasExternalID=true filter")
 			}
@@ -683,11 +694,11 @@ func TestProviderLoadResourcesFromRemote(t *testing.T) {
 						SourceDefinitionName: "postgres",
 						AccountID:            "acc-1",
 						ExternalID:           externalID,
-						Config: retlClient.RETLSQLModelConfig{
+						Config: mustMarshalSQLModelConfig(retlClient.RETLSQLModelConfig{
 							Description: "d1",
 							PrimaryKey:  "id",
 							Sql:         "SELECT 1",
-						},
+						}),
 					},
 				},
 			}, nil
@@ -716,7 +727,7 @@ func TestProviderLoadResourcesFromRemote(t *testing.T) {
 		t.Parallel()
 		mockClient := newDefaultMockClient()
 		provider := retl.New(mockClient)
-		mockClient.listRetlSourcesFunc = func(ctx context.Context, hasExternalID *bool) (*retlClient.RETLSources, error) {
+		mockClient.listRetlSourcesFunc = func(ctx context.Context, sourceType string, hasExternalID *bool) (*retlClient.RETLSources, error) {
 			return nil, fmt.Errorf("API error")
 		}
 
@@ -745,11 +756,11 @@ func TestProviderMapRemoteToState(t *testing.T) {
 			AccountID:            "acc-1",
 			IsEnabled:            true,
 			ExternalID:           extID,
-			Config: retlClient.RETLSQLModelConfig{
+			Config: mustMarshalSQLModelConfig(retlClient.RETLSQLModelConfig{
 				Description: "desc-1",
 				PrimaryKey:  "id",
 				Sql:         "SELECT 1",
-			},
+			}),
 		}
 		collection := resources.NewRemoteResources()
 		collection.Set(sqlmodel.ResourceType, map[string]*resources.RemoteResource{
@@ -814,7 +825,7 @@ func TestProviderLoadImportable(t *testing.T) {
 		provider := retl.New(mockClient)
 
 		// Mock list to return sources that do NOT have ExternalID yet
-		mockClient.listRetlSourcesFunc = func(ctx context.Context, hasExternalID *bool) (*retlClient.RETLSources, error) {
+		mockClient.listRetlSourcesFunc = func(ctx context.Context, sourceType string, hasExternalID *bool) (*retlClient.RETLSources, error) {
 			// Expect false for hasExternalID
 			require.NotNil(t, hasExternalID)
 			require.False(t, *hasExternalID)
@@ -827,11 +838,11 @@ func TestProviderLoadImportable(t *testing.T) {
 						SourceDefinitionName: "postgres",
 						AccountID:            "acc-1",
 						WorkspaceID:          "ws-1",
-						Config: retlClient.RETLSQLModelConfig{
+						Config: mustMarshalSQLModelConfig(retlClient.RETLSQLModelConfig{
 							Description: "desc-1",
 							PrimaryKey:  "id",
 							Sql:         "SELECT 1",
-						},
+						}),
 					},
 					{
 						ID:                   "source-2",
@@ -840,11 +851,11 @@ func TestProviderLoadImportable(t *testing.T) {
 						SourceDefinitionName: "postgres",
 						AccountID:            "acc-1",
 						WorkspaceID:          "ws-1",
-						Config: retlClient.RETLSQLModelConfig{
+						Config: mustMarshalSQLModelConfig(retlClient.RETLSQLModelConfig{
 							Description: "desc-2",
 							PrimaryKey:  "user_id",
 							Sql:         "SELECT 2",
-						},
+						}),
 					},
 				},
 			}, nil
@@ -876,7 +887,7 @@ func TestProviderLoadImportable(t *testing.T) {
 		t.Parallel()
 		mockClient := newDefaultMockClient()
 		provider := retl.New(mockClient)
-		mockClient.listRetlSourcesFunc = func(ctx context.Context, hasExternalID *bool) (*retlClient.RETLSources, error) {
+		mockClient.listRetlSourcesFunc = func(ctx context.Context, sourceType string, hasExternalID *bool) (*retlClient.RETLSources, error) {
 			return nil, fmt.Errorf("API error")
 		}
 
@@ -911,11 +922,11 @@ func TestProviderFormatForExport(t *testing.T) {
 			AccountID:            "acc-1",
 			WorkspaceID:          "ws-1",
 			IsEnabled:            true,
-			Config: retlClient.RETLSQLModelConfig{
+			Config: mustMarshalSQLModelConfig(retlClient.RETLSQLModelConfig{
 				Description: "desc-1",
 				PrimaryKey:  "id",
 				Sql:         "SELECT 1",
-			},
+			}),
 		}
 		collection := resources.NewRemoteResources()
 		collection.Set(sqlmodel.ResourceType, map[string]*resources.RemoteResource{

--- a/cli/internal/providers/retl/sqlmodel/handler.go
+++ b/cli/internal/providers/retl/sqlmodel/handler.go
@@ -264,7 +264,7 @@ func (h *Handler) Delete(ctx context.Context, ID string, state resources.Resourc
 }
 
 func (h *Handler) List(ctx context.Context, hasExternalId *bool) ([]resources.ResourceData, error) {
-	sources, err := h.client.ListRetlSources(ctx, modelSourceTypeFilter, hasExternalId)
+	sources, err := h.client.ListRetlSources(ctx, retlClient.WithSourceType(modelSourceTypeFilter), retlClient.WithHasExternalId(hasExternalId))
 	if err != nil {
 		return nil, fmt.Errorf("listing RETL sources: %w", err)
 	}
@@ -399,7 +399,7 @@ func (h *Handler) FetchImportData(ctx context.Context, args specs.ImportIds) (wr
 func (h *Handler) LoadResourcesFromRemote(ctx context.Context) (*resources.RemoteResources, error) {
 	collection := resources.NewRemoteResources()
 	hasExternalID := true
-	sources, err := h.client.ListRetlSources(ctx, modelSourceTypeFilter, &hasExternalID)
+	sources, err := h.client.ListRetlSources(ctx, retlClient.WithSourceType(modelSourceTypeFilter), retlClient.WithHasExternalId(&hasExternalID))
 	if err != nil {
 		return nil, fmt.Errorf("listing RETL sources: %w", err)
 	}
@@ -454,7 +454,7 @@ func (h *Handler) MapRemoteToState(collection *resources.RemoteResources) (*stat
 func (h *Handler) LoadImportable(ctx context.Context, idNamer namer.Namer) (*resources.RemoteResources, error) {
 	collection := resources.NewRemoteResources()
 	hasExternalID := false
-	sources, err := h.client.ListRetlSources(ctx, modelSourceTypeFilter, &hasExternalID)
+	sources, err := h.client.ListRetlSources(ctx, retlClient.WithSourceType(modelSourceTypeFilter), retlClient.WithHasExternalId(&hasExternalID))
 	if err != nil {
 		return nil, fmt.Errorf("listing RETL sources: %w", err)
 	}

--- a/cli/internal/providers/retl/sqlmodel/handler.go
+++ b/cli/internal/providers/retl/sqlmodel/handler.go
@@ -188,14 +188,9 @@ func (h *Handler) GetResources() ([]*resources.Resource, error) {
 
 // Create creates a new SQL Model resource
 func (h *Handler) Create(ctx context.Context, ID string, data resources.ResourceData) (*resources.ResourceData, error) {
-	cfg := toRETLSQLModelConfig(data)
-	rawCfg, err := retlClient.MarshalConfig(cfg)
-	if err != nil {
-		return nil, fmt.Errorf("encoding SQL model config: %w", err)
-	}
 	source := &retlClient.RETLSourceCreateRequest{
 		Name:                 data[DisplayNameKey].(string),
-		Config:               rawCfg,
+		Config:               toRETLSQLModelConfig(data),
 		SourceType:           retlClient.ModelSourceType,
 		SourceDefinitionName: data[SourceDefinitionKey].(string),
 		AccountID:            data[AccountIDKey].(string),
@@ -227,14 +222,9 @@ func (h *Handler) Update(ctx context.Context, ID string, data resources.Resource
 }
 
 func (h *Handler) updateCall(ctx context.Context, sourceID string, data resources.ResourceData) (*resources.ResourceData, error) {
-	cfg := toRETLSQLModelConfig(data)
-	rawCfg, err := retlClient.MarshalConfig(cfg)
-	if err != nil {
-		return nil, fmt.Errorf("encoding SQL model config: %w", err)
-	}
 	source := &retlClient.RETLSourceUpdateRequest{
 		Name:      data[DisplayNameKey].(string),
-		Config:    rawCfg,
+		Config:    toRETLSQLModelConfig(data),
 		IsEnabled: data[EnabledKey].(bool),
 		AccountID: data[AccountIDKey].(string),
 	}

--- a/cli/internal/providers/retl/sqlmodel/handler.go
+++ b/cli/internal/providers/retl/sqlmodel/handler.go
@@ -318,7 +318,11 @@ func (h *Handler) Import(ctx context.Context, ID string, data resources.Resource
 	currentState.FromResourceData(data)
 
 	if currentState.DiffUpstream(existingState) {
-		return h.updateCall(ctx, remoteId, data)
+		updated, err := h.updateCall(ctx, remoteId, data)
+		if err != nil {
+			return nil, fmt.Errorf("importing RETL source: %w", err)
+		}
+		return updated, nil
 	}
 	return existing, nil
 }

--- a/cli/internal/providers/retl/sqlmodel/handler.go
+++ b/cli/internal/providers/retl/sqlmodel/handler.go
@@ -17,6 +17,10 @@ import (
 	"github.com/rudderlabs/rudder-iac/cli/internal/resources/state"
 )
 
+// modelSourceTypeFilter is the sourceType query value passed to
+// ListRetlSources. The sqlmodel handler only cares about SQL model sources.
+const modelSourceTypeFilter = string(retlClient.ModelSourceType)
+
 // Handler implements the resourceHandler interface for SQL Model resources
 type Handler struct {
 	client    retlClient.RETLStore
@@ -184,9 +188,14 @@ func (h *Handler) GetResources() ([]*resources.Resource, error) {
 
 // Create creates a new SQL Model resource
 func (h *Handler) Create(ctx context.Context, ID string, data resources.ResourceData) (*resources.ResourceData, error) {
+	cfg := toRETLSQLModelConfig(data)
+	rawCfg, err := retlClient.MarshalConfig(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("encoding SQL model config: %w", err)
+	}
 	source := &retlClient.RETLSourceCreateRequest{
 		Name:                 data[DisplayNameKey].(string),
-		Config:               toRETLSQLModelConfig(data),
+		Config:               rawCfg,
 		SourceType:           retlClient.ModelSourceType,
 		SourceDefinitionName: data[SourceDefinitionKey].(string),
 		AccountID:            data[AccountIDKey].(string),
@@ -194,13 +203,12 @@ func (h *Handler) Create(ctx context.Context, ID string, data resources.Resource
 		ExternalID:           ID,
 	}
 
-	// Call API to create RETL source
 	resp, err := h.client.CreateRetlSource(ctx, source)
 	if err != nil {
 		return nil, fmt.Errorf("creating RETL source: %w", err)
 	}
 
-	return toResourceData(resp), nil
+	return toResourceData(resp)
 }
 
 // Update updates an existing SQL Model resource
@@ -219,20 +227,24 @@ func (h *Handler) Update(ctx context.Context, ID string, data resources.Resource
 }
 
 func (h *Handler) updateCall(ctx context.Context, sourceID string, data resources.ResourceData) (*resources.ResourceData, error) {
+	cfg := toRETLSQLModelConfig(data)
+	rawCfg, err := retlClient.MarshalConfig(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("encoding SQL model config: %w", err)
+	}
 	source := &retlClient.RETLSourceUpdateRequest{
 		Name:      data[DisplayNameKey].(string),
-		Config:    toRETLSQLModelConfig(data),
+		Config:    rawCfg,
 		IsEnabled: data[EnabledKey].(bool),
 		AccountID: data[AccountIDKey].(string),
 	}
 
-	// Call API to update RETL source
 	resp, err := h.client.UpdateRetlSource(ctx, sourceID, source)
 	if err != nil {
 		return nil, fmt.Errorf("updating RETL source: %w", err)
 	}
 
-	return toResourceData(resp), nil
+	return toResourceData(resp)
 }
 
 // Delete deletes an existing SQL Model resource
@@ -252,15 +264,19 @@ func (h *Handler) Delete(ctx context.Context, ID string, state resources.Resourc
 }
 
 func (h *Handler) List(ctx context.Context, hasExternalId *bool) ([]resources.ResourceData, error) {
-	sources, err := h.client.ListRetlSources(ctx, hasExternalId)
+	sources, err := h.client.ListRetlSources(ctx, modelSourceTypeFilter, hasExternalId)
 	if err != nil {
 		return nil, fmt.Errorf("listing RETL sources: %w", err)
 	}
 	re := regexp.MustCompile(`\s+`)
 	var resourceData []resources.ResourceData
 	for _, source := range sources.Data {
+		cfg, err := retlClient.DecodeConfig[retlClient.RETLSQLModelConfig](source.Config)
+		if err != nil {
+			return nil, fmt.Errorf("decoding SQL model config for source %s: %w", source.ID, err)
+		}
 		// Replace newlines with spaces and collapse multiple spaces into one
-		sql := re.ReplaceAllString(source.Config.Sql, " ")
+		sql := re.ReplaceAllString(cfg.Sql, " ")
 		resourceData = append(resourceData, resources.ResourceData{
 			IDKey:               source.ID,
 			"name":              source.Name,
@@ -269,9 +285,9 @@ func (h *Handler) List(ctx context.Context, hasExternalId *bool) ([]resources.Re
 			CreatedAtKey:        source.CreatedAt,
 			UpdatedAtKey:        source.UpdatedAt,
 			"config": map[string]interface{}{
-				PrimaryKeyKey:  source.Config.PrimaryKey,
+				PrimaryKeyKey:  cfg.PrimaryKey,
 				SQLKey:         sql,
-				DescriptionKey: source.Config.Description,
+				DescriptionKey: cfg.Description,
 			},
 		})
 	}
@@ -290,22 +306,21 @@ func (h *Handler) Import(ctx context.Context, ID string, data resources.Resource
 		return nil, fmt.Errorf("setting external ID for RETL source: %w", err)
 	}
 
+	existing, err := toResourceData(existingSource)
+	if err != nil {
+		return nil, err
+	}
+
 	existingState := &SQLModelResource{}
-	existingState.FromResourceData(*toResourceData(existingSource))
+	existingState.FromResourceData(*existing)
 
 	currentState := &SQLModelResource{}
 	currentState.FromResourceData(data)
 
-	changed := currentState.DiffUpstream(existingState)
-	result := toResourceData(existingSource)
-	if changed {
-		updatedData, err := h.updateCall(ctx, remoteId, data)
-		if err != nil {
-			return nil, fmt.Errorf("updating RETL source: %w", err)
-		}
-		result = updatedData
+	if currentState.DiffUpstream(existingState) {
+		return h.updateCall(ctx, remoteId, data)
 	}
-	return result, nil
+	return existing, nil
 }
 
 func (h *Handler) FetchImportData(ctx context.Context, args specs.ImportIds) (writer.FormattableEntity, error) {
@@ -326,16 +341,21 @@ func (h *Handler) FetchImportData(ctx context.Context, args specs.ImportIds) (wr
 		return writer.FormattableEntity{}, fmt.Errorf("source %s is not a SQL model (type: %s)", args.RemoteID, source.SourceType)
 	}
 
+	cfg, err := retlClient.DecodeConfig[retlClient.RETLSQLModelConfig](source.Config)
+	if err != nil {
+		return writer.FormattableEntity{}, fmt.Errorf("decoding SQL model config for source %s: %w", args.RemoteID, err)
+	}
+
 	// Create the base resource data structure for the imported source
 	importedData := resources.ResourceData{
 		IDKey:               args.LocalID,
 		DisplayNameKey:      source.Name,
-		DescriptionKey:      source.Config.Description,
+		DescriptionKey:      cfg.Description,
 		AccountIDKey:        source.AccountID,
-		PrimaryKeyKey:       source.Config.PrimaryKey,
+		PrimaryKeyKey:       cfg.PrimaryKey,
 		SourceDefinitionKey: source.SourceDefinitionName,
 		EnabledKey:          source.IsEnabled,
-		SQLKey:              source.Config.Sql,
+		SQLKey:              cfg.Sql,
 	}
 
 	importMetadata := specs.Metadata{
@@ -379,7 +399,7 @@ func (h *Handler) FetchImportData(ctx context.Context, args specs.ImportIds) (wr
 func (h *Handler) LoadResourcesFromRemote(ctx context.Context) (*resources.RemoteResources, error) {
 	collection := resources.NewRemoteResources()
 	hasExternalID := true
-	sources, err := h.client.ListRetlSources(ctx, &hasExternalID)
+	sources, err := h.client.ListRetlSources(ctx, modelSourceTypeFilter, &hasExternalID)
 	if err != nil {
 		return nil, fmt.Errorf("listing RETL sources: %w", err)
 	}
@@ -403,17 +423,24 @@ func (h *Handler) MapRemoteToState(collection *resources.RemoteResources) (*stat
 		if !ok {
 			return nil, fmt.Errorf("unable to cast resource to retl source")
 		}
+		cfg, err := retlClient.DecodeConfig[retlClient.RETLSQLModelConfig](source.Config)
+		if err != nil {
+			return nil, fmt.Errorf("decoding SQL model config for source %s: %w", source.ID, err)
+		}
+		output, err := toResourceData(&source)
+		if err != nil {
+			return nil, err
+		}
 		input := resources.ResourceData{
 			DisplayNameKey:      source.Name,
-			DescriptionKey:      source.Config.Description,
+			DescriptionKey:      cfg.Description,
 			AccountIDKey:        source.AccountID,
-			PrimaryKeyKey:       source.Config.PrimaryKey,
-			SQLKey:              source.Config.Sql,
+			PrimaryKeyKey:       cfg.PrimaryKey,
+			SQLKey:              cfg.Sql,
 			EnabledKey:          source.IsEnabled,
 			SourceDefinitionKey: source.SourceDefinitionName,
 			LocalIDKey:          source.ExternalID,
 		}
-		output := toResourceData(&source)
 		s.AddResource(&state.ResourceState{
 			Type:   ResourceType,
 			ID:     source.ExternalID,
@@ -427,7 +454,7 @@ func (h *Handler) MapRemoteToState(collection *resources.RemoteResources) (*stat
 func (h *Handler) LoadImportable(ctx context.Context, idNamer namer.Namer) (*resources.RemoteResources, error) {
 	collection := resources.NewRemoteResources()
 	hasExternalID := false
-	sources, err := h.client.ListRetlSources(ctx, &hasExternalID)
+	sources, err := h.client.ListRetlSources(ctx, modelSourceTypeFilter, &hasExternalID)
 	if err != nil {
 		return nil, fmt.Errorf("listing RETL sources: %w", err)
 	}
@@ -465,6 +492,10 @@ func (h *Handler) FormatForExport(collection *resources.RemoteResources, idNamer
 		if !ok {
 			return nil, fmt.Errorf("unable to cast resource to retl source")
 		}
+		cfg, err := retlClient.DecodeConfig[retlClient.RETLSQLModelConfig](sourceData.Config)
+		if err != nil {
+			return nil, fmt.Errorf("decoding SQL model config for source %s: %w", sourceData.ID, err)
+		}
 		workspaceMetadata.WorkspaceID = sourceData.WorkspaceID
 		urn := resources.URN(source.ExternalID, ResourceType)
 		workspaceMetadata.Resources = []specs.ImportIds{
@@ -492,10 +523,10 @@ func (h *Handler) FormatForExport(collection *resources.RemoteResources, idNamer
 			Metadata: metadataMap,
 			Spec: map[string]interface{}{
 				DisplayNameKey:      sourceData.Name,
-				DescriptionKey:      sourceData.Config.Description,
+				DescriptionKey:      cfg.Description,
 				AccountIDKey:        sourceData.AccountID,
-				PrimaryKeyKey:       sourceData.Config.PrimaryKey,
-				SQLKey:              sourceData.Config.Sql,
+				PrimaryKeyKey:       cfg.PrimaryKey,
+				SQLKey:              cfg.Sql,
 				SourceDefinitionKey: sourceData.SourceDefinitionName,
 				EnabledKey:          sourceData.IsEnabled,
 				IDKey:               source.ExternalID,
@@ -509,13 +540,17 @@ func (h *Handler) FormatForExport(collection *resources.RemoteResources, idNamer
 	return result, nil
 }
 
-func toResourceData(source *retlClient.RETLSource) *resources.ResourceData {
+func toResourceData(source *retlClient.RETLSource) (*resources.ResourceData, error) {
+	cfg, err := retlClient.DecodeConfig[retlClient.RETLSQLModelConfig](source.Config)
+	if err != nil {
+		return nil, fmt.Errorf("decoding SQL model config for source %s: %w", source.ID, err)
+	}
 	result := resources.ResourceData{
 		DisplayNameKey:      source.Name,
-		DescriptionKey:      source.Config.Description,
+		DescriptionKey:      cfg.Description,
 		AccountIDKey:        source.AccountID,
-		PrimaryKeyKey:       source.Config.PrimaryKey,
-		SQLKey:              source.Config.Sql,
+		PrimaryKeyKey:       cfg.PrimaryKey,
+		SQLKey:              cfg.Sql,
 		IDKey:               source.ID,
 		SourceTypeKey:       source.SourceType,
 		EnabledKey:          source.IsEnabled,
@@ -528,7 +563,7 @@ func toResourceData(source *retlClient.RETLSource) *resources.ResourceData {
 	if source.UpdatedAt != nil {
 		result[UpdatedAtKey] = source.UpdatedAt
 	}
-	return &result
+	return &result, nil
 }
 
 func toRETLSQLModelConfig(data resources.ResourceData) retlClient.RETLSQLModelConfig {

--- a/cli/internal/providers/retl/sqlmodel/handler_test.go
+++ b/cli/internal/providers/retl/sqlmodel/handler_test.go
@@ -34,12 +34,6 @@ func createTestRETLSourceWithConfig(id, name, sourceDefn, accountID string, enab
 	}
 }
 
-// mustMarshalSQLModelConfig wraps a typed SQL model config as a
-// retlClient.ConfigType for use in test fixtures.
-func mustMarshalSQLModelConfig(cfg retlClient.RETLSQLModelConfig) retlClient.ConfigType {
-	return cfg
-}
-
 // createTestResourceData creates test resource data with common defaults
 func createTestResourceData(id, displayName, description, sql string) resources.ResourceData {
 	return resources.ResourceData{
@@ -130,7 +124,7 @@ func (m *mockRETLClient) GetRetlSource(ctx context.Context, sourceID string) (*r
 	return &retlClient.RETLSource{
 		ID:                   sourceID,
 		Name:                 "Test Model",
-		Config:               mustMarshalSQLModelConfig(retlClient.RETLSQLModelConfig{}),
+		Config:               retlClient.RETLSQLModelConfig{},
 		SourceType:           "model",
 		SourceDefinitionName: "postgres",
 		AccountID:            "acc123",
@@ -175,7 +169,7 @@ func (m *mockRETLClient) ListRetlSources(ctx context.Context, opts ...retlClient
 			{
 				ID:                   m.sourceID,
 				Name:                 "Test Model",
-				Config:               mustMarshalSQLModelConfig(retlClient.RETLSQLModelConfig{}),
+				Config:               retlClient.RETLSQLModelConfig{},
 				SourceType:           "model",
 				SourceDefinitionName: "postgres",
 				AccountID:            "acc123",
@@ -1234,7 +1228,7 @@ func TestSQLModelHandler(t *testing.T) {
 				return &retlClient.RETLSource{
 					ID:                   "remote-id",
 					Name:                 "Imported Model",
-					Config:               mustMarshalSQLModelConfig(retlClient.RETLSQLModelConfig{Description: "desc", PrimaryKey: "id", Sql: "SELECT * FROM t"}),
+					Config:               retlClient.RETLSQLModelConfig{Description: "desc", PrimaryKey: "id", Sql: "SELECT * FROM t"},
 					SourceType:           retlClient.ModelSourceType,
 					SourceDefinitionName: "postgres",
 					AccountID:            "acc123",
@@ -1522,11 +1516,11 @@ func TestSQLModelHandler(t *testing.T) {
 						ExternalID:           "local-1",
 						CreatedAt:            &createdAt,
 						UpdatedAt:            &updatedAt,
-						Config: mustMarshalSQLModelConfig(retlClient.RETLSQLModelConfig{
+						Config: retlClient.RETLSQLModelConfig{
 							Description: "desc 1",
 							PrimaryKey:  "id",
 							Sql:         "SELECT * FROM one",
-						}),
+						},
 					},
 				},
 				"remote-2": {
@@ -1541,11 +1535,11 @@ func TestSQLModelHandler(t *testing.T) {
 						IsEnabled:            false,
 						WorkspaceID:          "ws-2",
 						ExternalID:           "local-2",
-						Config: mustMarshalSQLModelConfig(retlClient.RETLSQLModelConfig{
+						Config: retlClient.RETLSQLModelConfig{
 							Description: "desc 2",
 							PrimaryKey:  "pk",
 							Sql:         "SELECT * FROM two",
-						}),
+						},
 					},
 				},
 			}
@@ -1693,7 +1687,7 @@ func TestSQLModelHandler(t *testing.T) {
 			return &retlClient.RETLSource{
 				ID:                   "remote-id",
 				Name:                 "Imported Model",
-				Config:               mustMarshalSQLModelConfig(retlClient.RETLSQLModelConfig{Description: "desc", PrimaryKey: "id", Sql: sql}),
+				Config:               retlClient.RETLSQLModelConfig{Description: "desc", PrimaryKey: "id", Sql: sql},
 				SourceType:           retlClient.ModelSourceType,
 				SourceDefinitionName: "postgres",
 				AccountID:            "acc123",

--- a/cli/internal/providers/retl/sqlmodel/handler_test.go
+++ b/cli/internal/providers/retl/sqlmodel/handler_test.go
@@ -22,12 +22,7 @@ import (
 )
 
 // createTestRETLSourceWithConfig creates a test RETL source with custom config.
-// The typed config is encoded into json.RawMessage via retlClient.MarshalConfig.
 func createTestRETLSourceWithConfig(id, name, sourceDefn, accountID string, enabled bool, config retlClient.RETLSQLModelConfig) retlClient.RETLSource {
-	raw, err := retlClient.MarshalConfig(config)
-	if err != nil {
-		panic(fmt.Sprintf("marshalling test SQL model config: %v", err))
-	}
 	return retlClient.RETLSource{
 		ID:                   id,
 		Name:                 name,
@@ -35,18 +30,14 @@ func createTestRETLSourceWithConfig(id, name, sourceDefn, accountID string, enab
 		SourceType:           retlClient.ModelSourceType,
 		SourceDefinitionName: sourceDefn,
 		AccountID:            accountID,
-		Config:               raw,
+		Config:               config,
 	}
 }
 
-// mustMarshalSQLModelConfig encodes a SQL model config into json.RawMessage,
-// panicking on failure. Only for use inside test fixtures.
-func mustMarshalSQLModelConfig(cfg retlClient.RETLSQLModelConfig) json.RawMessage {
-	raw, err := retlClient.MarshalConfig(cfg)
-	if err != nil {
-		panic(fmt.Sprintf("marshalling test SQL model config: %v", err))
-	}
-	return raw
+// mustMarshalSQLModelConfig wraps a typed SQL model config as a
+// retlClient.ConfigType for use in test fixtures.
+func mustMarshalSQLModelConfig(cfg retlClient.RETLSQLModelConfig) retlClient.ConfigType {
+	return cfg
 }
 
 // createTestResourceData creates test resource data with common defaults

--- a/cli/internal/providers/retl/sqlmodel/handler_test.go
+++ b/cli/internal/providers/retl/sqlmodel/handler_test.go
@@ -21,8 +21,13 @@ import (
 	"github.com/rudderlabs/rudder-iac/cli/internal/resources"
 )
 
-// createTestRETLSourceWithConfig creates a test RETL source with custom config
+// createTestRETLSourceWithConfig creates a test RETL source with custom config.
+// The typed config is encoded into json.RawMessage via retlClient.MarshalConfig.
 func createTestRETLSourceWithConfig(id, name, sourceDefn, accountID string, enabled bool, config retlClient.RETLSQLModelConfig) retlClient.RETLSource {
+	raw, err := retlClient.MarshalConfig(config)
+	if err != nil {
+		panic(fmt.Sprintf("marshalling test SQL model config: %v", err))
+	}
 	return retlClient.RETLSource{
 		ID:                   id,
 		Name:                 name,
@@ -30,8 +35,18 @@ func createTestRETLSourceWithConfig(id, name, sourceDefn, accountID string, enab
 		SourceType:           retlClient.ModelSourceType,
 		SourceDefinitionName: sourceDefn,
 		AccountID:            accountID,
-		Config:               config,
+		Config:               raw,
 	}
+}
+
+// mustMarshalSQLModelConfig encodes a SQL model config into json.RawMessage,
+// panicking on failure. Only for use inside test fixtures.
+func mustMarshalSQLModelConfig(cfg retlClient.RETLSQLModelConfig) json.RawMessage {
+	raw, err := retlClient.MarshalConfig(cfg)
+	if err != nil {
+		panic(fmt.Sprintf("marshalling test SQL model config: %v", err))
+	}
+	return raw
 }
 
 // createTestResourceData creates test resource data with common defaults
@@ -76,8 +91,8 @@ func createTestSpecMap(fields map[string]interface{}) *specs.Spec {
 }
 
 // mockListRetlSources creates a mock list function that returns the given sources
-func mockListRetlSources(sources ...retlClient.RETLSource) func(ctx context.Context) (*retlClient.RETLSources, error) {
-	return func(ctx context.Context) (*retlClient.RETLSources, error) {
+func mockListRetlSources(sources ...retlClient.RETLSource) func(ctx context.Context, sourceType string, hasExternalID *bool) (*retlClient.RETLSources, error) {
+	return func(ctx context.Context, sourceType string, hasExternalID *bool) (*retlClient.RETLSources, error) {
 		return &retlClient.RETLSources{Data: sources}, nil
 	}
 }
@@ -92,7 +107,7 @@ type mockRETLClient struct {
 	updateError                bool
 	createRetlSourceFunc       func(ctx context.Context, req *retlClient.RETLSourceCreateRequest) (*retlClient.RETLSource, error)
 	updateRetlSourceFunc       func(ctx context.Context, sourceID string, req *retlClient.RETLSourceUpdateRequest) (*retlClient.RETLSource, error)
-	listRetlSourcesFunc        func(ctx context.Context) (*retlClient.RETLSources, error)
+	listRetlSourcesFunc        func(ctx context.Context, sourceType string, hasExternalID *bool) (*retlClient.RETLSources, error)
 	getRetlSourceFunc          func(ctx context.Context, sourceID string) (*retlClient.RETLSource, error)
 	submitSourcePreviewFunc    func(ctx context.Context, request *retlClient.PreviewSubmitRequest) (*retlClient.PreviewSubmitResponse, error)
 	getSourcePreviewResultFunc func(ctx context.Context, resultID string) (*retlClient.PreviewResultResponse, error)
@@ -124,7 +139,7 @@ func (m *mockRETLClient) GetRetlSource(ctx context.Context, sourceID string) (*r
 	return &retlClient.RETLSource{
 		ID:                   sourceID,
 		Name:                 "Test Model",
-		Config:               retlClient.RETLSQLModelConfig{},
+		Config:               mustMarshalSQLModelConfig(retlClient.RETLSQLModelConfig{}),
 		SourceType:           "model",
 		SourceDefinitionName: "postgres",
 		AccountID:            "acc123",
@@ -160,16 +175,16 @@ func (m *mockRETLClient) DeleteRetlSource(ctx context.Context, sourceID string) 
 	return nil
 }
 
-func (m *mockRETLClient) ListRetlSources(ctx context.Context, hasExternalID *bool) (*retlClient.RETLSources, error) {
+func (m *mockRETLClient) ListRetlSources(ctx context.Context, sourceType string, hasExternalID *bool) (*retlClient.RETLSources, error) {
 	if m.listRetlSourcesFunc != nil {
-		return m.listRetlSourcesFunc(ctx)
+		return m.listRetlSourcesFunc(ctx, sourceType, hasExternalID)
 	}
 	return &retlClient.RETLSources{
 		Data: []retlClient.RETLSource{
 			{
 				ID:                   m.sourceID,
 				Name:                 "Test Model",
-				Config:               retlClient.RETLSQLModelConfig{},
+				Config:               mustMarshalSQLModelConfig(retlClient.RETLSQLModelConfig{}),
 				SourceType:           "model",
 				SourceDefinitionName: "postgres",
 				AccountID:            "acc123",
@@ -1201,7 +1216,7 @@ func TestSQLModelHandler(t *testing.T) {
 
 			mockClient := &mockRETLClient{
 				sourceID: "src123",
-				listRetlSourcesFunc: func(ctx context.Context) (*retlClient.RETLSources, error) {
+				listRetlSourcesFunc: func(ctx context.Context, sourceType string, hasExternalID *bool) (*retlClient.RETLSources, error) {
 					return nil, fmt.Errorf("API error")
 				},
 			}
@@ -1228,7 +1243,7 @@ func TestSQLModelHandler(t *testing.T) {
 				return &retlClient.RETLSource{
 					ID:                   "remote-id",
 					Name:                 "Imported Model",
-					Config:               retlClient.RETLSQLModelConfig{Description: "desc", PrimaryKey: "id", Sql: "SELECT * FROM t"},
+					Config:               mustMarshalSQLModelConfig(retlClient.RETLSQLModelConfig{Description: "desc", PrimaryKey: "id", Sql: "SELECT * FROM t"}),
 					SourceType:           retlClient.ModelSourceType,
 					SourceDefinitionName: "postgres",
 					AccountID:            "acc123",
@@ -1473,7 +1488,7 @@ func TestSQLModelHandler(t *testing.T) {
 			t.Parallel()
 
 			mockClient := &mockRETLClient{
-				listRetlSourcesFunc: func(ctx context.Context) (*retlClient.RETLSources, error) {
+				listRetlSourcesFunc: func(ctx context.Context, sourceType string, hasExternalID *bool) (*retlClient.RETLSources, error) {
 					return nil, fmt.Errorf("API error listing sources")
 				},
 			}
@@ -1516,11 +1531,11 @@ func TestSQLModelHandler(t *testing.T) {
 						ExternalID:           "local-1",
 						CreatedAt:            &createdAt,
 						UpdatedAt:            &updatedAt,
-						Config: retlClient.RETLSQLModelConfig{
+						Config: mustMarshalSQLModelConfig(retlClient.RETLSQLModelConfig{
 							Description: "desc 1",
 							PrimaryKey:  "id",
 							Sql:         "SELECT * FROM one",
-						},
+						}),
 					},
 				},
 				"remote-2": {
@@ -1535,11 +1550,11 @@ func TestSQLModelHandler(t *testing.T) {
 						IsEnabled:            false,
 						WorkspaceID:          "ws-2",
 						ExternalID:           "local-2",
-						Config: retlClient.RETLSQLModelConfig{
+						Config: mustMarshalSQLModelConfig(retlClient.RETLSQLModelConfig{
 							Description: "desc 2",
 							PrimaryKey:  "pk",
 							Sql:         "SELECT * FROM two",
-						},
+						}),
 					},
 				},
 			}
@@ -1657,7 +1672,9 @@ func TestSQLModelHandler(t *testing.T) {
 
 		t.Run("API error", func(t *testing.T) {
 			t.Parallel()
-			mockClient := &mockRETLClient{listRetlSourcesFunc: func(ctx context.Context) (*retlClient.RETLSources, error) { return nil, fmt.Errorf("api") }}
+			mockClient := &mockRETLClient{listRetlSourcesFunc: func(ctx context.Context, sourceType string, hasExternalID *bool) (*retlClient.RETLSources, error) {
+				return nil, fmt.Errorf("api")
+			}}
 			h := sqlmodel.NewHandler(mockClient, "retl")
 			collection, err := h.LoadImportable(context.Background(), idNamer)
 			assert.Error(t, err)
@@ -1685,7 +1702,7 @@ func TestSQLModelHandler(t *testing.T) {
 			return &retlClient.RETLSource{
 				ID:                   "remote-id",
 				Name:                 "Imported Model",
-				Config:               retlClient.RETLSQLModelConfig{Description: "desc", PrimaryKey: "id", Sql: sql},
+				Config:               mustMarshalSQLModelConfig(retlClient.RETLSQLModelConfig{Description: "desc", PrimaryKey: "id", Sql: sql}),
 				SourceType:           retlClient.ModelSourceType,
 				SourceDefinitionName: "postgres",
 				AccountID:            "acc123",
@@ -1743,8 +1760,10 @@ func TestSQLModelHandler(t *testing.T) {
 				assert.Equal(t, "Imported Model", req.Name)
 				assert.Equal(t, "acc123", req.AccountID)
 				assert.True(t, req.IsEnabled)
-				assert.Equal(t, "id", req.Config.PrimaryKey)
-				assert.Equal(t, "SELECT * FROM t", req.Config.Sql)
+				decoded, err := retlClient.DecodeConfig[retlClient.RETLSQLModelConfig](req.Config)
+				require.NoError(t, err)
+				assert.Equal(t, "id", decoded.PrimaryKey)
+				assert.Equal(t, "SELECT * FROM t", decoded.Sql)
 				return &retlClient.RETLSource{
 					ID:                   "remote-id",
 					Name:                 req.Name,

--- a/cli/internal/providers/retl/sqlmodel/handler_test.go
+++ b/cli/internal/providers/retl/sqlmodel/handler_test.go
@@ -91,8 +91,8 @@ func createTestSpecMap(fields map[string]interface{}) *specs.Spec {
 }
 
 // mockListRetlSources creates a mock list function that returns the given sources
-func mockListRetlSources(sources ...retlClient.RETLSource) func(ctx context.Context, sourceType string, hasExternalID *bool) (*retlClient.RETLSources, error) {
-	return func(ctx context.Context, sourceType string, hasExternalID *bool) (*retlClient.RETLSources, error) {
+func mockListRetlSources(sources ...retlClient.RETLSource) func(ctx context.Context, opts ...retlClient.ListRetlSourcesOption) (*retlClient.RETLSources, error) {
+	return func(ctx context.Context, opts ...retlClient.ListRetlSourcesOption) (*retlClient.RETLSources, error) {
 		return &retlClient.RETLSources{Data: sources}, nil
 	}
 }
@@ -107,7 +107,7 @@ type mockRETLClient struct {
 	updateError                bool
 	createRetlSourceFunc       func(ctx context.Context, req *retlClient.RETLSourceCreateRequest) (*retlClient.RETLSource, error)
 	updateRetlSourceFunc       func(ctx context.Context, sourceID string, req *retlClient.RETLSourceUpdateRequest) (*retlClient.RETLSource, error)
-	listRetlSourcesFunc        func(ctx context.Context, sourceType string, hasExternalID *bool) (*retlClient.RETLSources, error)
+	listRetlSourcesFunc        func(ctx context.Context, opts ...retlClient.ListRetlSourcesOption) (*retlClient.RETLSources, error)
 	getRetlSourceFunc          func(ctx context.Context, sourceID string) (*retlClient.RETLSource, error)
 	submitSourcePreviewFunc    func(ctx context.Context, request *retlClient.PreviewSubmitRequest) (*retlClient.PreviewSubmitResponse, error)
 	getSourcePreviewResultFunc func(ctx context.Context, resultID string) (*retlClient.PreviewResultResponse, error)
@@ -175,9 +175,9 @@ func (m *mockRETLClient) DeleteRetlSource(ctx context.Context, sourceID string) 
 	return nil
 }
 
-func (m *mockRETLClient) ListRetlSources(ctx context.Context, sourceType string, hasExternalID *bool) (*retlClient.RETLSources, error) {
+func (m *mockRETLClient) ListRetlSources(ctx context.Context, opts ...retlClient.ListRetlSourcesOption) (*retlClient.RETLSources, error) {
 	if m.listRetlSourcesFunc != nil {
-		return m.listRetlSourcesFunc(ctx, sourceType, hasExternalID)
+		return m.listRetlSourcesFunc(ctx, opts...)
 	}
 	return &retlClient.RETLSources{
 		Data: []retlClient.RETLSource{
@@ -1216,7 +1216,7 @@ func TestSQLModelHandler(t *testing.T) {
 
 			mockClient := &mockRETLClient{
 				sourceID: "src123",
-				listRetlSourcesFunc: func(ctx context.Context, sourceType string, hasExternalID *bool) (*retlClient.RETLSources, error) {
+				listRetlSourcesFunc: func(ctx context.Context, opts ...retlClient.ListRetlSourcesOption) (*retlClient.RETLSources, error) {
 					return nil, fmt.Errorf("API error")
 				},
 			}
@@ -1488,7 +1488,7 @@ func TestSQLModelHandler(t *testing.T) {
 			t.Parallel()
 
 			mockClient := &mockRETLClient{
-				listRetlSourcesFunc: func(ctx context.Context, sourceType string, hasExternalID *bool) (*retlClient.RETLSources, error) {
+				listRetlSourcesFunc: func(ctx context.Context, opts ...retlClient.ListRetlSourcesOption) (*retlClient.RETLSources, error) {
 					return nil, fmt.Errorf("API error listing sources")
 				},
 			}
@@ -1672,7 +1672,7 @@ func TestSQLModelHandler(t *testing.T) {
 
 		t.Run("API error", func(t *testing.T) {
 			t.Parallel()
-			mockClient := &mockRETLClient{listRetlSourcesFunc: func(ctx context.Context, sourceType string, hasExternalID *bool) (*retlClient.RETLSources, error) {
+			mockClient := &mockRETLClient{listRetlSourcesFunc: func(ctx context.Context, opts ...retlClient.ListRetlSourcesOption) (*retlClient.RETLSources, error) {
 				return nil, fmt.Errorf("api")
 			}}
 			h := sqlmodel.NewHandler(mockClient, "retl")

--- a/cli/internal/providers/retl/testutils/mockclient.go
+++ b/cli/internal/providers/retl/testutils/mockclient.go
@@ -107,10 +107,6 @@ func NewDefaultMockClient() *mockRETLStore {
 				return nil, fmt.Errorf("retl source not found")
 			}
 
-			rawCfg, err := retlClient.MarshalConfig(retlClient.RETLSQLModelConfig{Description: "desc", PrimaryKey: "id", Sql: "SELECT * FROM t"})
-			if err != nil {
-				return nil, fmt.Errorf("encoding mock SQL model config: %w", err)
-			}
 			return &retlClient.RETLSource{
 				ID:                   "remote-id",
 				Name:                 "Imported Model",
@@ -118,7 +114,7 @@ func NewDefaultMockClient() *mockRETLStore {
 				SourceDefinitionName: "postgres",
 				AccountID:            "acc123",
 				IsEnabled:            true,
-				Config:               rawCfg,
+				Config:               retlClient.RETLSQLModelConfig{Description: "desc", PrimaryKey: "id", Sql: "SELECT * FROM t"},
 			}, nil
 		},
 		SubmitPreviewFunc: func(ctx context.Context, request *retlClient.PreviewSubmitRequest) (*retlClient.PreviewSubmitResponse, error) {

--- a/cli/internal/providers/retl/testutils/mockclient.go
+++ b/cli/internal/providers/retl/testutils/mockclient.go
@@ -16,7 +16,7 @@ type mockRETLStore struct {
 	UpdateRetlSourceFunc func(ctx context.Context, sourceID string, source *retlClient.RETLSourceUpdateRequest) (*retlClient.RETLSource, error)
 	DeleteRetlSourceFunc func(ctx context.Context, id string) error
 	GetRetlSourceFunc    func(ctx context.Context, id string) (*retlClient.RETLSource, error)
-	ListRetlSourcesFunc  func(ctx context.Context, hasExternalID *bool) (*retlClient.RETLSources, error)
+	ListRetlSourcesFunc  func(ctx context.Context, sourceType string, hasExternalID *bool) (*retlClient.RETLSources, error)
 	// Preview functions
 	SubmitPreviewFunc    func(ctx context.Context, request *retlClient.PreviewSubmitRequest) (*retlClient.PreviewSubmitResponse, error)
 	GetPreviewResultFunc func(ctx context.Context, resultID string) (*retlClient.PreviewResultResponse, error)
@@ -52,9 +52,9 @@ func (m *mockRETLStore) GetRetlSource(ctx context.Context, id string) (*retlClie
 	return nil, nil
 }
 
-func (m *mockRETLStore) ListRetlSources(ctx context.Context, hasExternalID *bool) (*retlClient.RETLSources, error) {
+func (m *mockRETLStore) ListRetlSources(ctx context.Context, sourceType string, hasExternalID *bool) (*retlClient.RETLSources, error) {
 	if m.ListRetlSourcesFunc != nil {
-		return m.ListRetlSourcesFunc(ctx, hasExternalID)
+		return m.ListRetlSourcesFunc(ctx, sourceType, hasExternalID)
 	}
 	return &retlClient.RETLSources{}, nil
 }
@@ -107,6 +107,10 @@ func NewDefaultMockClient() *mockRETLStore {
 				return nil, fmt.Errorf("retl source not found")
 			}
 
+			rawCfg, err := retlClient.MarshalConfig(retlClient.RETLSQLModelConfig{Description: "desc", PrimaryKey: "id", Sql: "SELECT * FROM t"})
+			if err != nil {
+				return nil, fmt.Errorf("encoding mock SQL model config: %w", err)
+			}
 			return &retlClient.RETLSource{
 				ID:                   "remote-id",
 				Name:                 "Imported Model",
@@ -114,7 +118,7 @@ func NewDefaultMockClient() *mockRETLStore {
 				SourceDefinitionName: "postgres",
 				AccountID:            "acc123",
 				IsEnabled:            true,
-				Config:               retlClient.RETLSQLModelConfig{Description: "desc", PrimaryKey: "id", Sql: "SELECT * FROM t"},
+				Config:               rawCfg,
 			}, nil
 		},
 		SubmitPreviewFunc: func(ctx context.Context, request *retlClient.PreviewSubmitRequest) (*retlClient.PreviewSubmitResponse, error) {


### PR DESCRIPTION
🔒 Scanned for secrets using gitleaks 8.28.0

## Description of the change

[PRO-5581](https://linear.app/rudderstack/issue/PRO-5581)

Extends the Go RETL API client to support the new `table` sourceType (warehouse tables + S3) alongside existing SQL `model` sources. `RETLSource.Config` is moved to `json.RawMessage` with a generic `MarshalConfig` / `DecodeConfig` pair so the client can carry multiple config shapes without a union type. `ListRetlSources` is refactored to functional options so callers can filter by `sourceType` and `hasExternalId` independently — the previous signature hard-coded `sourceType=model`, which blocked listing table sources.

### Key changes

- **`api/client/retl/types.go`**: `RETLSource.Config` and the Create/Update request configs are now `json.RawMessage`. Added `RETLTableConfig`, `RETLS3TableConfig`, the `ConfigType` constraint, and generic `MarshalConfig[T]` / `DecodeConfig[T]` helpers. Added `TableSourceType` constant.
- **`api/client/retl/retl.go` + `sources.go`**: `ListRetlSources` now takes `...ListRetlSourcesOption`. New options: `WithSourceType(string)`, `WithHasExternalId(*bool)`. The `sourceType` query param is only sent when non-empty (previously always `model`).
- **`cli/internal/providers/retl/sqlmodel/handler.go`**: Adapts to the `RawMessage` config — encodes via `MarshalConfig` on Create/Update and decodes via `DecodeConfig[RETLSQLModelConfig]` on List / Import / remote loads. All `ListRetlSources` calls now explicitly pass `WithSourceType(model)` so the sqlmodel handler only sees SQL model sources.
- **Tests**: updated call sites and mocks across `sources_test.go`, `provider_test.go`, `handler_test.go`, and `testutils/mockclient.go` for the new signature.


## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> [PRO-5581](https://linear.app/rudderstack/issue/PRO-5581)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request
