### PR TITLE
chore(vuln): remediate template-injection findings (SEC-251)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -34,17 +34,20 @@ jobs:
 
       - name: Set Docker Tag
         id: docker_tag
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REF_TYPE: ${{ github.ref_type }}
         run: |
-          if [[ ${{ github.event_name }} == 'repository_dispatch' ]]; then
+          if [[ "$EVENT_NAME" == 'repository_dispatch' ]]; then
             # For repository_dispatch from release-please, use tag_name and strip v prefix
             TAG_NAME="${{ github.event.client_payload.tag }}"
             echo "VERSION=${TAG_NAME#v}" >> $GITHUB_ENV
-          elif [[ ${{ github.ref_type }} == 'tag' ]]; then
+          elif [[ "$REF_TYPE" == 'tag' ]]; then
             # For version tags (v0.1.0), use version number (0.1.0)
             echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_ENV
           else
             # For PR, use PR branch name
-            if [[ ${{ github.event_name }} == 'pull_request' ]]; then
+            if [[ "$EVENT_NAME" == 'pull_request' ]]; then
               TAG="pr-${{ github.event.pull_request.number }}"
             else
               # For main branch push
@@ -59,9 +62,11 @@ jobs:
         env:
           TELEMETRY_WRITE_KEY: ${{ vars.TELEMETRY_WRITE_KEY }}
           TELEMETRY_DATAPLANE_URL: ${{ vars.TELEMETRY_DATAPLANE_URL }}
+          EVENT_NAME: ${{ github.event_name }}
+          REF_TYPE: ${{ github.ref_type }}
         run: |
           make docker-build
-          if [[ ${{ github.event_name }} == 'repository_dispatch' ]] || [[ ${{ github.ref_type }} == 'tag' ]]; then
+          if [[ "$EVENT_NAME" == 'repository_dispatch' ]] || [[ "$REF_TYPE" == 'tag' ]]; then
             # For releases (repository_dispatch) or version tags, also push as latest
             docker tag rudderlabs/rudder-cli:$VERSION rudderlabs/rudder-cli:latest
             docker push rudderlabs/rudder-cli:$VERSION

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -37,10 +37,12 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
           REF_TYPE: ${{ github.ref_type }}
+          CLIENT_PAYLOAD_TAG: ${{ github.event.client_payload.tag }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           if [[ "$EVENT_NAME" == 'repository_dispatch' ]]; then
             # For repository_dispatch from release-please, use tag_name and strip v prefix
-            TAG_NAME="${{ github.event.client_payload.tag }}"
+            TAG_NAME="$CLIENT_PAYLOAD_TAG"
             echo "VERSION=${TAG_NAME#v}" >> $GITHUB_ENV
           elif [[ "$REF_TYPE" == 'tag' ]]; then
             # For version tags (v0.1.0), use version number (0.1.0)
@@ -48,7 +50,7 @@ jobs:
           else
             # For PR, use PR branch name
             if [[ "$EVENT_NAME" == 'pull_request' ]]; then
-              TAG="pr-${{ github.event.pull_request.number }}"
+              TAG="pr-$PR_NUMBER"
             else
               # For main branch push
               TAG=$GITHUB_REF_NAME


### PR DESCRIPTION
Remediates `zizmor/template-injection` findings in this repo as part of the org-wide remediation tracked in [SEC-251](https://linear.app/rudderstack/issue/SEC-251) (parent: [SEC-162](https://linear.app/rudderstack/issue/SEC-162)).

## Verification

- actionlint (syntax+expressions): green before, green after
- zizmor: all targeted findings absent post-fix; no new findings introduced
- Edits scoped to `.github/` only; no reformatting / drive-by changes

## Test plan

- [ ] CI green
- [ ] No release-tagging or workflow-trigger regression (SEC-198 class)
