### PR TITLE
ci: add Homebrew tap automation to releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,5 +38,6 @@ jobs:
           args: release --clean -f ./cli/.goreleaser.yaml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           TELEMETRY_WRITE_KEY: ${{ vars.TELEMETRY_WRITE_KEY }}
           TELEMETRY_DATAPLANE_URL: ${{ vars.TELEMETRY_DATAPLANE_URL }}

--- a/cli/.goreleaser.yaml
+++ b/cli/.goreleaser.yaml
@@ -52,3 +52,17 @@ changelog:
     exclude:
       - "^docs:"
       - "^test:"
+
+brews:
+  - repository:
+      owner: rudderlabs
+      name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+    directory: Formula
+    homepage: "https://github.com/rudderlabs/rudder-iac"
+    description: "RudderStack Infrastructure-as-Code CLI"
+    license: "MIT"
+    install: |
+      bin.install "rudder-cli"
+    test: |
+      system "#{bin}/rudder-cli", "--version"


### PR DESCRIPTION

  ## Summary

  Configures GoReleaser to automatically publish a Homebrew formula to `rudderlabs/homebrew-tap` on each release. After setup, users can install via:

  ```bash
  brew install rudderlabs/tap/rudder-cli

  Changes

  - Add brews section to .goreleaser.yaml with formula configuration
  - Add HOMEBREW_TAP_TOKEN env var to release workflow

  Action Items (Required Before Merge)
  ┌─────┬───────────────────────────────────────────┬────────┬─────────────────────────────────────────────────────────────────────────┐
  │  #  │                   Task                    │ Owner  │                                 Details                                 │
  ├─────┼───────────────────────────────────────────┼────────┼─────────────────────────────────────────────────────────────────────────┤
  │ 1   │ Create rudderlabs/homebrew-tap repository │ DevOps │ Public repo with a README explaining installation                       │
  ├─────┼───────────────────────────────────────────┼────────┼─────────────────────────────────────────────────────────────────────────┤
  │ 2   │ Create GitHub PAT                         │ DevOps │ Fine-grained token with Contents (R/W) access to homebrew-tap repo only │
  ├─────┼───────────────────────────────────────────┼────────┼─────────────────────────────────────────────────────────────────────────┤
  │ 3   │ Add HOMEBREW_TAP_TOKEN secret             │ DevOps │ Add PAT to rudderlabs/rudder-iac → Settings → Secrets → Actions         │
  └─────┴───────────────────────────────────────────┴────────┴─────────────────────────────────────────────────────────────────────────┘
  Post-Release Verification
  ┌─────┬──────────────────────────────┬───────────────────────────────────────────────────────────────────────────────┐
  │  #  │             Task             │                                    Details                                    │
  ├─────┼──────────────────────────────┼───────────────────────────────────────────────────────────────────────────────┤
  │ 4   │ Verify formula was published │ Check rudderlabs/homebrew-tap/Formula/rudder-cli.rb exists after next release │
  ├─────┼──────────────────────────────┼───────────────────────────────────────────────────────────────────────────────┤
  │ 5   │ Test installation            │ Run brew install rudderlabs/tap/rudder-cli && rudder-cli --version            │
  └─────┴──────────────────────────────┴───────────────────────────────────────────────────────────────────────────────┘
  Testing

  - Reviewed GoReleaser documentation for brews configuration
  - Formula will be tested on first release after merge

  Risk / Impact

  Low - No impact on existing release process; Homebrew publishing is additive.