### PR TITLE
feat(api): add GeoEnrichmentEnabled and Transient to Source struct (INT-6264)

### DIFF
--- a/api/client/sources.go
+++ b/api/client/sources.go
@@ -7,14 +7,16 @@ import (
 )
 
 type Source struct {
-	ID        string          `json:"id,omitempty"`
-	Name      string          `json:"name"`
-	Type      string          `json:"type"`
-	WriteKey  string          `json:"writeKey,omitempty"`
-	IsEnabled bool            `json:"enabled"`
-	Config    json.RawMessage `json:"config"`
-	CreatedAt *time.Time      `json:"createdAt,omitempty"`
-	UpdatedAt *time.Time      `json:"updatedAt,omitempty"`
+	ID                   string          `json:"id,omitempty"`
+	Name                 string          `json:"name"`
+	Type                 string          `json:"type"`
+	WriteKey             string          `json:"writeKey,omitempty"`
+	IsEnabled            bool            `json:"enabled"`
+	Config               json.RawMessage `json:"config"`
+	CreatedAt            *time.Time      `json:"createdAt,omitempty"`
+	UpdatedAt            *time.Time      `json:"updatedAt,omitempty"`
+	GeoEnrichmentEnabled *bool           `json:"geoEnrichmentEnabled,omitempty"`
+	Transient            *bool           `json:"transient,omitempty"`
 }
 
 type sources struct {

--- a/api/client/sources_test.go
+++ b/api/client/sources_test.go
@@ -182,6 +182,44 @@ func TestClientSourcesCreate(t *testing.T) {
 	httpClient.AssertNumberOfCalls()
 }
 
+func boolPtr(b bool) *bool { return &b }
+
+func TestClientSourcesGetWithGeoEnrichmentAndTransient(t *testing.T) {
+	ctx := context.Background()
+
+	calls := []testutils.Call{
+		{
+			Validate: func(req *http.Request) bool {
+				return testutils.ValidateRequest(t, req, "GET", "https://api.rudderstack.com/v2/sources/some-id", "")
+			},
+			ResponseStatus: 200,
+			ResponseBody: `{
+				"source": {
+					"id": "some-id",
+					"name": "some-name",
+					"type": "some-type",
+					"config": { "key1": "val1" },
+					"enabled": true,
+					"geoEnrichmentEnabled": true,
+					"transient": true
+				}
+			}`,
+		},
+	}
+
+	httpClient := testutils.NewMockHTTPClient(t, calls...)
+
+	c, err := client.New("some-access-token", client.WithHTTPClient(httpClient))
+	require.NoError(t, err)
+
+	source, err := c.Sources.Get(ctx, "some-id")
+	require.NoError(t, err)
+	assert.Equal(t, boolPtr(true), source.GeoEnrichmentEnabled)
+	assert.Equal(t, boolPtr(true), source.Transient)
+
+	httpClient.AssertNumberOfCalls()
+}
+
 func TestClientSourcesUpdate(t *testing.T) {
 	ctx := context.Background()
 


### PR DESCRIPTION
🔒 Scanned for secrets using gitleaks 8.30.1

## 🔗 Ticket

<!-- Required for traceability -->

Resolves [INT-6264](https://linear.app/rudderstack/issue/INT-6264/rudder-iac-add-geoenrichmentenabled-and-transient-to-event-stream)

---

## Summary

This pull request adds support for new fields in the `Source` struct and introduces a corresponding test to ensure these fields are correctly handled. The main focus is on tracking whether geo enrichment is enabled and whether a source is transient.

Enhancements to the `Source` struct:

* Added two new optional boolean fields, `GeoEnrichmentEnabled` and `Transient`, to the `Source` struct in `sources.go` to allow tracking of geo enrichment and transient status.

Testing improvements:

* Added a new test, `TestClientSourcesGetWithGeoEnrichmentAndTransient`, in `sources_test.go` to verify that the new `GeoEnrichmentEnabled` and `Transient` fields are correctly parsed from the API response.
* Introduced a helper function, `boolPtr`, to simplify pointer comparisons for boolean values in tests.

## Why this is needed 

- [rudder-terraform-provider](https://github.com/rudderlabs/terraform-provider-rudderstack/blob/main/rudderstack/resource_source.go#L94) uses exported functions of source client to manage sources. 
- We want users to update`GeoEnrichmentEnabled` and `Transient` fields using rudder-terraform-provider 
- I have added a support of `GeoEnrichmentEnabled` and `Transient` in rudder-api, which is called this source client

---

## Testing

How was this tested?

- Unit test added for getting source object
- Manually done a testing and perfomed source CRUD operations 

---

## Risk / Impact

Low

---

## Checklist

- [ ] Ticket linked
- [ ] Tests added/updated
- [ ] No breaking changes (or documented)
