### PR TITLE
docs: make top-level README more concise

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,41 +2,27 @@
 
 ## Table of Contents
 
-- [⚠️ Work in Progress](#️-work-in-progress)
 - [Installation](#installation)
-  - [MacOS](#macos)
-    - [Apple Silicon](#apple-silicon)
-    - [Intel-based](#intel-based)
-  - [Linux](#linux)
-  - [Docker](#docker)
-  - [Build from Source](#build-from-source)
-
-## ⚠️ Work in Progress
-
-> **Warning**
->
-> Please note that this tool is currently a work in progress. We are actively developing and improving it, and as such, there may be frequent changes and updates. We do not guarantee backwards compatibility at this stage.
 
 ## Installation
 
-### MacOS
+### Release Binary
 
-#### Apple Silicon
+Download the latest release for your platform from the [releases page](https://github.com/rudderlabs/rudder-iac/releases/latest), or run:
 
+**macOS (Apple Silicon)**
 ```sh
 curl -L https://github.com/rudderlabs/rudder-iac/releases/latest/download/rudder-cli_Darwin_arm64.tar.gz | tar -xz rudder-cli
 sudo mv rudder-cli /usr/local/bin/
 ```
 
-#### Intel-based
-
+**macOS (Intel)**
 ```sh
 curl -L https://github.com/rudderlabs/rudder-iac/releases/latest/download/rudder-cli_Darwin_x86_64.tar.gz | tar -xz rudder-cli
 sudo mv rudder-cli /usr/local/bin/
 ```
 
-### Linux
-
+**Linux**
 ```sh
 curl -L https://github.com/rudderlabs/rudder-iac/releases/latest/download/rudder-cli_Linux_x86_64.tar.gz | tar -xz rudder-cli
 sudo mv rudder-cli /usr/local/bin/
@@ -44,33 +30,19 @@ sudo mv rudder-cli /usr/local/bin/
 
 ### Docker
 
-You can run the CLI directly using Docker:
-
+Run the CLI directly:
 ```sh
 docker run rudderlabs/rudder-cli
 ```
 
-If you need to persist your configuration, or provide an external configuration file, you can mount your local config directory into the container. Assuming your config directory is located at `~/.rudder`, you can run the following command:
-
+Mount your local config directory:
 ```sh
 docker run -v ~/.rudder:/.rudder rudderlabs/rudder-cli
 ```
 
-To run commands with local catalog files, mount your files directory and use the `-l` flag. For example:
-
-```sh
-docker run -v ~/.rudder:/.rudder -v ~/my-catalog:/catalog rudderlabs/rudder-cli tp apply --dry-run -l /catalog
-```
-
-This will use the access token from your local configuration file, and the catalog files from the `/catalog` directory. Alternatively, you can use the `RUDDERSTACK_ACCESS_TOKEN` environment variable to provide the access token:
-
-```sh
-docker run -v ~/my-catalog:/catalog -e RUDDERSTACK_ACCESS_TOKEN=your-access-token rudderlabs/rudder-cli tp apply --dry-run -l /catalog
-```
-
 ### Build from Source
 
-To build the `rudder-cli` from source, you need to have Go installed. Then, run the following commands:
+Requires [Go](https://go.dev/).
 
 ```sh
 git clone https://github.com/rudderlabs/rudder-iac.git
@@ -79,8 +51,7 @@ make build
 sudo mv bin/rudder-cli /usr/local/bin/
 ```
 
-To build the Docker image locally:
-
+Build the Docker image locally:
 ```sh
 make docker-build
 ```


### PR DESCRIPTION
## 🔗 Ticket

Not applicable

---

## Summary

Streamlined the top-level README.md to reduce verbosity while preserving all essential installation and usage information.

---

## Changes

- Removed the stale 'Work in Progress' warning
- Simplified the Table of Contents
- Consolidated per-architecture installation instructions (macOS Apple Silicon, Intel, Linux) under a single 'Release Binary' subsection
- Condensed Docker examples to the two most common commands
- Streamlined 'Build from Source' wording

---

## Testing

- Verified markdown rendering and command accuracy manually
- Confirmed all curl, docker, and make commands remain copy-paste correct
- `make lint` targets Go only and is not applicable for this markdown-only change

---

## Risk / Impact

Low
Notes: Documentation-only change. No functional or breaking changes.

---

## Checklist

- [x] Ticket linked (N/A)
- [x] Tests added/updated (N/A)
- [x] No breaking changes