### PR TITLE
feat(import): add --filter and --on-conflict flags for workspace import

### DIFF
--- a/cli/internal/cmd/import/workspace.go
+++ b/cli/internal/cmd/import/workspace.go
@@ -9,6 +9,7 @@ import (
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/rudderlabs/rudder-iac/cli/internal/app"
 	"github.com/rudderlabs/rudder-iac/cli/internal/cmd/telemetry"
+	"github.com/rudderlabs/rudder-iac/cli/internal/config"
 	"github.com/rudderlabs/rudder-iac/cli/internal/project"
 	"github.com/rudderlabs/rudder-iac/cli/internal/project/importer"
 	"github.com/rudderlabs/rudder-iac/cli/internal/ui"
@@ -47,6 +48,18 @@ The --on-conflict flag controls how to handle resources that already exist local
 			$ rudder-cli import workspace --location </path/to/project_dir> --filter all --on-conflict keep-both
 		`),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
+			cfg := config.GetConfig()
+
+			// Check if experimental flag is enabled for non-default options
+			if !cfg.ExperimentalFlags.ImportFilter {
+				if filter != "unmanaged" {
+					return fmt.Errorf("--filter flag requires experimental feature 'importFilter' to be enabled. Run: rudder-cli experimental enable importFilter")
+				}
+				if onConflict != "keep-local" {
+					return fmt.Errorf("--on-conflict flag requires experimental feature 'importFilter' to be enabled. Run: rudder-cli experimental enable importFilter")
+				}
+			}
+
 			// Validate filter option
 			switch importer.FilterOption(filter) {
 			case importer.FilterUnmanaged, importer.FilterManaged, importer.FilterAll:

--- a/cli/internal/cmd/import/workspace.go
+++ b/cli/internal/cmd/import/workspace.go
@@ -21,16 +21,33 @@ func NewCmdWorkspaceImport() *cobra.Command {
 		p        project.Project
 		err      error
 		location string
+		filter   string
 	)
 
 	cmd := &cobra.Command{
 		Use:   "workspace",
 		Short: "Import workspace resources",
-		Long:  "Import upstream workspace resources using available providers into configuration files",
+		Long: `Import upstream workspace resources using available providers into configuration files.
+
+The --filter flag controls which resources are imported:
+  - unmanaged (default): Import only resources WITHOUT external IDs (not yet managed by IaC)
+  - managed: Import only resources WITH external IDs (already managed by IaC, useful for backup/sync)
+  - all: Import both managed and unmanaged resources`,
 		Example: heredoc.Doc(`
 			$ rudder-cli import workspace --location </path/to/project_dir>
+			$ rudder-cli import workspace --location </path/to/project_dir> --filter unmanaged
+			$ rudder-cli import workspace --location </path/to/project_dir> --filter managed
+			$ rudder-cli import workspace --location </path/to/project_dir> --filter all
 		`),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
+			// Validate filter option
+			switch importer.FilterOption(filter) {
+			case importer.FilterUnmanaged, importer.FilterManaged, importer.FilterAll:
+				// valid
+			default:
+				return fmt.Errorf("invalid filter option: %q (must be 'unmanaged', 'managed', or 'all')", filter)
+			}
+
 			deps, err = app.NewDeps()
 			if err != nil {
 				return fmt.Errorf("initialising dependencies: %w", err)
@@ -65,7 +82,10 @@ func NewCmdWorkspaceImport() *cobra.Command {
 			spinner := ui.NewSpinner("Importing ...")
 			spinner.Start()
 
-			err = importer.WorkspaceImport(cmd.Context(), p, deps.CompositeProvider())
+			opts := importer.ImportOptions{
+				Filter: importer.FilterOption(filter),
+			}
+			err = importer.WorkspaceImport(cmd.Context(), p, deps.CompositeProvider(), opts)
 
 			spinner.Stop()
 			if err == nil {
@@ -77,5 +97,6 @@ func NewCmdWorkspaceImport() *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&location, "location", "l", ".", "Path to the directory containing the project files")
+	cmd.Flags().StringVarP(&filter, "filter", "f", "unmanaged", "Filter resources to import: 'unmanaged' (default), 'managed', or 'all'")
 	return cmd
 }

--- a/cli/internal/cmd/import/workspace.go
+++ b/cli/internal/cmd/import/workspace.go
@@ -17,11 +17,12 @@ import (
 
 func NewCmdWorkspaceImport() *cobra.Command {
 	var (
-		deps     app.Deps
-		p        project.Project
-		err      error
-		location string
-		filter   string
+		deps       app.Deps
+		p          project.Project
+		err        error
+		location   string
+		filter     string
+		onConflict string
 	)
 
 	cmd := &cobra.Command{
@@ -32,12 +33,18 @@ func NewCmdWorkspaceImport() *cobra.Command {
 The --filter flag controls which resources are imported:
   - unmanaged (default): Import only resources WITHOUT external IDs (not yet managed by IaC)
   - managed: Import only resources WITH external IDs (already managed by IaC, useful for backup/sync)
-  - all: Import both managed and unmanaged resources`,
+  - all: Import both managed and unmanaged resources
+
+The --on-conflict flag controls how to handle resources that already exist locally (only applies when --filter is 'managed' or 'all'):
+  - keep-local (default): Skip importing resources that already exist locally
+  - accept-incoming: Overwrite local files with the incoming/remote version
+  - keep-both: Keep both versions by creating a new file with '-imported' suffix`,
 		Example: heredoc.Doc(`
 			$ rudder-cli import workspace --location </path/to/project_dir>
 			$ rudder-cli import workspace --location </path/to/project_dir> --filter unmanaged
 			$ rudder-cli import workspace --location </path/to/project_dir> --filter managed
-			$ rudder-cli import workspace --location </path/to/project_dir> --filter all
+			$ rudder-cli import workspace --location </path/to/project_dir> --filter managed --on-conflict accept-incoming
+			$ rudder-cli import workspace --location </path/to/project_dir> --filter all --on-conflict keep-both
 		`),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			// Validate filter option
@@ -46,6 +53,14 @@ The --filter flag controls which resources are imported:
 				// valid
 			default:
 				return fmt.Errorf("invalid filter option: %q (must be 'unmanaged', 'managed', or 'all')", filter)
+			}
+
+			// Validate on-conflict option
+			switch importer.ConflictResolution(onConflict) {
+			case importer.ConflictKeepLocal, importer.ConflictAcceptIncoming, importer.ConflictKeepBoth:
+				// valid
+			default:
+				return fmt.Errorf("invalid on-conflict option: %q (must be 'keep-local', 'accept-incoming', or 'keep-both')", onConflict)
 			}
 
 			deps, err = app.NewDeps()
@@ -83,7 +98,8 @@ The --filter flag controls which resources are imported:
 			spinner.Start()
 
 			opts := importer.ImportOptions{
-				Filter: importer.FilterOption(filter),
+				Filter:     importer.FilterOption(filter),
+				OnConflict: importer.ConflictResolution(onConflict),
 			}
 			err = importer.WorkspaceImport(cmd.Context(), p, deps.CompositeProvider(), opts)
 
@@ -98,5 +114,6 @@ The --filter flag controls which resources are imported:
 
 	cmd.Flags().StringVarP(&location, "location", "l", ".", "Path to the directory containing the project files")
 	cmd.Flags().StringVarP(&filter, "filter", "f", "unmanaged", "Filter resources to import: 'unmanaged' (default), 'managed', or 'all'")
+	cmd.Flags().StringVar(&onConflict, "on-conflict", "keep-local", "Conflict resolution when importing managed resources: 'keep-local' (default), 'accept-incoming', or 'keep-both'")
 	return cmd
 }

--- a/cli/internal/config/experimental.go
+++ b/cli/internal/config/experimental.go
@@ -20,6 +20,8 @@ type ExperimentalConfig struct {
 	Transformations bool `mapstructure:"transformations"`
 	// DataGraph enables data graph operations (sync, validate, import)
 	DataGraph bool `mapstructure:"dataGraph"`
+	// ImportFilter enables --filter and --on-conflict flags for import workspace command
+	ImportFilter bool `mapstructure:"importFilter"`
 }
 
 // getAvailableExperimentalFlags returns information about all available experimental flags

--- a/cli/internal/project/importer/importer.go
+++ b/cli/internal/project/importer/importer.go
@@ -5,9 +5,11 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	"github.com/rudderlabs/rudder-iac/cli/internal/namer"
 	"github.com/rudderlabs/rudder-iac/cli/internal/project/formatter"
+	"github.com/rudderlabs/rudder-iac/cli/internal/project/specs"
 	"github.com/rudderlabs/rudder-iac/cli/internal/project/writer"
 	"github.com/rudderlabs/rudder-iac/cli/internal/provider"
 	"github.com/rudderlabs/rudder-iac/cli/internal/resolver"
@@ -32,11 +34,28 @@ const (
 	FilterAll FilterOption = "all"
 )
 
+// ConflictResolution specifies how to handle conflicts when importing managed resources
+// that already exist locally.
+type ConflictResolution string
+
+const (
+	// ConflictKeepLocal skips importing resources that already exist locally.
+	ConflictKeepLocal ConflictResolution = "keep-local"
+	// ConflictAcceptIncoming overwrites local files with the incoming/remote version.
+	ConflictAcceptIncoming ConflictResolution = "accept-incoming"
+	// ConflictKeepBoth keeps both versions by creating a new file with a suffix for the incoming version.
+	ConflictKeepBoth ConflictResolution = "keep-both"
+)
+
 // ImportOptions configures the workspace import behavior.
 type ImportOptions struct {
 	// Filter determines which resources to import based on their management status.
 	// Defaults to FilterUnmanaged if not specified.
 	Filter FilterOption
+	// OnConflict determines how to handle conflicts when importing managed resources
+	// that already exist locally. Only applies when Filter is FilterManaged or FilterAll.
+	// Defaults to ConflictKeepLocal if not specified.
+	OnConflict ConflictResolution
 }
 
 var ErrProjectNotSynced = errors.New("import not allowed as project has changes to be synced")
@@ -61,6 +80,10 @@ func WorkspaceImport(
 	// Default to unmanaged if no filter specified
 	if opts.Filter == "" {
 		opts.Filter = FilterUnmanaged
+	}
+	// Default to keep-local if no conflict resolution specified
+	if opts.OnConflict == "" {
+		opts.OnConflict = ConflictKeepLocal
 	}
 
 	remoteCollection, err := p.LoadResourcesFromRemote(ctx)
@@ -108,6 +131,16 @@ func WorkspaceImport(
 	entities, err := p.FormatForExport(importable, idNamer, resolver)
 	if err != nil {
 		return fmt.Errorf("normalizing for import: %w", err)
+	}
+
+	// Apply conflict resolution when importing managed resources
+	if opts.Filter == FilterManaged || opts.Filter == FilterAll {
+		entities = applyConflictResolution(entities, targetGraph, opts.OnConflict)
+	}
+
+	if len(entities) == 0 {
+		fmt.Println("No resources to import")
+		return nil
 	}
 
 	formatters := formatter.Setup(formatter.DefaultYAML, formatter.DefaultText)
@@ -190,4 +223,96 @@ func initResolver(
 		Graph:      graph,
 		Importable: importable,
 	}, nil
+}
+
+// applyConflictResolution filters and modifies entities based on the conflict resolution strategy.
+// It checks if resources already exist in the target graph and applies the appropriate action:
+// - ConflictKeepLocal: Skip entities for resources that exist locally
+// - ConflictAcceptIncoming: Keep all entities (they will overwrite local files)
+// - ConflictKeepBoth: Modify paths for conflicting entities by adding a suffix
+func applyConflictResolution(
+	entities []writer.FormattableEntity,
+	targetGraph *resources.Graph,
+	onConflict ConflictResolution,
+) []writer.FormattableEntity {
+	if len(entities) == 0 {
+		return entities
+	}
+
+	var result []writer.FormattableEntity
+
+	for _, entity := range entities {
+		hasConflict := entityHasConflict(entity, targetGraph)
+
+		switch onConflict {
+		case ConflictKeepLocal:
+			if !hasConflict {
+				result = append(result, entity)
+			}
+		case ConflictAcceptIncoming:
+			result = append(result, entity)
+		case ConflictKeepBoth:
+			if hasConflict {
+				entity.RelativePath = generateConflictPath(entity.RelativePath)
+			}
+			result = append(result, entity)
+		default:
+			// Unknown conflict resolution, default to keep-local behavior
+			if !hasConflict {
+				result = append(result, entity)
+			}
+		}
+	}
+
+	return result
+}
+
+// entityHasConflict checks if any resource in the entity already exists in the target graph.
+func entityHasConflict(entity writer.FormattableEntity, targetGraph *resources.Graph) bool {
+	urns := extractURNsFromEntity(entity)
+	for _, urn := range urns {
+		if _, exists := targetGraph.GetResource(urn); exists {
+			return true
+		}
+	}
+	return false
+}
+
+// extractURNsFromEntity extracts URNs from the entity's metadata.
+// It handles both specs.Spec pointers and values.
+func extractURNsFromEntity(entity writer.FormattableEntity) []string {
+	var spec *specs.Spec
+
+	switch s := entity.Content.(type) {
+	case *specs.Spec:
+		spec = s
+	case specs.Spec:
+		spec = &s
+	default:
+		return nil
+	}
+
+	metadata, err := spec.CommonMetadata()
+	if err != nil || metadata.Import == nil {
+		return nil
+	}
+
+	var urns []string
+	for _, workspace := range metadata.Import.Workspaces {
+		for _, resource := range workspace.Resources {
+			if resource.URN != "" {
+				urns = append(urns, resource.URN)
+			}
+		}
+	}
+
+	return urns
+}
+
+// generateConflictPath adds a suffix to the file path for keep-both conflict resolution.
+// For example, "sources/my-source.yaml" becomes "sources/my-source-imported.yaml"
+func generateConflictPath(relativePath string) string {
+	ext := filepath.Ext(relativePath)
+	base := strings.TrimSuffix(relativePath, ext)
+	return base + "-imported" + ext
 }

--- a/cli/internal/project/importer/importer.go
+++ b/cli/internal/project/importer/importer.go
@@ -20,6 +20,25 @@ const (
 	ImportedDir = "imported"
 )
 
+// FilterOption specifies which resources to import based on their management status.
+type FilterOption string
+
+const (
+	// FilterUnmanaged imports only resources without external IDs (not yet managed by IaC).
+	FilterUnmanaged FilterOption = "unmanaged"
+	// FilterManaged imports only resources with external IDs (already managed by IaC).
+	FilterManaged FilterOption = "managed"
+	// FilterAll imports all resources regardless of their management status.
+	FilterAll FilterOption = "all"
+)
+
+// ImportOptions configures the workspace import behavior.
+type ImportOptions struct {
+	// Filter determines which resources to import based on their management status.
+	// Defaults to FilterUnmanaged if not specified.
+	Filter FilterOption
+}
+
 var ErrProjectNotSynced = errors.New("import not allowed as project has changes to be synced")
 
 type ImportProvider interface {
@@ -36,7 +55,13 @@ type Project interface {
 func WorkspaceImport(
 	ctx context.Context,
 	project Project,
-	p ImportProvider) error {
+	p ImportProvider,
+	opts ImportOptions,
+) error {
+	// Default to unmanaged if no filter specified
+	if opts.Filter == "" {
+		opts.Filter = FilterUnmanaged
+	}
 
 	remoteCollection, err := p.LoadResourcesFromRemote(ctx)
 	if err != nil {
@@ -64,9 +89,10 @@ func WorkspaceImport(
 		return fmt.Errorf("initializing namer: %w", err)
 	}
 
-	importable, err := p.LoadImportable(ctx, idNamer)
+	// Load resources based on filter option
+	importable, err := loadResourcesForImport(ctx, p, opts.Filter, idNamer, remoteCollection)
 	if err != nil {
-		return fmt.Errorf("loading importable resources: %w", err)
+		return fmt.Errorf("loading resources for import: %w", err)
 	}
 
 	if importable.Len() == 0 {
@@ -92,6 +118,46 @@ func WorkspaceImport(
 	}
 
 	return nil
+}
+
+// loadResourcesForImport loads resources based on the filter option.
+// - FilterUnmanaged: loads only unmanaged resources (without external IDs)
+// - FilterManaged: loads only managed resources (with external IDs), using existing IDs
+// - FilterAll: combines both managed and unmanaged resources
+func loadResourcesForImport(
+	ctx context.Context,
+	p ImportProvider,
+	filter FilterOption,
+	idNamer namer.Namer,
+	remoteCollection *resources.RemoteResources,
+) (*resources.RemoteResources, error) {
+	switch filter {
+	case FilterUnmanaged:
+		return p.LoadImportable(ctx, idNamer)
+
+	case FilterManaged:
+		return loadManagedForExport(remoteCollection)
+
+	case FilterAll:
+		unmanaged, err := p.LoadImportable(ctx, idNamer)
+		if err != nil {
+			return nil, fmt.Errorf("loading unmanaged resources: %w", err)
+		}
+		managed, err := loadManagedForExport(remoteCollection)
+		if err != nil {
+			return nil, fmt.Errorf("loading managed resources: %w", err)
+		}
+		return unmanaged.Merge(managed)
+
+	default:
+		return nil, fmt.Errorf("unknown filter option: %s", filter)
+	}
+}
+
+// loadManagedForExport returns the remote collection as-is since it already contains
+// managed resources with their existing external IDs from LoadResourcesFromRemote.
+func loadManagedForExport(remoteCollection *resources.RemoteResources) (*resources.RemoteResources, error) {
+	return remoteCollection, nil
 }
 
 func initNamer(graph *resources.Graph) (namer.Namer, error) {

--- a/cli/internal/project/importer/importer_test.go
+++ b/cli/internal/project/importer/importer_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/rudderlabs/rudder-iac/cli/internal/namer"
+	"github.com/rudderlabs/rudder-iac/cli/internal/project/specs"
 	"github.com/rudderlabs/rudder-iac/cli/internal/project/writer"
 	"github.com/rudderlabs/rudder-iac/cli/internal/resolver"
 	"github.com/rudderlabs/rudder-iac/cli/internal/resources"
@@ -247,4 +248,332 @@ func TestImportOptions_DefaultFilter(t *testing.T) {
 
 	opts = ImportOptions{Filter: FilterManaged}
 	assert.Equal(t, FilterManaged, opts.Filter)
+}
+
+func TestConflictResolution_Values(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		resolution ConflictResolution
+		expected   string
+	}{
+		{
+			name:       "keep-local conflict resolution value",
+			resolution: ConflictKeepLocal,
+			expected:   "keep-local",
+		},
+		{
+			name:       "accept-incoming conflict resolution value",
+			resolution: ConflictAcceptIncoming,
+			expected:   "accept-incoming",
+		},
+		{
+			name:       "keep-both conflict resolution value",
+			resolution: ConflictKeepBoth,
+			expected:   "keep-both",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, string(tt.resolution))
+		})
+	}
+}
+
+func TestImportOptions_DefaultOnConflict(t *testing.T) {
+	t.Parallel()
+
+	opts := ImportOptions{}
+	assert.Equal(t, ConflictResolution(""), opts.OnConflict)
+
+	opts = ImportOptions{OnConflict: ConflictAcceptIncoming}
+	assert.Equal(t, ConflictAcceptIncoming, opts.OnConflict)
+}
+
+// createTestSpec creates a test specs.Spec with the given URNs in import metadata
+func createTestSpec(urns []string) *specs.Spec {
+	importResources := make([]specs.ImportIds, 0, len(urns))
+	for _, urn := range urns {
+		importResources = append(importResources, specs.ImportIds{
+			URN:      urn,
+			RemoteID: "remote-" + urn,
+		})
+	}
+
+	metadata := specs.Metadata{
+		Name: "test-spec",
+		Import: &specs.WorkspacesImportMetadata{
+			Workspaces: []specs.WorkspaceImportMetadata{
+				{
+					WorkspaceID: "workspace-1",
+					Resources:   importResources,
+				},
+			},
+		},
+	}
+
+	metadataMap, _ := metadata.ToMap()
+
+	return &specs.Spec{
+		Version:  specs.SpecVersionV1,
+		Kind:     "test-kind",
+		Metadata: metadataMap,
+		Spec:     map[string]any{"name": "test"},
+	}
+}
+
+func TestExtractURNsFromEntity(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		entity       writer.FormattableEntity
+		expectedURNs []string
+	}{
+		{
+			name: "extracts URNs from spec pointer",
+			entity: writer.FormattableEntity{
+				Content:      createTestSpec([]string{"source:my-source", "destination:my-dest"}),
+				RelativePath: "test.yaml",
+			},
+			expectedURNs: []string{"source:my-source", "destination:my-dest"},
+		},
+		{
+			name: "extracts URNs from spec value",
+			entity: writer.FormattableEntity{
+				Content:      *createTestSpec([]string{"source:single-source"}),
+				RelativePath: "test.yaml",
+			},
+			expectedURNs: []string{"source:single-source"},
+		},
+		{
+			name: "returns empty for non-spec content",
+			entity: writer.FormattableEntity{
+				Content:      map[string]any{"key": "value"},
+				RelativePath: "test.yaml",
+			},
+			expectedURNs: nil,
+		},
+		{
+			name: "returns empty for spec without import metadata",
+			entity: writer.FormattableEntity{
+				Content: &specs.Spec{
+					Version:  specs.SpecVersionV1,
+					Kind:     "test-kind",
+					Metadata: map[string]any{"name": "test"},
+					Spec:     map[string]any{"name": "test"},
+				},
+				RelativePath: "test.yaml",
+			},
+			expectedURNs: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			urns := extractURNsFromEntity(tt.entity)
+			assert.Equal(t, tt.expectedURNs, urns)
+		})
+	}
+}
+
+func TestEntityHasConflict(t *testing.T) {
+	t.Parallel()
+
+	// Create a graph with existing resources
+	graph := resources.NewGraph()
+	graph.AddResource(resources.NewResource("existing-source", "source", resources.ResourceData{"name": "Existing"}, nil))
+	graph.AddResource(resources.NewResource("existing-dest", "destination", resources.ResourceData{"name": "Existing Dest"}, nil))
+
+	tests := []struct {
+		name        string
+		entity      writer.FormattableEntity
+		hasConflict bool
+	}{
+		{
+			name: "detects conflict when resource exists",
+			entity: writer.FormattableEntity{
+				Content:      createTestSpec([]string{"source:existing-source"}),
+				RelativePath: "sources/existing-source.yaml",
+			},
+			hasConflict: true,
+		},
+		{
+			name: "detects conflict when any resource in entity exists",
+			entity: writer.FormattableEntity{
+				Content:      createTestSpec([]string{"source:new-source", "destination:existing-dest"}),
+				RelativePath: "mixed.yaml",
+			},
+			hasConflict: true,
+		},
+		{
+			name: "no conflict when resource does not exist",
+			entity: writer.FormattableEntity{
+				Content:      createTestSpec([]string{"source:new-source"}),
+				RelativePath: "sources/new-source.yaml",
+			},
+			hasConflict: false,
+		},
+		{
+			name: "no conflict for non-spec content",
+			entity: writer.FormattableEntity{
+				Content:      map[string]any{"key": "value"},
+				RelativePath: "other.yaml",
+			},
+			hasConflict: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := entityHasConflict(tt.entity, graph)
+			assert.Equal(t, tt.hasConflict, result)
+		})
+	}
+}
+
+func TestGenerateConflictPath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		inputPath    string
+		expectedPath string
+	}{
+		{
+			name:         "adds suffix before yaml extension",
+			inputPath:    "sources/my-source.yaml",
+			expectedPath: "sources/my-source-imported.yaml",
+		},
+		{
+			name:         "handles nested paths",
+			inputPath:    "deep/nested/path/resource.yaml",
+			expectedPath: "deep/nested/path/resource-imported.yaml",
+		},
+		{
+			name:         "handles different extensions",
+			inputPath:    "config/settings.txt",
+			expectedPath: "config/settings-imported.txt",
+		},
+		{
+			name:         "handles file without extension",
+			inputPath:    "config/noextension",
+			expectedPath: "config/noextension-imported",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := generateConflictPath(tt.inputPath)
+			assert.Equal(t, tt.expectedPath, result)
+		})
+	}
+}
+
+func TestApplyConflictResolution(t *testing.T) {
+	t.Parallel()
+
+	// Create a graph with existing resources
+	graph := resources.NewGraph()
+	graph.AddResource(resources.NewResource("existing-source", "source", resources.ResourceData{"name": "Existing"}, nil))
+
+	// Create test entities - one with conflict, one without
+	conflictingEntity := writer.FormattableEntity{
+		Content:      createTestSpec([]string{"source:existing-source"}),
+		RelativePath: "sources/existing-source.yaml",
+	}
+	newEntity := writer.FormattableEntity{
+		Content:      createTestSpec([]string{"source:new-source"}),
+		RelativePath: "sources/new-source.yaml",
+	}
+
+	tests := []struct {
+		name           string
+		entities       []writer.FormattableEntity
+		onConflict     ConflictResolution
+		expectedCount  int
+		expectedPaths  []string
+	}{
+		{
+			name:           "keep-local skips conflicting entities",
+			entities:       []writer.FormattableEntity{conflictingEntity, newEntity},
+			onConflict:     ConflictKeepLocal,
+			expectedCount:  1,
+			expectedPaths:  []string{"sources/new-source.yaml"},
+		},
+		{
+			name:           "accept-incoming keeps all entities",
+			entities:       []writer.FormattableEntity{conflictingEntity, newEntity},
+			onConflict:     ConflictAcceptIncoming,
+			expectedCount:  2,
+			expectedPaths:  []string{"sources/existing-source.yaml", "sources/new-source.yaml"},
+		},
+		{
+			name:           "keep-both modifies path for conflicting entities",
+			entities:       []writer.FormattableEntity{conflictingEntity, newEntity},
+			onConflict:     ConflictKeepBoth,
+			expectedCount:  2,
+			expectedPaths:  []string{"sources/existing-source-imported.yaml", "sources/new-source.yaml"},
+		},
+		{
+			name:           "empty entities returns empty",
+			entities:       []writer.FormattableEntity{},
+			onConflict:     ConflictKeepLocal,
+			expectedCount:  0,
+			expectedPaths:  nil,
+		},
+		{
+			name:           "unknown conflict resolution defaults to keep-local behavior",
+			entities:       []writer.FormattableEntity{conflictingEntity, newEntity},
+			onConflict:     ConflictResolution("unknown"),
+			expectedCount:  1,
+			expectedPaths:  []string{"sources/new-source.yaml"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := applyConflictResolution(tt.entities, graph, tt.onConflict)
+			assert.Equal(t, tt.expectedCount, len(result))
+
+			if tt.expectedPaths != nil {
+				actualPaths := make([]string, len(result))
+				for i, e := range result {
+					actualPaths[i] = e.RelativePath
+				}
+				assert.ElementsMatch(t, tt.expectedPaths, actualPaths)
+			}
+		})
+	}
+}
+
+func TestApplyConflictResolution_OnlyAffectsManagedFilter(t *testing.T) {
+	t.Parallel()
+
+	// This test verifies that conflict resolution only applies when filter is managed or all.
+	// The logic is in WorkspaceImport, but we test the applyConflictResolution function directly
+	// to ensure it works correctly when called.
+
+	graph := resources.NewGraph()
+	graph.AddResource(resources.NewResource("existing", "source", resources.ResourceData{}, nil))
+
+	entity := writer.FormattableEntity{
+		Content:      createTestSpec([]string{"source:existing"}),
+		RelativePath: "sources/existing.yaml",
+	}
+
+	// With keep-local, conflicting entity should be skipped
+	result := applyConflictResolution([]writer.FormattableEntity{entity}, graph, ConflictKeepLocal)
+	assert.Equal(t, 0, len(result))
+
+	// With accept-incoming, entity should be kept
+	result = applyConflictResolution([]writer.FormattableEntity{entity}, graph, ConflictAcceptIncoming)
+	assert.Equal(t, 1, len(result))
+
+	// With keep-both, path should be modified
+	result = applyConflictResolution([]writer.FormattableEntity{entity}, graph, ConflictKeepBoth)
+	require.Equal(t, 1, len(result))
+	assert.Equal(t, "sources/existing-imported.yaml", result[0].RelativePath)
 }

--- a/cli/internal/project/importer/importer_test.go
+++ b/cli/internal/project/importer/importer_test.go
@@ -1,0 +1,250 @@
+package importer
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/rudderlabs/rudder-iac/cli/internal/namer"
+	"github.com/rudderlabs/rudder-iac/cli/internal/project/writer"
+	"github.com/rudderlabs/rudder-iac/cli/internal/resolver"
+	"github.com/rudderlabs/rudder-iac/cli/internal/resources"
+	"github.com/rudderlabs/rudder-iac/cli/internal/resources/state"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockImportProvider implements ImportProvider for testing
+type mockImportProvider struct {
+	managedResources   *resources.RemoteResources
+	unmanagedResources *resources.RemoteResources
+	loadRemoteErr      error
+	loadImportableErr  error
+	mapToStateErr      error
+	formatExportErr    error
+}
+
+func (m *mockImportProvider) LoadResourcesFromRemote(ctx context.Context) (*resources.RemoteResources, error) {
+	if m.loadRemoteErr != nil {
+		return nil, m.loadRemoteErr
+	}
+	return m.managedResources, nil
+}
+
+func (m *mockImportProvider) LoadImportable(ctx context.Context, idNamer namer.Namer) (*resources.RemoteResources, error) {
+	if m.loadImportableErr != nil {
+		return nil, m.loadImportableErr
+	}
+	return m.unmanagedResources, nil
+}
+
+func (m *mockImportProvider) MapRemoteToState(collection *resources.RemoteResources) (*state.State, error) {
+	if m.mapToStateErr != nil {
+		return nil, m.mapToStateErr
+	}
+	return state.EmptyState(), nil
+}
+
+func (m *mockImportProvider) FormatForExport(
+	collection *resources.RemoteResources,
+	idNamer namer.Namer,
+	resolver resolver.ReferenceResolver,
+) ([]writer.FormattableEntity, error) {
+	if m.formatExportErr != nil {
+		return nil, m.formatExportErr
+	}
+	return []writer.FormattableEntity{}, nil
+}
+
+// mockProject implements Project for testing
+type mockProject struct {
+	graph    *resources.Graph
+	location string
+	graphErr error
+}
+
+func (m *mockProject) ResourceGraph() (*resources.Graph, error) {
+	if m.graphErr != nil {
+		return nil, m.graphErr
+	}
+	return m.graph, nil
+}
+
+func (m *mockProject) Location() string {
+	return m.location
+}
+
+func TestFilterOption_Values(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		filter   FilterOption
+		expected string
+	}{
+		{
+			name:     "unmanaged filter value",
+			filter:   FilterUnmanaged,
+			expected: "unmanaged",
+		},
+		{
+			name:     "managed filter value",
+			filter:   FilterManaged,
+			expected: "managed",
+		},
+		{
+			name:     "all filter value",
+			filter:   FilterAll,
+			expected: "all",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, string(tt.filter))
+		})
+	}
+}
+
+func TestLoadResourcesForImport(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	idNamer := namer.NewExternalIdNamer(namer.NewKebabCase())
+
+	// Create test resources
+	managedResource := &resources.RemoteResource{
+		ID:         "remote-1",
+		ExternalID: "managed-resource-1",
+		Data:       map[string]interface{}{"name": "Managed Resource"},
+	}
+
+	unmanagedResource := &resources.RemoteResource{
+		ID:         "remote-2",
+		ExternalID: "unmanaged-resource-1",
+		Data:       map[string]interface{}{"name": "Unmanaged Resource"},
+	}
+
+	managedCollection := resources.NewRemoteResources()
+	managedCollection.Set("test-type", map[string]*resources.RemoteResource{
+		"remote-1": managedResource,
+	})
+
+	unmanagedCollection := resources.NewRemoteResources()
+	unmanagedCollection.Set("test-type-unmanaged", map[string]*resources.RemoteResource{
+		"remote-2": unmanagedResource,
+	})
+
+	tests := []struct {
+		name          string
+		filter        FilterOption
+		provider      *mockImportProvider
+		expectedLen   int
+		expectedError string
+	}{
+		{
+			name:   "FilterUnmanaged returns unmanaged resources",
+			filter: FilterUnmanaged,
+			provider: &mockImportProvider{
+				managedResources:   managedCollection,
+				unmanagedResources: unmanagedCollection,
+			},
+			expectedLen: 1,
+		},
+		{
+			name:   "FilterManaged returns managed resources",
+			filter: FilterManaged,
+			provider: &mockImportProvider{
+				managedResources:   managedCollection,
+				unmanagedResources: unmanagedCollection,
+			},
+			expectedLen: 1,
+		},
+		{
+			name:   "FilterAll returns all resources",
+			filter: FilterAll,
+			provider: &mockImportProvider{
+				managedResources:   managedCollection,
+				unmanagedResources: unmanagedCollection,
+			},
+			expectedLen: 2,
+		},
+		{
+			name:   "FilterUnmanaged with error",
+			filter: FilterUnmanaged,
+			provider: &mockImportProvider{
+				managedResources:   managedCollection,
+				loadImportableErr:  errors.New("failed to load"),
+			},
+			expectedError: "failed to load",
+		},
+		{
+			name:   "FilterAll with unmanaged error",
+			filter: FilterAll,
+			provider: &mockImportProvider{
+				managedResources:   managedCollection,
+				loadImportableErr:  errors.New("failed to load unmanaged"),
+			},
+			expectedError: "loading unmanaged resources",
+		},
+		{
+			name:          "Unknown filter returns error",
+			filter:        FilterOption("invalid"),
+			provider:      &mockImportProvider{},
+			expectedError: "unknown filter option",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := loadResourcesForImport(ctx, tt.provider, tt.filter, idNamer, tt.provider.managedResources)
+
+			if tt.expectedError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedError)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedLen, result.Len())
+		})
+	}
+}
+
+func TestLoadManagedForExport(t *testing.T) {
+	t.Parallel()
+
+	managedResource := &resources.RemoteResource{
+		ID:         "remote-1",
+		ExternalID: "managed-resource-1",
+		Data:       map[string]interface{}{"name": "Test Resource"},
+		Reference:  "#test:managed-resource-1",
+	}
+
+	collection := resources.NewRemoteResources()
+	collection.Set("test-type", map[string]*resources.RemoteResource{
+		"remote-1": managedResource,
+	})
+
+	result, err := loadManagedForExport(collection)
+	require.NoError(t, err)
+
+	// The function should return the same collection
+	assert.Equal(t, collection, result)
+	assert.Equal(t, 1, result.Len())
+
+	// Verify the resource is accessible
+	resource, found := result.GetByID("test-type", "remote-1")
+	require.True(t, found)
+	assert.Equal(t, "managed-resource-1", resource.ExternalID)
+}
+
+func TestImportOptions_DefaultFilter(t *testing.T) {
+	t.Parallel()
+
+	opts := ImportOptions{}
+	assert.Equal(t, FilterOption(""), opts.Filter)
+
+	opts = ImportOptions{Filter: FilterManaged}
+	assert.Equal(t, FilterManaged, opts.Filter)
+}

--- a/cli/internal/provider/provider_import_test.go
+++ b/cli/internal/provider/provider_import_test.go
@@ -42,7 +42,7 @@ func TestExampleImport(t *testing.T) {
 	_, err = b.CreateBook("Book B", wB.ID, "")
 	require.NoError(t, err)
 
-	err = importer.WorkspaceImport(context.Background(), proj, provider)
+	err = importer.WorkspaceImport(context.Background(), proj, provider, importer.ImportOptions{})
 	require.NoError(t, err, "Failed to import workspace")
 
 	assertDirContents(t, testDir)


### PR DESCRIPTION
## 🔗 Ticket

<!-- No ticket linked - internal improvement -->

---

## Summary

Adds new flags to the `import workspace` command that give users more control over which resources are imported and how conflicts are resolved. These features are gated behind the `importFilter` experimental flag.

---

## Changes

- Add `--filter` flag with options: `unmanaged` (default), `managed`, `all`
  - `unmanaged`: Import only resources without external IDs (existing behavior)
  - `managed`: Import only resources with external IDs (for backup/sync purposes)
  - `all`: Import both managed and unmanaged resources
- Add `--on-conflict` flag for managed imports: `keep-local` (default), `accept-incoming`, `keep-both`
  - `keep-local`: Skip resources that already exist locally
  - `accept-incoming`: Overwrite local files with remote version
  - `keep-both`: Create new file with `-imported` suffix
- Add `importFilter` experimental flag to gate the new functionality
- Add comprehensive unit tests for all new functionality

---

## Testing

- Unit tests added for filter options, conflict resolution logic, and edge cases
- `make lint` passes
- `make test` passes

---

## Risk / Impact

**Low**

- Features are behind experimental flag, disabled by default
- Default behavior unchanged (filter=unmanaged, on-conflict=keep-local)

---

## Checklist

- [ ] Ticket linked
- [x] Tests added/updated
- [x] No breaking changes (or documented)

---
