### PR TITLE
chore(typer/swift): run swift typer e2e tests on swift typer changes

### DIFF
--- a/.github/workflows/typer-swift-validate.yml
+++ b/.github/workflows/typer-swift-validate.yml
@@ -25,6 +25,7 @@ jobs:
   typer-swift-validate:
     name: validate generated Swift against RudderStack Swift SDK
     runs-on: macos-latest
+    timeout-minutes: 20
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0

--- a/.github/workflows/typer-swift-validate.yml
+++ b/.github/workflows/typer-swift-validate.yml
@@ -1,0 +1,41 @@
+name: typer swift validate
+on:
+  push:
+    branches:
+      - main
+      - "release/*"
+    paths:
+      - "cli/internal/typer/generator/platforms/swift/**"
+      - ".github/workflows/typer-swift-validate.yml"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "cli/internal/typer/generator/platforms/swift/**"
+      - ".github/workflows/typer-swift-validate.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  typer-swift-validate:
+    name: validate generated Swift against RudderStack Swift SDK
+    runs-on: macos-latest
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        with:
+          egress-policy: audit
+
+      - name: checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: swift version
+        run: swift --version
+
+      - name: run typer-swift-validate
+        run: make typer-swift-validate


### PR DESCRIPTION
## 🔗 Ticket

Resolves the CI wiring step for [DEX-311](https://linear.app/rudderstack/issue/DEX-311) — Add e2e tests for RudderTyper Swift.

Stack context:
- [#516](https://github.com/rudderlabs/rudder-iac/pull/516) validator skeleton + `testIdentify`
- [#517](https://github.com/rudderlabs/rudder-iac/pull/517) group + screen
- [#518](https://github.com/rudderlabs/rudder-iac/pull/518) core track
- [#519](https://github.com/rudderlabs/rudder-iac/pull/519) edge track
- **this PR** — wires `make typer-swift-validate` into GitHub Actions

---

## Summary

Adds a GitHub Actions workflow that runs the Swift typer validator suite against the real RudderStack Swift SDK on every change to the Swift generator. Until now `make typer-swift-validate` only ran locally — so the golden file could drift or fail to compile without anyone noticing. This closes that gap.

The Kotlin validator is Linux/Docker based, but the Swift SDK depends on Apple-specific frameworks (Foundation, platform networking) that are unavailable on Linux. The workflow therefore uses `macos-latest`, which ships the full Apple toolchain and runs `swift test` natively.

---

## Changes

- New workflow `.github/workflows/typer-swift-validate.yml`:
  - Runs on `macos-latest`.
  - Triggers only on push to `main` / `release/*` and PRs to `main`, scoped via `paths:` to `cli/internal/typer/generator/platforms/swift/**` and the workflow file itself — unrelated changes won't spin up a macOS runner.
  - Steps: `step-security/harden-runner` (audit) → `actions/checkout` → `swift --version` → `make typer-swift-validate`.
  - Action refs are SHA-pinned matching the SEC-171 policy; SHAs reused from `lint.yml` so no new entries needed in the org allowlist.

---

## Testing

- CI run on this PR executes the workflow end to end (golden file copy → `swift test --disable-swift-testing`) against the 12-case XCTest suite added in #516–#519. Merge only once this PR's own `typer swift validate` check is green.
- No production code touched — test-infra only.

---

## Risk / Impact

Low.

Additive CI job only. No generator, provider, or runtime code paths are affected. Worst case on failure: a PR touching Swift typer code is blocked on the new check — which is the intended signal.

---

## Checklist

- [x] Ticket linked
- [x] Tests added/updated (wires existing validator into CI)
- [x] No breaking changes (or documented)