### PR TITLE
feat(retl): add Go API client for RETL connections (PRO-5604)

### DIFF
--- a/api/client/retl/connection_types.go
+++ b/api/client/retl/connection_types.go
@@ -1,0 +1,159 @@
+package retl
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/rudderlabs/rudder-iac/api/client"
+)
+
+// SyncBehaviour is how records are synced to the destination.
+type SyncBehaviour string
+
+const (
+	SyncBehaviourUpsert SyncBehaviour = "upsert"
+	SyncBehaviourMirror SyncBehaviour = "mirror"
+	SyncBehaviourFull   SyncBehaviour = "full"
+)
+
+// ScheduleType is the schedule kind for a RETL connection.
+type ScheduleType string
+
+const (
+	ScheduleTypeBasic  ScheduleType = "basic"
+	ScheduleTypeManual ScheduleType = "manual"
+	ScheduleTypeCron   ScheduleType = "cron"
+)
+
+// EventType is the CDP event type for JSON Mapper flows.
+type EventType string
+
+const (
+	EventTypeIdentify EventType = "identify"
+	EventTypeTrack    EventType = "track"
+)
+
+// Schedule defines when a RETL connection syncs.
+type Schedule struct {
+	Type         ScheduleType `json:"type"`
+	EveryMinutes *int         `json:"everyMinutes,omitempty"`
+}
+
+// Event represents the CDP event configuration for a JSON Mapper flow.
+// Name and NameColumn are mutually exclusive.
+type Event struct {
+	Type       EventType `json:"type"`
+	Name       string    `json:"name,omitempty"`
+	NameColumn string    `json:"nameColumn,omitempty"`
+}
+
+// Mapping maps a source column to a destination field or identifier.
+type Mapping struct {
+	From string `json:"from"`
+	To   string `json:"to"`
+}
+
+// Constant represents a user-defined constant added to every synced record.
+// Only applicable for JSON Mapper flows.
+type Constant struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+// SyncLogsConfig controls retention of sync log snapshots.
+type SyncLogsConfig struct {
+	Enabled            *bool `json:"enabled,omitempty"`
+	LogRetentionInDays *int  `json:"logRetentionInDays,omitempty"`
+	SnapshotsToRetain  *int  `json:"snapshotsToRetain,omitempty"`
+}
+
+// FailedKeysConfig controls retry behaviour for failed keys.
+type FailedKeysConfig struct {
+	EnableFailedKeysRetry *bool `json:"enableFailedKeysRetry,omitempty"`
+}
+
+// SyncSettings bundles operational settings for a connection. When omitted on
+// create, the backend applies defaults.
+type SyncSettings struct {
+	SyncLogsConfig   *SyncLogsConfig   `json:"syncLogsConfig,omitempty"`
+	FailedKeysConfig *FailedKeysConfig `json:"failedKeysConfig,omitempty"`
+}
+
+// RETLConnection is the full connection resource returned by the API.
+// DestinationConfig is json.RawMessage so callers can decode per destination.
+type RETLConnection struct {
+	ID                string          `json:"id"`
+	SourceID          string          `json:"sourceId"`
+	DestinationID     string          `json:"destinationId"`
+	Enabled           bool            `json:"enabled"`
+	ExternalID        string          `json:"externalId,omitempty"`
+	Schedule          Schedule        `json:"schedule"`
+	SyncSettings      *SyncSettings   `json:"syncSettings,omitempty"`
+	SyncBehaviour     SyncBehaviour   `json:"syncBehaviour"`
+	Identifiers       []Mapping       `json:"identifiers"`
+	Mappings          []Mapping       `json:"mappings,omitempty"`
+	Event             *Event          `json:"event,omitempty"`
+	Constants         []Constant      `json:"constants,omitempty"`
+	CursorColumn      string          `json:"cursorColumn,omitempty"`
+	Object            string          `json:"object,omitempty"`
+	DestinationConfig json.RawMessage `json:"destinationConfig,omitempty"`
+	CreatedAt         *time.Time      `json:"createdAt,omitempty"`
+	UpdatedAt         *time.Time      `json:"updatedAt,omitempty"`
+}
+
+// CreateRETLConnectionRequest is the request body for POST /v2/retl-connections.
+// Flow detection (JSON Mapper / Object mapping / Destination-specific) happens
+// server-side based on the destination definition — callers do not specify a flow.
+type CreateRETLConnectionRequest struct {
+	SourceID          string          `json:"sourceId"`
+	DestinationID     string          `json:"destinationId"`
+	Enabled           *bool           `json:"enabled,omitempty"`
+	ExternalID        string          `json:"externalId,omitempty"`
+	Schedule          Schedule        `json:"schedule"`
+	SyncSettings      *SyncSettings   `json:"syncSettings,omitempty"`
+	SyncBehaviour     SyncBehaviour   `json:"syncBehaviour"`
+	Identifiers       []Mapping       `json:"identifiers"`
+	Mappings          []Mapping       `json:"mappings,omitempty"`
+	Event             *Event          `json:"event,omitempty"`
+	Constants         []Constant      `json:"constants,omitempty"`
+	CursorColumn      string          `json:"cursorColumn,omitempty"`
+	Object            string          `json:"object,omitempty"`
+	DestinationConfig json.RawMessage `json:"destinationConfig,omitempty"`
+}
+
+// UpdateRETLConnectionRequest is the request body for PUT /v2/retl-connections/:id.
+// Only mutable fields are accepted; the API rejects immutable fields at the
+// validation layer. Per-flow mutability of Identifiers/Constants/Mappings is
+// enforced server-side based on the detected flow.
+type UpdateRETLConnectionRequest struct {
+	Enabled      *bool         `json:"enabled,omitempty"`
+	Schedule     Schedule      `json:"schedule"`
+	SyncSettings *SyncSettings `json:"syncSettings,omitempty"`
+	Mappings     []Mapping     `json:"mappings,omitempty"`
+	Constants    []Constant    `json:"constants,omitempty"`
+	Identifiers  []Mapping     `json:"identifiers,omitempty"`
+}
+
+// ListRETLConnectionsRequest is the request for listing connections.
+// Deviates from the ticket's positional signature to surface pagination —
+// the API returns a paginated page, and callers need Page/PageSize to iterate.
+type ListRETLConnectionsRequest struct {
+	SourceID      string
+	DestinationID string
+	HasExternalID *bool
+	Page          int
+	PageSize      int
+}
+
+// SetRETLConnectionExternalIDRequest is the request for setting a connection's
+// external ID.
+type SetRETLConnectionExternalIDRequest struct {
+	ID         string
+	ExternalID string
+}
+
+// RETLConnectionsPage is the paginated response from GET /v2/retl-connections.
+type RETLConnectionsPage struct {
+	Data   []RETLConnection `json:"data"`
+	Paging client.Paging    `json:"paging"`
+}

--- a/api/client/retl/connection_types.go
+++ b/api/client/retl/connection_types.go
@@ -129,9 +129,12 @@ type UpdateRETLConnectionRequest struct {
 	Enabled      *bool         `json:"enabled,omitempty"`
 	Schedule     Schedule      `json:"schedule"`
 	SyncSettings *SyncSettings `json:"syncSettings,omitempty"`
-	Mappings     []Mapping     `json:"mappings,omitempty"`
-	Constants    []Constant    `json:"constants,omitempty"`
-	Identifiers  []Mapping     `json:"identifiers,omitempty"`
+	// Pointer-to-slice so callers can distinguish "not provided" (nil) from
+	// "explicitly empty" (pointer to empty slice) — needed to clear existing
+	// values via update.
+	Mappings    *[]Mapping  `json:"mappings,omitempty"`
+	Constants   *[]Constant `json:"constants,omitempty"`
+	Identifiers []Mapping   `json:"identifiers,omitempty"`
 }
 
 // ListRETLConnectionsRequest is the request for listing connections.

--- a/api/client/retl/connection_types.go
+++ b/api/client/retl/connection_types.go
@@ -148,8 +148,8 @@ type ListRETLConnectionsRequest struct {
 // SetRETLConnectionExternalIDRequest is the request for setting a connection's
 // external ID.
 type SetRETLConnectionExternalIDRequest struct {
-	ID         string
-	ExternalID string
+	ID         string `json:"id,omitempty"`
+	ExternalID string `json:"externalId"`
 }
 
 // RETLConnectionsPage is the paginated response from GET /v2/retl-connections.

--- a/api/client/retl/connections.go
+++ b/api/client/retl/connections.go
@@ -13,9 +13,12 @@ const retlConnectionsBasePath = "/v2/retl-connections"
 
 // CreateConnection creates a new RETL connection.
 func (r *RudderRETLStore) CreateConnection(ctx context.Context, req *CreateRETLConnectionRequest) (*RETLConnection, error) {
+	if req == nil {
+		return nil, fmt.Errorf("request cannot be nil")
+	}
 	// Schedule is required server-side; guard here so callers get a clear
 	// error instead of a 400 complaining about an empty enum value.
-	if req == nil || req.Schedule.Type == "" {
+	if req.Schedule.Type == "" {
 		return nil, fmt.Errorf("schedule.type is required")
 	}
 
@@ -42,9 +45,12 @@ func (r *RudderRETLStore) UpdateConnection(ctx context.Context, id string, req *
 	if id == "" {
 		return nil, fmt.Errorf("connection ID cannot be empty")
 	}
+	if req == nil {
+		return nil, fmt.Errorf("request cannot be nil")
+	}
 	// Schedule is required server-side; guard here so callers get a clear
 	// error instead of a 400 complaining about an empty enum value.
-	if req == nil || req.Schedule.Type == "" {
+	if req.Schedule.Type == "" {
 		return nil, fmt.Errorf("schedule.type is required")
 	}
 

--- a/api/client/retl/connections.go
+++ b/api/client/retl/connections.go
@@ -1,0 +1,150 @@
+package retl
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+)
+
+const retlConnectionsBasePath = "/v2/retl-connections"
+
+// CreateConnection creates a new RETL connection.
+func (r *RudderRETLStore) CreateConnection(ctx context.Context, req *CreateRETLConnectionRequest) (*RETLConnection, error) {
+	data, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("marshalling connection: %w", err)
+	}
+
+	resp, err := r.client.Do(ctx, "POST", retlConnectionsBasePath, bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("creating RETL connection: %w", err)
+	}
+
+	var result RETLConnection
+	if err := json.Unmarshal(resp, &result); err != nil {
+		return nil, fmt.Errorf("unmarshalling response: %w", err)
+	}
+
+	return &result, nil
+}
+
+// UpdateConnection updates mutable fields of a RETL connection.
+func (r *RudderRETLStore) UpdateConnection(ctx context.Context, id string, req *UpdateRETLConnectionRequest) (*RETLConnection, error) {
+	if id == "" {
+		return nil, fmt.Errorf("connection ID cannot be empty")
+	}
+
+	data, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("marshalling connection: %w", err)
+	}
+
+	path := fmt.Sprintf("%s/%s", retlConnectionsBasePath, id)
+	resp, err := r.client.Do(ctx, "PUT", path, bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("updating RETL connection: %w", err)
+	}
+
+	var result RETLConnection
+	if err := json.Unmarshal(resp, &result); err != nil {
+		return nil, fmt.Errorf("unmarshalling response: %w", err)
+	}
+
+	return &result, nil
+}
+
+// DeleteConnection soft-deletes a RETL connection.
+func (r *RudderRETLStore) DeleteConnection(ctx context.Context, id string) error {
+	if id == "" {
+		return fmt.Errorf("connection ID cannot be empty")
+	}
+
+	path := fmt.Sprintf("%s/%s", retlConnectionsBasePath, id)
+	if _, err := r.client.Do(ctx, "DELETE", path, nil); err != nil {
+		return fmt.Errorf("deleting RETL connection: %w", err)
+	}
+
+	return nil
+}
+
+// GetConnection retrieves a RETL connection by ID.
+func (r *RudderRETLStore) GetConnection(ctx context.Context, id string) (*RETLConnection, error) {
+	if id == "" {
+		return nil, fmt.Errorf("connection ID cannot be empty")
+	}
+
+	path := fmt.Sprintf("%s/%s", retlConnectionsBasePath, id)
+	resp, err := r.client.Do(ctx, "GET", path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("getting RETL connection: %w", err)
+	}
+
+	var result RETLConnection
+	if err := json.Unmarshal(resp, &result); err != nil {
+		return nil, fmt.Errorf("unmarshalling response: %w", err)
+	}
+
+	return &result, nil
+}
+
+// ListConnections returns a paginated list of RETL connections matching the
+// provided filters.
+func (r *RudderRETLStore) ListConnections(ctx context.Context, req *ListRETLConnectionsRequest) (*RETLConnectionsPage, error) {
+	path := retlConnectionsBasePath
+	query := url.Values{}
+	if req != nil {
+		if req.SourceID != "" {
+			query.Add("sourceId", req.SourceID)
+		}
+		if req.DestinationID != "" {
+			query.Add("destinationId", req.DestinationID)
+		}
+		if req.HasExternalID != nil {
+			query.Add("hasExternalId", strconv.FormatBool(*req.HasExternalID))
+		}
+		if req.Page > 0 {
+			query.Add("page", strconv.Itoa(req.Page))
+		}
+		if req.PageSize > 0 {
+			query.Add("pageSize", strconv.Itoa(req.PageSize))
+		}
+	}
+
+	if len(query) > 0 {
+		path = fmt.Sprintf("%s?%s", path, query.Encode())
+	}
+
+	resp, err := r.client.Do(ctx, "GET", path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("listing RETL connections: %w", err)
+	}
+
+	var result RETLConnectionsPage
+	if err := json.Unmarshal(resp, &result); err != nil {
+		return nil, fmt.Errorf("unmarshalling response: %w", err)
+	}
+
+	return &result, nil
+}
+
+// SetConnectionExternalID sets the external ID for a RETL connection.
+func (r *RudderRETLStore) SetConnectionExternalID(ctx context.Context, req *SetRETLConnectionExternalIDRequest) error {
+	if req == nil || req.ID == "" {
+		return fmt.Errorf("connection ID cannot be empty")
+	}
+
+	path := fmt.Sprintf("%s/%s/external-id", retlConnectionsBasePath, req.ID)
+	data, err := json.Marshal(map[string]string{"externalId": req.ExternalID})
+	if err != nil {
+		return fmt.Errorf("marshalling external ID: %w", err)
+	}
+
+	if _, err := r.client.Do(ctx, "PUT", path, bytes.NewReader(data)); err != nil {
+		return fmt.Errorf("setting external ID: %w", err)
+	}
+
+	return nil
+}

--- a/api/client/retl/connections.go
+++ b/api/client/retl/connections.go
@@ -147,9 +147,12 @@ func (r *RudderRETLStore) ListConnections(ctx context.Context, req *ListRETLConn
 	return &result, nil
 }
 
-// SetConnectionExternalID sets the external ID for a RETL connection.
-func (r *RudderRETLStore) SetConnectionExternalID(ctx context.Context, req *SetRETLConnectionExternalIDRequest) error {
-	if req == nil || req.ID == "" {
+// SetConnectionExternalId sets the external ID for a RETL connection.
+func (r *RudderRETLStore) SetConnectionExternalId(ctx context.Context, req *SetRETLConnectionExternalIDRequest) error {
+	if req == nil {
+		return fmt.Errorf("request cannot be nil")
+	}
+	if req.ID == "" {
 		return fmt.Errorf("connection ID cannot be empty")
 	}
 

--- a/api/client/retl/connections.go
+++ b/api/client/retl/connections.go
@@ -13,6 +13,12 @@ const retlConnectionsBasePath = "/v2/retl-connections"
 
 // CreateConnection creates a new RETL connection.
 func (r *RudderRETLStore) CreateConnection(ctx context.Context, req *CreateRETLConnectionRequest) (*RETLConnection, error) {
+	// Schedule is required server-side; guard here so callers get a clear
+	// error instead of a 400 complaining about an empty enum value.
+	if req == nil || req.Schedule.Type == "" {
+		return nil, fmt.Errorf("schedule.type is required")
+	}
+
 	data, err := json.Marshal(req)
 	if err != nil {
 		return nil, fmt.Errorf("marshalling connection: %w", err)
@@ -35,6 +41,11 @@ func (r *RudderRETLStore) CreateConnection(ctx context.Context, req *CreateRETLC
 func (r *RudderRETLStore) UpdateConnection(ctx context.Context, id string, req *UpdateRETLConnectionRequest) (*RETLConnection, error) {
 	if id == "" {
 		return nil, fmt.Errorf("connection ID cannot be empty")
+	}
+	// Schedule is required server-side; guard here so callers get a clear
+	// error instead of a 400 complaining about an empty enum value.
+	if req == nil || req.Schedule.Type == "" {
+		return nil, fmt.Errorf("schedule.type is required")
 	}
 
 	data, err := json.Marshal(req)

--- a/api/client/retl/connections_test.go
+++ b/api/client/retl/connections_test.go
@@ -339,6 +339,20 @@ func TestCreateConnection_RequiresSchedule(t *testing.T) {
 	assert.Contains(t, err.Error(), "schedule.type is required")
 }
 
+func TestConnection_NilRequestErrors(t *testing.T) {
+	c, err := client.New("test-token")
+	require.NoError(t, err)
+	retlClient := retl.NewRudderRETLStore(c)
+
+	_, err = retlClient.CreateConnection(context.Background(), nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "request cannot be nil")
+
+	_, err = retlClient.UpdateConnection(context.Background(), "conn-1", nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "request cannot be nil")
+}
+
 func TestCreateConnection_APIError(t *testing.T) {
 	httpClient := testutils.NewMockHTTPClient(t, testutils.Call{
 		Validate: func(req *http.Request) bool {

--- a/api/client/retl/connections_test.go
+++ b/api/client/retl/connections_test.go
@@ -115,7 +115,7 @@ func TestUpdateConnection(t *testing.T) {
 
 	req := &retl.UpdateRETLConnectionRequest{
 		Schedule: retl.Schedule{Type: retl.ScheduleTypeBasic, EveryMinutes: intPtr(120)},
-		Mappings: []retl.Mapping{{From: "name", To: "first_name"}},
+		Mappings: &[]retl.Mapping{{From: "name", To: "first_name"}},
 	}
 
 	updated, err := retlClient.UpdateConnection(context.Background(), "conn-1", req)
@@ -125,6 +125,35 @@ func TestUpdateConnection(t *testing.T) {
 	require.NotNil(t, updated.Schedule.EveryMinutes)
 	assert.Equal(t, 120, *updated.Schedule.EveryMinutes)
 
+	httpClient.AssertNumberOfCalls()
+}
+
+func TestUpdateConnection_ExplicitEmptyMappingsAndConstants(t *testing.T) {
+	// Pointer-to-slice fields let callers send an empty array on the wire to
+	// clear existing values, distinct from omitting the field entirely.
+	httpClient := testutils.NewMockHTTPClient(t, testutils.Call{
+		Validate: func(req *http.Request) bool {
+			expected := `{
+				"schedule": {"type": "manual"},
+				"mappings": [],
+				"constants": []
+			}`
+			return assertCall(t, req, "PUT", "https://api.rudderstack.com/v2/retl-connections/conn-1", expected)
+		},
+		ResponseStatus: 200,
+		ResponseBody:   `{"id":"conn-1","sourceId":"s","destinationId":"d","enabled":true,"schedule":{"type":"manual"},"syncBehaviour":"upsert","identifiers":[]}`,
+	})
+
+	c, err := client.New("test-token", client.WithHTTPClient(httpClient))
+	require.NoError(t, err)
+	retlClient := retl.NewRudderRETLStore(c)
+
+	_, err = retlClient.UpdateConnection(context.Background(), "conn-1", &retl.UpdateRETLConnectionRequest{
+		Schedule:  retl.Schedule{Type: retl.ScheduleTypeManual},
+		Mappings:  &[]retl.Mapping{},
+		Constants: &[]retl.Constant{},
+	})
+	require.NoError(t, err)
 	httpClient.AssertNumberOfCalls()
 }
 

--- a/api/client/retl/connections_test.go
+++ b/api/client/retl/connections_test.go
@@ -1,0 +1,402 @@
+package retl_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/rudderlabs/rudder-iac/api/client"
+	"github.com/rudderlabs/rudder-iac/api/client/retl"
+	"github.com/rudderlabs/rudder-iac/api/internal/testutils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func boolPtr(b bool) *bool { return &b }
+
+func intPtr(i int) *int { return &i }
+
+func TestCreateConnection(t *testing.T) {
+	httpClient := testutils.NewMockHTTPClient(t, testutils.Call{
+		Validate: func(req *http.Request) bool {
+			expected := `{
+				"sourceId": "retl-src-123",
+				"destinationId": "dest-456",
+				"enabled": true,
+				"schedule": {"type": "basic", "everyMinutes": 60},
+				"syncBehaviour": "upsert",
+				"identifiers": [{"from": "email", "to": "user_id"}],
+				"mappings": [{"from": "name", "to": "first_name"}],
+				"event": {"type": "identify"}
+			}`
+			return testutils.ValidateRequest(t, req, "POST", "https://api.rudderstack.com/v2/retl-connections", expected)
+		},
+		ResponseStatus: 200,
+		ResponseBody: `{
+			"id": "conn-1",
+			"sourceId": "retl-src-123",
+			"destinationId": "dest-456",
+			"enabled": true,
+			"schedule": {"type": "basic", "everyMinutes": 60},
+			"syncBehaviour": "upsert",
+			"identifiers": [{"from": "email", "to": "user_id"}],
+			"mappings": [{"from": "name", "to": "first_name"}],
+			"event": {"type": "identify"},
+			"createdAt": "2026-04-20T12:00:00Z",
+			"updatedAt": "2026-04-20T12:00:00Z"
+		}`,
+	})
+
+	c, err := client.New("test-token", client.WithHTTPClient(httpClient))
+	require.NoError(t, err)
+	retlClient := retl.NewRudderRETLStore(c)
+
+	req := &retl.CreateRETLConnectionRequest{
+		SourceID:      "retl-src-123",
+		DestinationID: "dest-456",
+		Enabled:       boolPtr(true),
+		Schedule:      retl.Schedule{Type: retl.ScheduleTypeBasic, EveryMinutes: intPtr(60)},
+		SyncBehaviour: retl.SyncBehaviourUpsert,
+		Identifiers:   []retl.Mapping{{From: "email", To: "user_id"}},
+		Mappings:      []retl.Mapping{{From: "name", To: "first_name"}},
+		Event:         &retl.Event{Type: retl.EventTypeIdentify},
+	}
+
+	created, err := retlClient.CreateConnection(context.Background(), req)
+	require.NoError(t, err)
+
+	assert.Equal(t, "conn-1", created.ID)
+	assert.Equal(t, "retl-src-123", created.SourceID)
+	assert.Equal(t, "dest-456", created.DestinationID)
+	assert.True(t, created.Enabled)
+	assert.Equal(t, retl.SyncBehaviourUpsert, created.SyncBehaviour)
+	assert.Equal(t, retl.ScheduleTypeBasic, created.Schedule.Type)
+	require.NotNil(t, created.Schedule.EveryMinutes)
+	assert.Equal(t, 60, *created.Schedule.EveryMinutes)
+	assert.Equal(t, []retl.Mapping{{From: "email", To: "user_id"}}, created.Identifiers)
+
+	httpClient.AssertNumberOfCalls()
+}
+
+func TestUpdateConnection(t *testing.T) {
+	httpClient := testutils.NewMockHTTPClient(t, testutils.Call{
+		Validate: func(req *http.Request) bool {
+			expected := `{
+				"schedule": {"type": "basic", "everyMinutes": 120},
+				"mappings": [{"from": "name", "to": "first_name"}]
+			}`
+			return testutils.ValidateRequest(t, req, "PUT", "https://api.rudderstack.com/v2/retl-connections/conn-1", expected)
+		},
+		ResponseStatus: 200,
+		ResponseBody: `{
+			"id": "conn-1",
+			"sourceId": "retl-src-123",
+			"destinationId": "dest-456",
+			"enabled": true,
+			"schedule": {"type": "basic", "everyMinutes": 120},
+			"syncBehaviour": "upsert",
+			"identifiers": [{"from": "email", "to": "user_id"}],
+			"mappings": [{"from": "name", "to": "first_name"}]
+		}`,
+	})
+
+	c, err := client.New("test-token", client.WithHTTPClient(httpClient))
+	require.NoError(t, err)
+	retlClient := retl.NewRudderRETLStore(c)
+
+	req := &retl.UpdateRETLConnectionRequest{
+		Schedule: retl.Schedule{Type: retl.ScheduleTypeBasic, EveryMinutes: intPtr(120)},
+		Mappings: []retl.Mapping{{From: "name", To: "first_name"}},
+	}
+
+	updated, err := retlClient.UpdateConnection(context.Background(), "conn-1", req)
+	require.NoError(t, err)
+
+	assert.Equal(t, "conn-1", updated.ID)
+	require.NotNil(t, updated.Schedule.EveryMinutes)
+	assert.Equal(t, 120, *updated.Schedule.EveryMinutes)
+
+	httpClient.AssertNumberOfCalls()
+}
+
+func TestGetConnection(t *testing.T) {
+	httpClient := testutils.NewMockHTTPClient(t, testutils.Call{
+		Validate: func(req *http.Request) bool {
+			return testutils.ValidateRequest(t, req, "GET", "https://api.rudderstack.com/v2/retl-connections/conn-1", "")
+		},
+		ResponseStatus: 200,
+		ResponseBody: `{
+			"id": "conn-1",
+			"sourceId": "retl-src-123",
+			"destinationId": "dest-456",
+			"enabled": false,
+			"schedule": {"type": "manual"},
+			"syncBehaviour": "upsert",
+			"identifiers": [{"from": "email", "to": "user_id"}]
+		}`,
+	})
+
+	c, err := client.New("test-token", client.WithHTTPClient(httpClient))
+	require.NoError(t, err)
+	retlClient := retl.NewRudderRETLStore(c)
+
+	got, err := retlClient.GetConnection(context.Background(), "conn-1")
+	require.NoError(t, err)
+
+	assert.Equal(t, "conn-1", got.ID)
+	assert.False(t, got.Enabled)
+	assert.Equal(t, retl.ScheduleTypeManual, got.Schedule.Type)
+	assert.Nil(t, got.Schedule.EveryMinutes)
+
+	httpClient.AssertNumberOfCalls()
+}
+
+func TestDeleteConnection(t *testing.T) {
+	httpClient := testutils.NewMockHTTPClient(t, testutils.Call{
+		Validate: func(req *http.Request) bool {
+			return testutils.ValidateRequest(t, req, "DELETE", "https://api.rudderstack.com/v2/retl-connections/conn-1", "")
+		},
+		ResponseStatus: 204,
+		ResponseBody:   "",
+	})
+
+	c, err := client.New("test-token", client.WithHTTPClient(httpClient))
+	require.NoError(t, err)
+	retlClient := retl.NewRudderRETLStore(c)
+
+	require.NoError(t, retlClient.DeleteConnection(context.Background(), "conn-1"))
+	httpClient.AssertNumberOfCalls()
+}
+
+func TestListConnections_NoFilters(t *testing.T) {
+	httpClient := testutils.NewMockHTTPClient(t, testutils.Call{
+		Validate: func(req *http.Request) bool {
+			return testutils.ValidateRequest(t, req, "GET", "https://api.rudderstack.com/v2/retl-connections", "")
+		},
+		ResponseStatus: 200,
+		ResponseBody: `{
+			"data": [],
+			"paging": {"total": 0}
+		}`,
+	})
+
+	c, err := client.New("test-token", client.WithHTTPClient(httpClient))
+	require.NoError(t, err)
+	retlClient := retl.NewRudderRETLStore(c)
+
+	page, err := retlClient.ListConnections(context.Background(), &retl.ListRETLConnectionsRequest{})
+	require.NoError(t, err)
+	assert.Empty(t, page.Data)
+	assert.Equal(t, 0, page.Paging.Total)
+
+	httpClient.AssertNumberOfCalls()
+}
+
+func TestListConnections_WithFiltersAndPaging(t *testing.T) {
+	httpClient := testutils.NewMockHTTPClient(t, testutils.Call{
+		Validate: func(req *http.Request) bool {
+			query := req.URL.Query()
+			if query.Get("sourceId") != "retl-src-123" {
+				return false
+			}
+			if query.Get("destinationId") != "dest-456" {
+				return false
+			}
+			if query.Get("hasExternalId") != "true" {
+				return false
+			}
+			if query.Get("page") != "2" {
+				return false
+			}
+			if query.Get("pageSize") != "50" {
+				return false
+			}
+			if req.URL.Path != "/v2/retl-connections" {
+				return false
+			}
+			return req.Method == http.MethodGet
+		},
+		ResponseStatus: 200,
+		ResponseBody: `{
+			"data": [
+				{
+					"id": "conn-1",
+					"sourceId": "retl-src-123",
+					"destinationId": "dest-456",
+					"enabled": true,
+					"externalId": "ext-1",
+					"schedule": {"type": "basic", "everyMinutes": 60},
+					"syncBehaviour": "upsert",
+					"identifiers": [{"from": "email", "to": "user_id"}]
+				}
+			],
+			"paging": {
+				"total": 42,
+				"next": "/v2/retl-connections?page=3&pageSize=50"
+			}
+		}`,
+	})
+
+	c, err := client.New("test-token", client.WithHTTPClient(httpClient))
+	require.NoError(t, err)
+	retlClient := retl.NewRudderRETLStore(c)
+
+	page, err := retlClient.ListConnections(context.Background(), &retl.ListRETLConnectionsRequest{
+		SourceID:      "retl-src-123",
+		DestinationID: "dest-456",
+		HasExternalID: boolPtr(true),
+		Page:          2,
+		PageSize:      50,
+	})
+	require.NoError(t, err)
+
+	assert.Len(t, page.Data, 1)
+	assert.Equal(t, "conn-1", page.Data[0].ID)
+	assert.Equal(t, "ext-1", page.Data[0].ExternalID)
+	assert.Equal(t, 42, page.Paging.Total)
+	assert.Equal(t, "/v2/retl-connections?page=3&pageSize=50", page.Paging.Next)
+
+	httpClient.AssertNumberOfCalls()
+}
+
+func TestSetConnectionExternalID(t *testing.T) {
+	httpClient := testutils.NewMockHTTPClient(t, testutils.Call{
+		Validate: func(req *http.Request) bool {
+			expected := `{"externalId": "ext-123"}`
+			return testutils.ValidateRequest(t, req, "PUT", "https://api.rudderstack.com/v2/retl-connections/conn-1/external-id", expected)
+		},
+		ResponseStatus: 200,
+		ResponseBody:   `{"id": "conn-1", "externalId": "ext-123"}`,
+	})
+
+	c, err := client.New("test-token", client.WithHTTPClient(httpClient))
+	require.NoError(t, err)
+	retlClient := retl.NewRudderRETLStore(c)
+
+	err = retlClient.SetConnectionExternalID(context.Background(), &retl.SetRETLConnectionExternalIDRequest{
+		ID:         "conn-1",
+		ExternalID: "ext-123",
+	})
+	require.NoError(t, err)
+	httpClient.AssertNumberOfCalls()
+}
+
+func TestConnection_EmptyIDErrors(t *testing.T) {
+	c, err := client.New("test-token")
+	require.NoError(t, err)
+	retlClient := retl.NewRudderRETLStore(c)
+
+	_, err = retlClient.UpdateConnection(context.Background(), "", &retl.UpdateRETLConnectionRequest{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "connection ID cannot be empty")
+
+	err = retlClient.DeleteConnection(context.Background(), "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "connection ID cannot be empty")
+
+	_, err = retlClient.GetConnection(context.Background(), "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "connection ID cannot be empty")
+
+	err = retlClient.SetConnectionExternalID(context.Background(), &retl.SetRETLConnectionExternalIDRequest{ID: "", ExternalID: "x"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "connection ID cannot be empty")
+}
+
+func TestCreateConnection_APIError(t *testing.T) {
+	httpClient := testutils.NewMockHTTPClient(t, testutils.Call{
+		Validate: func(req *http.Request) bool {
+			return testutils.ValidateRequest(t, req, "POST", "https://api.rudderstack.com/v2/retl-connections", "")
+		},
+		ResponseStatus: 400,
+		ResponseBody:   `{"error": "Bad Request"}`,
+	})
+
+	c, err := client.New("test-token", client.WithHTTPClient(httpClient))
+	require.NoError(t, err)
+	retlClient := retl.NewRudderRETLStore(c)
+
+	_, err = retlClient.CreateConnection(context.Background(), &retl.CreateRETLConnectionRequest{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "creating RETL connection")
+	httpClient.AssertNumberOfCalls()
+}
+
+func TestGetConnection_MalformedResponse(t *testing.T) {
+	httpClient := testutils.NewMockHTTPClient(t, testutils.Call{
+		Validate: func(req *http.Request) bool {
+			return testutils.ValidateRequest(t, req, "GET", "https://api.rudderstack.com/v2/retl-connections/conn-1", "")
+		},
+		ResponseStatus: 200,
+		ResponseBody:   `{malformed`,
+	})
+
+	c, err := client.New("test-token", client.WithHTTPClient(httpClient))
+	require.NoError(t, err)
+	retlClient := retl.NewRudderRETLStore(c)
+
+	_, err = retlClient.GetConnection(context.Background(), "conn-1")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unmarshalling response")
+	httpClient.AssertNumberOfCalls()
+}
+
+func TestListConnections_APIError(t *testing.T) {
+	httpClient := testutils.NewMockHTTPClient(t, testutils.Call{
+		Validate: func(req *http.Request) bool {
+			return testutils.ValidateRequest(t, req, "GET", "https://api.rudderstack.com/v2/retl-connections", "")
+		},
+		ResponseStatus: 500,
+		ResponseBody:   `{"error": "Internal Server Error"}`,
+	})
+
+	c, err := client.New("test-token", client.WithHTTPClient(httpClient))
+	require.NoError(t, err)
+	retlClient := retl.NewRudderRETLStore(c)
+
+	_, err = retlClient.ListConnections(context.Background(), &retl.ListRETLConnectionsRequest{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "listing RETL connections")
+	httpClient.AssertNumberOfCalls()
+}
+
+func TestDeleteConnection_APIError(t *testing.T) {
+	httpClient := testutils.NewMockHTTPClient(t, testutils.Call{
+		Validate: func(req *http.Request) bool {
+			return testutils.ValidateRequest(t, req, "DELETE", "https://api.rudderstack.com/v2/retl-connections/conn-1", "")
+		},
+		ResponseStatus: 500,
+		ResponseBody:   `{"error": "Internal Server Error"}`,
+	})
+
+	c, err := client.New("test-token", client.WithHTTPClient(httpClient))
+	require.NoError(t, err)
+	retlClient := retl.NewRudderRETLStore(c)
+
+	err = retlClient.DeleteConnection(context.Background(), "conn-1")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "deleting RETL connection")
+	httpClient.AssertNumberOfCalls()
+}
+
+func TestSetConnectionExternalID_APIError(t *testing.T) {
+	httpClient := testutils.NewMockHTTPClient(t, testutils.Call{
+		Validate: func(req *http.Request) bool {
+			return testutils.ValidateRequest(t, req, "PUT", "https://api.rudderstack.com/v2/retl-connections/conn-1/external-id", "")
+		},
+		ResponseStatus: 500,
+		ResponseBody:   `{"error": "Internal Server Error"}`,
+	})
+
+	c, err := client.New("test-token", client.WithHTTPClient(httpClient))
+	require.NoError(t, err)
+	retlClient := retl.NewRudderRETLStore(c)
+
+	err = retlClient.SetConnectionExternalID(context.Background(), &retl.SetRETLConnectionExternalIDRequest{
+		ID:         "conn-1",
+		ExternalID: "ext-123",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "setting external ID")
+	httpClient.AssertNumberOfCalls()
+}

--- a/api/client/retl/connections_test.go
+++ b/api/client/retl/connections_test.go
@@ -303,6 +303,33 @@ func TestConnection_EmptyIDErrors(t *testing.T) {
 	assert.Contains(t, err.Error(), "connection ID cannot be empty")
 }
 
+func TestUpdateConnection_RequiresSchedule(t *testing.T) {
+	c, err := client.New("test-token")
+	require.NoError(t, err)
+	retlClient := retl.NewRudderRETLStore(c)
+
+	// Zero-value Schedule would otherwise serialize as {"schedule":{"type":""}}
+	// and fail server-side validation with a confusing enum error.
+	_, err = retlClient.UpdateConnection(context.Background(), "conn-1", &retl.UpdateRETLConnectionRequest{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "schedule.type is required")
+}
+
+func TestCreateConnection_RequiresSchedule(t *testing.T) {
+	c, err := client.New("test-token")
+	require.NoError(t, err)
+	retlClient := retl.NewRudderRETLStore(c)
+
+	_, err = retlClient.CreateConnection(context.Background(), &retl.CreateRETLConnectionRequest{
+		SourceID:      "retl-src-123",
+		DestinationID: "dest-456",
+		SyncBehaviour: retl.SyncBehaviourUpsert,
+		Identifiers:   []retl.Mapping{{From: "email", To: "user_id"}},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "schedule.type is required")
+}
+
 func TestCreateConnection_APIError(t *testing.T) {
 	httpClient := testutils.NewMockHTTPClient(t, testutils.Call{
 		Validate: func(req *http.Request) bool {
@@ -316,7 +343,9 @@ func TestCreateConnection_APIError(t *testing.T) {
 	require.NoError(t, err)
 	retlClient := retl.NewRudderRETLStore(c)
 
-	_, err = retlClient.CreateConnection(context.Background(), &retl.CreateRETLConnectionRequest{})
+	_, err = retlClient.CreateConnection(context.Background(), &retl.CreateRETLConnectionRequest{
+		Schedule: retl.Schedule{Type: retl.ScheduleTypeManual},
+	})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "creating RETL connection")
 	httpClient.AssertNumberOfCalls()

--- a/api/client/retl/connections_test.go
+++ b/api/client/retl/connections_test.go
@@ -268,7 +268,7 @@ func TestListConnections_WithFiltersAndPaging(t *testing.T) {
 	httpClient.AssertNumberOfCalls()
 }
 
-func TestSetConnectionExternalID(t *testing.T) {
+func TestSetConnectionExternalId(t *testing.T) {
 	httpClient := testutils.NewMockHTTPClient(t, testutils.Call{
 		Validate: func(req *http.Request) bool {
 			expected := `{"externalId": "ext-123"}`
@@ -282,7 +282,7 @@ func TestSetConnectionExternalID(t *testing.T) {
 	require.NoError(t, err)
 	retlClient := retl.NewRudderRETLStore(c)
 
-	err = retlClient.SetConnectionExternalID(context.Background(), &retl.SetRETLConnectionExternalIDRequest{
+	err = retlClient.SetConnectionExternalId(context.Background(), &retl.SetRETLConnectionExternalIDRequest{
 		ID:         "conn-1",
 		ExternalID: "ext-123",
 	})
@@ -307,7 +307,7 @@ func TestConnection_EmptyIDErrors(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "connection ID cannot be empty")
 
-	err = retlClient.SetConnectionExternalID(context.Background(), &retl.SetRETLConnectionExternalIDRequest{ID: "", ExternalID: "x"})
+	err = retlClient.SetConnectionExternalId(context.Background(), &retl.SetRETLConnectionExternalIDRequest{ID: "", ExternalID: "x"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "connection ID cannot be empty")
 }
@@ -349,6 +349,10 @@ func TestConnection_NilRequestErrors(t *testing.T) {
 	assert.Contains(t, err.Error(), "request cannot be nil")
 
 	_, err = retlClient.UpdateConnection(context.Background(), "conn-1", nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "request cannot be nil")
+
+	err = retlClient.SetConnectionExternalId(context.Background(), nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "request cannot be nil")
 }
@@ -431,7 +435,7 @@ func TestDeleteConnection_APIError(t *testing.T) {
 	httpClient.AssertNumberOfCalls()
 }
 
-func TestSetConnectionExternalID_APIError(t *testing.T) {
+func TestSetConnectionExternalId_APIError(t *testing.T) {
 	httpClient := testutils.NewMockHTTPClient(t, testutils.Call{
 		Validate: func(req *http.Request) bool {
 			return assertCall(t, req, "PUT", "https://api.rudderstack.com/v2/retl-connections/conn-1/external-id", "")
@@ -444,7 +448,7 @@ func TestSetConnectionExternalID_APIError(t *testing.T) {
 	require.NoError(t, err)
 	retlClient := retl.NewRudderRETLStore(c)
 
-	err = retlClient.SetConnectionExternalID(context.Background(), &retl.SetRETLConnectionExternalIDRequest{
+	err = retlClient.SetConnectionExternalId(context.Background(), &retl.SetRETLConnectionExternalIDRequest{
 		ID:         "conn-1",
 		ExternalID: "ext-123",
 	})

--- a/api/client/retl/connections_test.go
+++ b/api/client/retl/connections_test.go
@@ -16,6 +16,15 @@ func boolPtr(b bool) *bool { return &b }
 
 func intPtr(i int) *int { return &i }
 
+// assertCall validates an incoming mock HTTP request against the expected
+// method, URL, and JSON body. testutils.ValidateRequest currently ignores its
+// url argument, so we assert the URL here explicitly.
+func assertCall(t *testing.T, req *http.Request, method, url, body string) bool {
+	t.Helper()
+	return assert.Equal(t, url, req.URL.String()) &&
+		testutils.ValidateRequest(t, req, method, url, body)
+}
+
 func TestCreateConnection(t *testing.T) {
 	httpClient := testutils.NewMockHTTPClient(t, testutils.Call{
 		Validate: func(req *http.Request) bool {
@@ -29,7 +38,7 @@ func TestCreateConnection(t *testing.T) {
 				"mappings": [{"from": "name", "to": "first_name"}],
 				"event": {"type": "identify"}
 			}`
-			return testutils.ValidateRequest(t, req, "POST", "https://api.rudderstack.com/v2/retl-connections", expected)
+			return assertCall(t, req, "POST", "https://api.rudderstack.com/v2/retl-connections", expected)
 		},
 		ResponseStatus: 200,
 		ResponseBody: `{
@@ -85,7 +94,7 @@ func TestUpdateConnection(t *testing.T) {
 				"schedule": {"type": "basic", "everyMinutes": 120},
 				"mappings": [{"from": "name", "to": "first_name"}]
 			}`
-			return testutils.ValidateRequest(t, req, "PUT", "https://api.rudderstack.com/v2/retl-connections/conn-1", expected)
+			return assertCall(t, req, "PUT", "https://api.rudderstack.com/v2/retl-connections/conn-1", expected)
 		},
 		ResponseStatus: 200,
 		ResponseBody: `{
@@ -122,7 +131,7 @@ func TestUpdateConnection(t *testing.T) {
 func TestGetConnection(t *testing.T) {
 	httpClient := testutils.NewMockHTTPClient(t, testutils.Call{
 		Validate: func(req *http.Request) bool {
-			return testutils.ValidateRequest(t, req, "GET", "https://api.rudderstack.com/v2/retl-connections/conn-1", "")
+			return assertCall(t, req, "GET", "https://api.rudderstack.com/v2/retl-connections/conn-1", "")
 		},
 		ResponseStatus: 200,
 		ResponseBody: `{
@@ -154,7 +163,7 @@ func TestGetConnection(t *testing.T) {
 func TestDeleteConnection(t *testing.T) {
 	httpClient := testutils.NewMockHTTPClient(t, testutils.Call{
 		Validate: func(req *http.Request) bool {
-			return testutils.ValidateRequest(t, req, "DELETE", "https://api.rudderstack.com/v2/retl-connections/conn-1", "")
+			return assertCall(t, req, "DELETE", "https://api.rudderstack.com/v2/retl-connections/conn-1", "")
 		},
 		ResponseStatus: 204,
 		ResponseBody:   "",
@@ -171,7 +180,7 @@ func TestDeleteConnection(t *testing.T) {
 func TestListConnections_NoFilters(t *testing.T) {
 	httpClient := testutils.NewMockHTTPClient(t, testutils.Call{
 		Validate: func(req *http.Request) bool {
-			return testutils.ValidateRequest(t, req, "GET", "https://api.rudderstack.com/v2/retl-connections", "")
+			return assertCall(t, req, "GET", "https://api.rudderstack.com/v2/retl-connections", "")
 		},
 		ResponseStatus: 200,
 		ResponseBody: `{
@@ -263,7 +272,7 @@ func TestSetConnectionExternalID(t *testing.T) {
 	httpClient := testutils.NewMockHTTPClient(t, testutils.Call{
 		Validate: func(req *http.Request) bool {
 			expected := `{"externalId": "ext-123"}`
-			return testutils.ValidateRequest(t, req, "PUT", "https://api.rudderstack.com/v2/retl-connections/conn-1/external-id", expected)
+			return assertCall(t, req, "PUT", "https://api.rudderstack.com/v2/retl-connections/conn-1/external-id", expected)
 		},
 		ResponseStatus: 200,
 		ResponseBody:   `{"id": "conn-1", "externalId": "ext-123"}`,
@@ -333,7 +342,7 @@ func TestCreateConnection_RequiresSchedule(t *testing.T) {
 func TestCreateConnection_APIError(t *testing.T) {
 	httpClient := testutils.NewMockHTTPClient(t, testutils.Call{
 		Validate: func(req *http.Request) bool {
-			return testutils.ValidateRequest(t, req, "POST", "https://api.rudderstack.com/v2/retl-connections", "")
+			return assertCall(t, req, "POST", "https://api.rudderstack.com/v2/retl-connections", "")
 		},
 		ResponseStatus: 400,
 		ResponseBody:   `{"error": "Bad Request"}`,
@@ -354,7 +363,7 @@ func TestCreateConnection_APIError(t *testing.T) {
 func TestGetConnection_MalformedResponse(t *testing.T) {
 	httpClient := testutils.NewMockHTTPClient(t, testutils.Call{
 		Validate: func(req *http.Request) bool {
-			return testutils.ValidateRequest(t, req, "GET", "https://api.rudderstack.com/v2/retl-connections/conn-1", "")
+			return assertCall(t, req, "GET", "https://api.rudderstack.com/v2/retl-connections/conn-1", "")
 		},
 		ResponseStatus: 200,
 		ResponseBody:   `{malformed`,
@@ -373,7 +382,7 @@ func TestGetConnection_MalformedResponse(t *testing.T) {
 func TestListConnections_APIError(t *testing.T) {
 	httpClient := testutils.NewMockHTTPClient(t, testutils.Call{
 		Validate: func(req *http.Request) bool {
-			return testutils.ValidateRequest(t, req, "GET", "https://api.rudderstack.com/v2/retl-connections", "")
+			return assertCall(t, req, "GET", "https://api.rudderstack.com/v2/retl-connections", "")
 		},
 		ResponseStatus: 500,
 		ResponseBody:   `{"error": "Internal Server Error"}`,
@@ -392,7 +401,7 @@ func TestListConnections_APIError(t *testing.T) {
 func TestDeleteConnection_APIError(t *testing.T) {
 	httpClient := testutils.NewMockHTTPClient(t, testutils.Call{
 		Validate: func(req *http.Request) bool {
-			return testutils.ValidateRequest(t, req, "DELETE", "https://api.rudderstack.com/v2/retl-connections/conn-1", "")
+			return assertCall(t, req, "DELETE", "https://api.rudderstack.com/v2/retl-connections/conn-1", "")
 		},
 		ResponseStatus: 500,
 		ResponseBody:   `{"error": "Internal Server Error"}`,
@@ -411,7 +420,7 @@ func TestDeleteConnection_APIError(t *testing.T) {
 func TestSetConnectionExternalID_APIError(t *testing.T) {
 	httpClient := testutils.NewMockHTTPClient(t, testutils.Call{
 		Validate: func(req *http.Request) bool {
-			return testutils.ValidateRequest(t, req, "PUT", "https://api.rudderstack.com/v2/retl-connections/conn-1/external-id", "")
+			return assertCall(t, req, "PUT", "https://api.rudderstack.com/v2/retl-connections/conn-1/external-id", "")
 		},
 		ResponseStatus: 500,
 		ResponseBody:   `{"error": "Internal Server Error"}`,

--- a/api/client/retl/retl.go
+++ b/api/client/retl/retl.go
@@ -30,8 +30,8 @@ type RETLConnectionStore interface {
 	// ListConnections returns a paginated list of RETL connections matching the provided filters.
 	ListConnections(ctx context.Context, req *ListRETLConnectionsRequest) (*RETLConnectionsPage, error)
 
-	// SetConnectionExternalID sets the external ID for a RETL connection.
-	SetConnectionExternalID(ctx context.Context, req *SetRETLConnectionExternalIDRequest) error
+	// SetConnectionExternalId sets the external ID for a RETL connection.
+	SetConnectionExternalId(ctx context.Context, req *SetRETLConnectionExternalIDRequest) error
 }
 
 // RETLSourceStore is the interface for RETL source operations

--- a/api/client/retl/retl.go
+++ b/api/client/retl/retl.go
@@ -9,7 +9,29 @@ import (
 // RETLStore is the interface for RETL operations
 type RETLStore interface {
 	RETLSourceStore
+	RETLConnectionStore
 	PreviewStore
+}
+
+// RETLConnectionStore is the interface for RETL connection operations.
+type RETLConnectionStore interface {
+	// CreateConnection creates a new RETL connection.
+	CreateConnection(ctx context.Context, req *CreateRETLConnectionRequest) (*RETLConnection, error)
+
+	// UpdateConnection updates mutable fields of a RETL connection.
+	UpdateConnection(ctx context.Context, id string, req *UpdateRETLConnectionRequest) (*RETLConnection, error)
+
+	// DeleteConnection soft-deletes a RETL connection by ID.
+	DeleteConnection(ctx context.Context, id string) error
+
+	// GetConnection retrieves a RETL connection by ID.
+	GetConnection(ctx context.Context, id string) (*RETLConnection, error)
+
+	// ListConnections returns a paginated list of RETL connections matching the provided filters.
+	ListConnections(ctx context.Context, req *ListRETLConnectionsRequest) (*RETLConnectionsPage, error)
+
+	// SetConnectionExternalID sets the external ID for a RETL connection.
+	SetConnectionExternalID(ctx context.Context, req *SetRETLConnectionExternalIDRequest) error
 }
 
 // RETLSourceStore is the interface for RETL source operations

--- a/cli/internal/providers/retl/sqlmodel/handler_test.go
+++ b/cli/internal/providers/retl/sqlmodel/handler_test.go
@@ -205,6 +205,33 @@ func (m *mockRETLClient) SetExternalId(ctx context.Context, sourceID string, ext
 	return nil
 }
 
+// RETL connection methods are unused by the sqlmodel handler; stubs satisfy
+// the combined RETLStore interface so this mock can be passed to NewHandler.
+
+func (m *mockRETLClient) CreateConnection(ctx context.Context, req *retlClient.CreateRETLConnectionRequest) (*retlClient.RETLConnection, error) {
+	return nil, nil
+}
+
+func (m *mockRETLClient) UpdateConnection(ctx context.Context, id string, req *retlClient.UpdateRETLConnectionRequest) (*retlClient.RETLConnection, error) {
+	return nil, nil
+}
+
+func (m *mockRETLClient) DeleteConnection(ctx context.Context, id string) error {
+	return nil
+}
+
+func (m *mockRETLClient) GetConnection(ctx context.Context, id string) (*retlClient.RETLConnection, error) {
+	return nil, nil
+}
+
+func (m *mockRETLClient) ListConnections(ctx context.Context, req *retlClient.ListRETLConnectionsRequest) (*retlClient.RETLConnectionsPage, error) {
+	return nil, nil
+}
+
+func (m *mockRETLClient) SetConnectionExternalID(ctx context.Context, req *retlClient.SetRETLConnectionExternalIDRequest) error {
+	return nil
+}
+
 func TestSQLModelHandler(t *testing.T) {
 	t.Parallel()
 

--- a/cli/internal/providers/retl/sqlmodel/handler_test.go
+++ b/cli/internal/providers/retl/sqlmodel/handler_test.go
@@ -233,8 +233,8 @@ func (m *mockRETLClient) ListConnections(ctx context.Context, req *retlClient.Li
 	return nil, unexpectedConnectionCall("ListConnections")
 }
 
-func (m *mockRETLClient) SetConnectionExternalID(ctx context.Context, req *retlClient.SetRETLConnectionExternalIDRequest) error {
-	return unexpectedConnectionCall("SetConnectionExternalID")
+func (m *mockRETLClient) SetConnectionExternalId(ctx context.Context, req *retlClient.SetRETLConnectionExternalIDRequest) error {
+	return unexpectedConnectionCall("SetConnectionExternalId")
 }
 
 func TestSQLModelHandler(t *testing.T) {

--- a/cli/internal/providers/retl/sqlmodel/handler_test.go
+++ b/cli/internal/providers/retl/sqlmodel/handler_test.go
@@ -205,31 +205,36 @@ func (m *mockRETLClient) SetExternalId(ctx context.Context, sourceID string, ext
 	return nil
 }
 
-// RETL connection methods are unused by the sqlmodel handler; stubs satisfy
-// the combined RETLStore interface so this mock can be passed to NewHandler.
+// RETL connection methods are unused by the sqlmodel handler. Stubs fail fast
+// so that if the handler ever starts calling them, tests surface the change
+// instead of silently passing with nil responses.
+
+func unexpectedConnectionCall(method string) error {
+	return errors.New("unexpected call to mockRETLClient." + method)
+}
 
 func (m *mockRETLClient) CreateConnection(ctx context.Context, req *retlClient.CreateRETLConnectionRequest) (*retlClient.RETLConnection, error) {
-	return nil, nil
+	return nil, unexpectedConnectionCall("CreateConnection")
 }
 
 func (m *mockRETLClient) UpdateConnection(ctx context.Context, id string, req *retlClient.UpdateRETLConnectionRequest) (*retlClient.RETLConnection, error) {
-	return nil, nil
+	return nil, unexpectedConnectionCall("UpdateConnection")
 }
 
 func (m *mockRETLClient) DeleteConnection(ctx context.Context, id string) error {
-	return nil
+	return unexpectedConnectionCall("DeleteConnection")
 }
 
 func (m *mockRETLClient) GetConnection(ctx context.Context, id string) (*retlClient.RETLConnection, error) {
-	return nil, nil
+	return nil, unexpectedConnectionCall("GetConnection")
 }
 
 func (m *mockRETLClient) ListConnections(ctx context.Context, req *retlClient.ListRETLConnectionsRequest) (*retlClient.RETLConnectionsPage, error) {
-	return nil, nil
+	return nil, unexpectedConnectionCall("ListConnections")
 }
 
 func (m *mockRETLClient) SetConnectionExternalID(ctx context.Context, req *retlClient.SetRETLConnectionExternalIDRequest) error {
-	return nil
+	return unexpectedConnectionCall("SetConnectionExternalID")
 }
 
 func TestSQLModelHandler(t *testing.T) {


### PR DESCRIPTION
## 🔗 Ticket

Resolves [PRO-5604](https://linear.app/rudderstack/issue/PRO-5604/rudder-iac-retl-connection-go-api-client)

---

## Summary

Adds the Go API client that consumes the RETL connections endpoints introduced in [PRO-5603](https://linear.app/rudderstack/issue/PRO-5603) (rudder-api). Provides typed CRUD + `SetConnectionExternalID` over `/v2/retl-connections`, plus pagination and filtering on list. Blocks [PRO-5605](https://linear.app/rudderstack/issue/PRO-5605) (terraform provider resource).

---

## Changes

- **New** `api/client/retl/connection_types.go` — `RETLConnection`, `CreateRETLConnectionRequest`, `UpdateRETLConnectionRequest`, `Schedule`, `Event`, `Mapping`, `Constant`, `SyncSettings`, `ListRETLConnectionsRequest`, `SetRETLConnectionExternalIDRequest`, and `RETLConnectionsPage` (uses shared `client.Paging`). `DestinationConfig` is `json.RawMessage` so callers decode per destination.
- **New** `api/client/retl/connections.go` — `CreateConnection`, `UpdateConnection`, `DeleteConnection`, `GetConnection`, `ListConnections`, `SetConnectionExternalID`.
- **Modified** `api/client/retl/retl.go` — new `RETLConnectionStore` interface, embedded in combined `RETLStore`.
- **New** `api/client/retl/connections_test.go` — 15 unit tests: happy paths, filters + pagination, empty-ID validation, API errors (4xx/5xx), malformed responses.
- **Modified** `cli/internal/providers/retl/sqlmodel/handler_test.go` — stub implementations of the new methods on `mockRETLClient` to satisfy the combined interface (methods unused by sqlmodel handler).

### Deviation from the ticket

The ticket specifies `ListConnections(ctx, sourceID, destinationID string, hasExternalID *bool) (*RETLConnectionsPage, error)`. This PR uses a request struct with `Page`/`PageSize` added, matching the existing `datagraph.ListDataGraphs` pattern. The API endpoint is paginated and callers need these params to iterate — the positional signature made pagination unreachable.

---

## Testing

- \`make lint\` — clean (0 issues)
- \`go test ./api/client/retl/... ./cli/internal/providers/retl/...\` — all pass
- Full \`make test\` — all pass except the pre-existing \`TestProjectLoad\` which requires \`RUDDERSTACK_ACCESS_TOKEN\` (verified it also fails on the base branch)

---

## Risk / Impact

Low — additive client code. No existing call sites change behaviour; the only modifications to existing files are interface composition (new methods added to the combined interface) and a mock stub to keep it compiling.

Upstream dependency: [PRO-5603](https://linear.app/rudderstack/issue/PRO-5603) rudder-api module is merged (draft) but config-backend CRUD ([PRO-5601](https://linear.app/rudderstack/issue/PRO-5601)) is not yet deployed — live end-to-end verification is gated on that.

---

## Checklist

- [x] Ticket linked
- [x] Tests added/updated
- [x] No breaking changes (additive only)