### PR TITLE
docs: make top-level README more concise

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,34 +1,21 @@
 # rudder-cli
 
-## Table of Contents
+`rudder-cli` is a Go CLI for managing RudderStack resources using Infrastructure-as-Code.
 
-- [⚠️ Work in Progress](#️-work-in-progress)
-- [Installation](#installation)
-  - [MacOS](#macos)
-    - [Apple Silicon](#apple-silicon)
-    - [Intel-based](#intel-based)
-  - [Linux](#linux)
-  - [Docker](#docker)
-  - [Build from Source](#build-from-source)
+## Status
 
-## ⚠️ Work in Progress
-
-> **Warning**
->
-> Please note that this tool is currently a work in progress. We are actively developing and improving it, and as such, there may be frequent changes and updates. We do not guarantee backwards compatibility at this stage.
+> **Work in progress:** frequent changes are expected and backwards compatibility is not guaranteed yet.
 
 ## Installation
 
-### MacOS
-
-#### Apple Silicon
+### macOS (Apple Silicon)
 
 ```sh
 curl -L https://github.com/rudderlabs/rudder-iac/releases/latest/download/rudder-cli_Darwin_arm64.tar.gz | tar -xz rudder-cli
 sudo mv rudder-cli /usr/local/bin/
 ```
 
-#### Intel-based
+### macOS (Intel)
 
 ```sh
 curl -L https://github.com/rudderlabs/rudder-iac/releases/latest/download/rudder-cli_Darwin_x86_64.tar.gz | tar -xz rudder-cli
@@ -42,35 +29,33 @@ curl -L https://github.com/rudderlabs/rudder-iac/releases/latest/download/rudder
 sudo mv rudder-cli /usr/local/bin/
 ```
 
-### Docker
+## Docker
 
-You can run the CLI directly using Docker:
-
-```sh
-docker run rudderlabs/rudder-cli
-```
-
-If you need to persist your configuration, or provide an external configuration file, you can mount your local config directory into the container. Assuming your config directory is located at `~/.rudder`, you can run the following command:
+Run the CLI:
 
 ```sh
-docker run -v ~/.rudder:/.rudder rudderlabs/rudder-cli
+docker run --rm rudderlabs/rudder-cli
 ```
 
-To run commands with local catalog files, mount your files directory and use the `-l` flag. For example:
+Use local config (`~/.rudder`):
 
 ```sh
-docker run -v ~/.rudder:/.rudder -v ~/my-catalog:/catalog rudderlabs/rudder-cli tp apply --dry-run -l /catalog
+docker run --rm -v ~/.rudder:/.rudder rudderlabs/rudder-cli
 ```
 
-This will use the access token from your local configuration file, and the catalog files from the `/catalog` directory. Alternatively, you can use the `RUDDERSTACK_ACCESS_TOKEN` environment variable to provide the access token:
+Run commands with a local catalog:
 
 ```sh
-docker run -v ~/my-catalog:/catalog -e RUDDERSTACK_ACCESS_TOKEN=your-access-token rudderlabs/rudder-cli tp apply --dry-run -l /catalog
+docker run --rm -v ~/.rudder:/.rudder -v ~/my-catalog:/catalog rudderlabs/rudder-cli tp apply --dry-run -l /catalog
 ```
 
-### Build from Source
+Use token from environment:
 
-To build the `rudder-cli` from source, you need to have Go installed. Then, run the following commands:
+```sh
+docker run --rm -v ~/my-catalog:/catalog -e RUDDERSTACK_ACCESS_TOKEN=your-access-token rudderlabs/rudder-cli tp apply --dry-run -l /catalog
+```
+
+## Build from Source
 
 ```sh
 git clone https://github.com/rudderlabs/rudder-iac.git
@@ -79,7 +64,7 @@ make build
 sudo mv bin/rudder-cli /usr/local/bin/
 ```
 
-To build the Docker image locally:
+Build Docker image locally:
 
 ```sh
 make docker-build

--- a/README.md
+++ b/README.md
@@ -1,61 +1,52 @@
 # rudder-cli
 
-`rudder-cli` is a Go CLI for managing RudderStack resources using Infrastructure-as-Code.
+`rudder-cli` is a Go CLI for managing RudderStack resources with Infrastructure as Code.
 
 ## Status
 
-> **Work in progress:** frequent changes are expected and backwards compatibility is not guaranteed yet.
+> **Work in progress:** changes are frequent and backward compatibility is not guaranteed yet.
 
-## Installation
+## Install
 
-### macOS (Apple Silicon)
+Download the latest release for your OS/architecture and move it into your `PATH`:
 
 ```sh
-curl -L https://github.com/rudderlabs/rudder-iac/releases/latest/download/rudder-cli_Darwin_arm64.tar.gz | tar -xz rudder-cli
+curl -L https://github.com/rudderlabs/rudder-iac/releases/latest/download/<artifact>.tar.gz | tar -xz rudder-cli
 sudo mv rudder-cli /usr/local/bin/
 ```
 
-### macOS (Intel)
-
-```sh
-curl -L https://github.com/rudderlabs/rudder-iac/releases/latest/download/rudder-cli_Darwin_x86_64.tar.gz | tar -xz rudder-cli
-sudo mv rudder-cli /usr/local/bin/
-```
-
-### Linux
-
-```sh
-curl -L https://github.com/rudderlabs/rudder-iac/releases/latest/download/rudder-cli_Linux_x86_64.tar.gz | tar -xz rudder-cli
-sudo mv rudder-cli /usr/local/bin/
-```
+Common artifacts include:
+- `rudder-cli_Darwin_arm64`
+- `rudder-cli_Darwin_x86_64`
+- `rudder-cli_Linux_x86_64`
 
 ## Docker
 
-Run the CLI:
+Run the CLI directly:
 
 ```sh
 docker run --rm rudderlabs/rudder-cli
 ```
 
-Use local config (`~/.rudder`):
+Run against a local catalog:
 
 ```sh
-docker run --rm -v ~/.rudder:/.rudder rudderlabs/rudder-cli
+docker run --rm \
+  -v ~/.rudder:/.rudder \
+  -v ~/my-catalog:/catalog \
+  rudderlabs/rudder-cli tp apply --dry-run -l /catalog
 ```
 
-Run commands with a local catalog:
+Use an access token from env if needed:
 
 ```sh
-docker run --rm -v ~/.rudder:/.rudder -v ~/my-catalog:/catalog rudderlabs/rudder-cli tp apply --dry-run -l /catalog
+docker run --rm \
+  -v ~/my-catalog:/catalog \
+  -e RUDDERSTACK_ACCESS_TOKEN=your-access-token \
+  rudderlabs/rudder-cli tp apply --dry-run -l /catalog
 ```
 
-Use token from environment:
-
-```sh
-docker run --rm -v ~/my-catalog:/catalog -e RUDDERSTACK_ACCESS_TOKEN=your-access-token rudderlabs/rudder-cli tp apply --dry-run -l /catalog
-```
-
-## Build from Source
+## Build from source
 
 ```sh
 git clone https://github.com/rudderlabs/rudder-iac.git
@@ -64,7 +55,7 @@ make build
 sudo mv bin/rudder-cli /usr/local/bin/
 ```
 
-Build Docker image locally:
+Build the Docker image locally:
 
 ```sh
 make docker-build


### PR DESCRIPTION
## 🔗 Ticket

Resolves [DEX-XXX](link-to-ticket)

---

## Summary

Tightened the top-level README to be more concise while keeping the same key user paths: install from release artifacts, run via Docker, and build from source.

---

## Changes

- simplified status and section copy for readability
- kept install flow but reduced verbosity by using a single artifact placeholder plus common artifact names
- streamlined Docker usage text while retaining direct, local-catalog, and token-based examples

---

## Testing

How was this tested?

- Manual review of README markdown and rendered structure
- Dev-container validation not run (no repo dev-container setup found for this documentation-only root change)

---

## Risk / Impact

Low
Notes (if any): Documentation-only change; main risk is omitting useful context while shortening text.

---

## Checklist

- [x] Ticket linked
- [ ] Tests added/updated
- [x] No breaking changes (or documented)