### PR TITLE
chore: add swift and kotlin to allowed source definition types

### DIFF
--- a/cli/internal/providers/event-stream/rules/source/source_spec_valid_test.go
+++ b/cli/internal/providers/event-stream/rules/source/source_spec_valid_test.go
@@ -92,7 +92,7 @@ func TestSourceSpecSyntaxValidRule_AllSourceTypes(t *testing.T) {
 	sourceTypes := []string{
 		"java", "dotnet", "php", "flutter", "cordova", "rust",
 		"react_native", "python", "ios", "android", "javascript",
-		"go", "node", "ruby", "unity",
+		"go", "node", "ruby", "unity", "swift", "kotlin",
 	}
 
 	for _, st := range sourceTypes {
@@ -154,7 +154,7 @@ func TestSourceSpecSyntaxValidRule_InvalidSpecs(t *testing.T) {
 				SourceDefinition: "invalid_type",
 			},
 			wantMessages: []string{
-				"'type' must be one of [java dotnet php flutter cordova rust react_native python ios android javascript go node ruby unity]",
+				"'type' must be one of [java dotnet php flutter cordova rust react_native python ios android javascript go node ruby unity swift kotlin]",
 			},
 		},
 		{
@@ -312,7 +312,7 @@ func TestSourceSpecSyntaxValidV1Rule_AllSourceTypes(t *testing.T) {
 	sourceTypes := []string{
 		"java", "dotnet", "php", "flutter", "cordova", "rust",
 		"react_native", "python", "ios", "android", "javascript",
-		"go", "node", "ruby", "unity",
+		"go", "node", "ruby", "unity", "swift", "kotlin",
 	}
 
 	for _, st := range sourceTypes {
@@ -374,7 +374,7 @@ func TestSourceSpecSyntaxValidV1Rule_InvalidSpecs(t *testing.T) {
 				SourceDefinition: "invalid_type",
 			},
 			wantMessages: []string{
-				"'type' must be one of [java dotnet php flutter cordova rust react_native python ios android javascript go node ruby unity]",
+				"'type' must be one of [java dotnet php flutter cordova rust react_native python ios android javascript go node ruby unity swift kotlin]",
 			},
 		},
 		{

--- a/cli/internal/providers/event-stream/source/model.go
+++ b/cli/internal/providers/event-stream/source/model.go
@@ -61,6 +61,8 @@ var sourceDefinitions = []string{
 	"node",
 	"ruby",
 	"unity",
+	"swift",
+	"kotlin",
 }
 
 // SourceSpec mirrors the YAML spec structure. JSON tags enable the typed rule engine's
@@ -69,7 +71,7 @@ var sourceDefinitions = []string{
 type SourceSpec struct {
 	LocalID          string                `json:"id"         mapstructure:"id"         validate:"required"`
 	Name             string                `json:"name"       mapstructure:"name"       validate:"required"`
-	SourceDefinition string                `json:"type"       mapstructure:"type"       validate:"required,oneof=java dotnet php flutter cordova rust react_native python ios android javascript go node ruby unity"`
+	SourceDefinition string                `json:"type"       mapstructure:"type"       validate:"required,oneof=java dotnet php flutter cordova rust react_native python ios android javascript go node ruby unity swift kotlin"`
 	Enabled          *bool                 `json:"enabled"    mapstructure:"enabled"`
 	Governance       *SourceGovernanceSpec `json:"governance" mapstructure:"governance"`
 }


### PR DESCRIPTION
## 🔗 Ticket

resolves [DEX-329](https://linear.app/rudderstack/issue/DEX-329)

---

## Summary

Adds `swift` and `kotlin` to the allowed source definition types in the event-stream source validation. These source types already exist in RudderStack but were missing from the CLI's validation enum, causing specs with these types to fail validation.

---

## Changes

* Added `swift` and `kotlin` to the `oneof` validate tag on `SourceSpec.SourceDefinition`
* Added `swift` and `kotlin` to the `sourceDefinitions` slice
* Updated test cases for both V0 and V1 `AllSourceTypes` to include the new types
* Updated `invalid_type_enum` error message expectations to include the new types

---

## Testing

* Unit tests — updated and passing (`go test ./cli/internal/providers/event-stream/rules/source/`)

---

## Risk / Impact

Low — additive change to a validation enum with no impact on existing source types.

---

## Checklist

* [x] Ticket linked
* [x] Tests added/updated
* [x] No breaking changes (or documented)