### PR TITLE
docs: concise top-level README for rudder-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,34 +1,21 @@
 # rudder-cli
 
-## Table of Contents
+`rudder-cli` is a Go CLI for managing RudderStack resources using Infrastructure-as-Code.
 
-- [⚠️ Work in Progress](#️-work-in-progress)
-- [Installation](#installation)
-  - [MacOS](#macos)
-    - [Apple Silicon](#apple-silicon)
-    - [Intel-based](#intel-based)
-  - [Linux](#linux)
-  - [Docker](#docker)
-  - [Build from Source](#build-from-source)
+## Status
 
-## ⚠️ Work in Progress
-
-> **Warning**
->
-> Please note that this tool is currently a work in progress. We are actively developing and improving it, and as such, there may be frequent changes and updates. We do not guarantee backwards compatibility at this stage.
+> **Work in progress:** frequent changes are expected and backwards compatibility is not guaranteed yet.
 
 ## Installation
 
-### MacOS
-
-#### Apple Silicon
+### macOS (Apple Silicon)
 
 ```sh
 curl -L https://github.com/rudderlabs/rudder-iac/releases/latest/download/rudder-cli_Darwin_arm64.tar.gz | tar -xz rudder-cli
 sudo mv rudder-cli /usr/local/bin/
 ```
 
-#### Intel-based
+### macOS (Intel)
 
 ```sh
 curl -L https://github.com/rudderlabs/rudder-iac/releases/latest/download/rudder-cli_Darwin_x86_64.tar.gz | tar -xz rudder-cli
@@ -42,35 +29,33 @@ curl -L https://github.com/rudderlabs/rudder-iac/releases/latest/download/rudder
 sudo mv rudder-cli /usr/local/bin/
 ```
 
-### Docker
+## Docker
 
-You can run the CLI directly using Docker:
-
-```sh
-docker run rudderlabs/rudder-cli
-```
-
-If you need to persist your configuration, or provide an external configuration file, you can mount your local config directory into the container. Assuming your config directory is located at `~/.rudder`, you can run the following command:
+Run the CLI:
 
 ```sh
-docker run -v ~/.rudder:/.rudder rudderlabs/rudder-cli
+docker run --rm rudderlabs/rudder-cli
 ```
 
-To run commands with local catalog files, mount your files directory and use the `-l` flag. For example:
+Use local config (`~/.rudder`):
 
 ```sh
-docker run -v ~/.rudder:/.rudder -v ~/my-catalog:/catalog rudderlabs/rudder-cli tp apply --dry-run -l /catalog
+docker run --rm -v ~/.rudder:/.rudder rudderlabs/rudder-cli
 ```
 
-This will use the access token from your local configuration file, and the catalog files from the `/catalog` directory. Alternatively, you can use the `RUDDERSTACK_ACCESS_TOKEN` environment variable to provide the access token:
+Run commands with a local catalog:
 
 ```sh
-docker run -v ~/my-catalog:/catalog -e RUDDERSTACK_ACCESS_TOKEN=your-access-token rudderlabs/rudder-cli tp apply --dry-run -l /catalog
+docker run --rm -v ~/.rudder:/.rudder -v ~/my-catalog:/catalog rudderlabs/rudder-cli tp apply --dry-run -l /catalog
 ```
 
-### Build from Source
+Use token from environment:
 
-To build the `rudder-cli` from source, you need to have Go installed. Then, run the following commands:
+```sh
+docker run --rm -v ~/my-catalog:/catalog -e RUDDERSTACK_ACCESS_TOKEN=your-access-token rudderlabs/rudder-cli tp apply --dry-run -l /catalog
+```
+
+## Build from Source
 
 ```sh
 git clone https://github.com/rudderlabs/rudder-iac.git
@@ -79,7 +64,7 @@ make build
 sudo mv bin/rudder-cli /usr/local/bin/
 ```
 
-To build the Docker image locally:
+Build Docker image locally:
 
 ```sh
 make docker-build


### PR DESCRIPTION
## 🔗 Ticket

Resolves N/A (no Linear ticket provided by harness)

---

## Summary

Refined `README.md` into a shorter onboarding guide for `rudder-cli` while keeping the essential installation and execution instructions intact.

---

## Changes

- removed the table of contents and long warning paragraph, replacing them with a compact status section
- simplified installation headings and wording for macOS (Apple Silicon/Intel) and Linux
- kept Docker examples for direct run, mounted config, mounted catalog, and token-based auth with concise labels
- retained source build and local Docker build commands

---

## Testing

How was this tested?

- manual README markdown structure review
- manual shell command snippet sanity check against existing command patterns
- not validated in a dev container (repository does not include `.devcontainer`)

---

## Risk / Impact

Low
Notes (if any):

- documentation-only change; no runtime behavior modified

---

## Checklist

- [ ] Ticket linked (no ticket provided by harness)
- [ ] Tests added/updated (docs-only change)
- [x] No breaking changes (or documented)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because this is a documentation-only change that doesn’t affect runtime behavior. Primary risk is minor confusion if any updated command/example no longer matches current release artifacts or Docker usage.
> 
> **Overview**
> Shortens and restructures `README.md` into a more concise onboarding page by removing the table of contents and replacing the long WIP warning with a compact **Status** note.
> 
> Simplifies install section headings (macOS split by architecture, Linux) and refines Docker usage examples with clearer labels and `--rm`, while keeping source build and local Docker build instructions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dda97dabe613a628533a28bc62c6f131c87a51f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->