### PR TITLE
feat(apply): add --no-delete and --provider flags for selective apply

### DIFF
--- a/cli/internal/cmd/project/apply/apply.go
+++ b/cli/internal/cmd/project/apply/apply.go
@@ -3,6 +3,8 @@ package apply
 import (
 	"context"
 	"fmt"
+	"slices"
+	"strings"
 
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/rudderlabs/rudder-iac/cli/internal/app"
@@ -10,6 +12,7 @@ import (
 	"github.com/rudderlabs/rudder-iac/cli/internal/config"
 	"github.com/rudderlabs/rudder-iac/cli/internal/logger"
 	"github.com/rudderlabs/rudder-iac/cli/internal/project"
+	"github.com/rudderlabs/rudder-iac/cli/internal/provider"
 	"github.com/rudderlabs/rudder-iac/cli/internal/syncer"
 	"github.com/rudderlabs/rudder-iac/cli/internal/ui"
 	"github.com/spf13/cobra"
@@ -24,12 +27,14 @@ var (
 
 func NewCmdApply() *cobra.Command {
 	var (
-		deps     app.Deps
-		p        project.Project
-		err      error
-		location string
-		dryRun   bool
-		confirm  bool
+		deps      app.Deps
+		p         project.Project
+		err       error
+		location  string
+		dryRun    bool
+		confirm   bool
+		noDelete  bool
+		providers []string
 	)
 
 	cmd := &cobra.Command{
@@ -39,11 +44,16 @@ func NewCmdApply() *cobra.Command {
 			Applies the project configuration changes to the RudderStack workspace associated with your access token.
 			This includes creating, updating, or deleting resources based on
 			the differences between local configuration and the workspace resources.
+
+			Use --no-delete to skip deletion of resources that are no longer in the local configuration.
+			Use --provider to apply changes only for specific providers (e.g., retl, eventstream, datacatalog).
 		`),
 		Example: heredoc.Doc(`
 			$ rudder-cli apply --location </path/to/dir or file>
 			$ rudder-cli apply --location </path/to/dir or file> --dry-run
 			$ rudder-cli apply --location </path/to/dir or file> --confirm=false
+			$ rudder-cli apply --no-delete
+			$ rudder-cli apply --provider retl --provider eventstream
 		`),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			deps, err = app.NewDeps()
@@ -65,7 +75,7 @@ func NewCmdApply() *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			applyLog.Debug("apply", "location", location, "dryRun", dryRun, "confirm", confirm)
+			applyLog.Debug("apply", "location", location, "dryRun", dryRun, "confirm", confirm, "noDelete", noDelete, "providers", providers)
 			applyLog.Debug("identifying changes for the upstream catalog")
 
 			defer func() {
@@ -73,6 +83,8 @@ func NewCmdApply() *cobra.Command {
 					{K: "location", V: location},
 					{K: "dryRun", V: dryRun},
 					{K: "confirm", V: confirm},
+					{K: "noDelete", V: noDelete},
+					{K: "providers", V: strings.Join(providers, ",")},
 				}...)
 			}()
 
@@ -91,6 +103,29 @@ func NewCmdApply() *cobra.Command {
 				syncer.WithDryRun(dryRun),
 				syncer.WithAskConfirmation(confirm),
 				syncer.WithReporter(app.SyncReporter()),
+				syncer.WithSkipDeletes(noDelete),
+			}
+
+			// Filter by provider if specified
+			if len(providers) > 0 {
+				cp, ok := deps.CompositeProvider().(*provider.CompositeProvider)
+				if !ok {
+					return fmt.Errorf("provider filtering requires composite provider")
+				}
+
+				// Validate provider names
+				validNames := cp.ProviderNames()
+				for _, name := range providers {
+					if !slices.Contains(validNames, name) {
+						return fmt.Errorf("unknown provider: %s (valid providers: %s)", name, strings.Join(validNames, ", "))
+					}
+				}
+
+				resourceTypes, err := cp.ResourceTypesForProviders(providers)
+				if err != nil {
+					return fmt.Errorf("getting resource types for providers: %w", err)
+				}
+				options = append(options, syncer.WithResourceTypes(resourceTypes))
 			}
 
 			if config.GetConfig().ExperimentalFlags.ConcurrentSyncs {
@@ -122,6 +157,8 @@ func NewCmdApply() *cobra.Command {
 	cmd.Flags().StringVarP(&location, "location", "l", ".", "Path to the directory containing the project files or a specific file")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Only show the changes without applying them")
 	cmd.Flags().BoolVar(&confirm, "confirm", true, "Confirm changes before applying them")
+	cmd.Flags().BoolVar(&noDelete, "no-delete", false, "Skip deletion of resources (only create and update)")
+	cmd.Flags().StringArrayVar(&providers, "provider", nil, "Only apply changes for specified providers (can be repeated)")
 
 	return cmd
 }

--- a/cli/internal/cmd/project/apply/apply.go
+++ b/cli/internal/cmd/project/apply/apply.go
@@ -56,6 +56,18 @@ func NewCmdApply() *cobra.Command {
 			$ rudder-cli apply --provider retl --provider eventstream
 		`),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
+			cfg := config.GetConfig()
+
+			// Check if experimental flag is enabled for non-default options
+			if !cfg.ExperimentalFlags.ApplyOptions {
+				if noDelete {
+					return fmt.Errorf("--no-delete flag requires experimental feature 'applyOptions' to be enabled. Run: rudder-cli experimental enable applyOptions")
+				}
+				if len(providers) > 0 {
+					return fmt.Errorf("--provider flag requires experimental feature 'applyOptions' to be enabled. Run: rudder-cli experimental enable applyOptions")
+				}
+			}
+
 			deps, err = app.NewDeps()
 			if err != nil {
 				return fmt.Errorf("initialising dependencies: %w", err)

--- a/cli/internal/config/experimental.go
+++ b/cli/internal/config/experimental.go
@@ -20,6 +20,8 @@ type ExperimentalConfig struct {
 	Transformations bool `mapstructure:"transformations"`
 	// DataGraph enables data graph operations (sync, validate, import)
 	DataGraph bool `mapstructure:"dataGraph"`
+	// ApplyOptions enables --no-delete and --provider flags for apply command
+	ApplyOptions bool `mapstructure:"applyOptions"`
 }
 
 // getAvailableExperimentalFlags returns information about all available experimental flags

--- a/cli/internal/provider/composite.go
+++ b/cli/internal/provider/composite.go
@@ -394,5 +394,24 @@ func (p *CompositeProvider) SemanticRules() []rules.Rule {
 	return allRules
 }
 
+// ProviderNames returns the names of all registered providers
+func (p *CompositeProvider) ProviderNames() []string {
+	return maps.Keys(p.Providers)
+}
+
+// ResourceTypesForProviders returns all resource types supported by the specified
+// provider names. If a provider name is not found, it returns an error.
+func (p *CompositeProvider) ResourceTypesForProviders(names []string) ([]string, error) {
+	var types []string
+	for _, name := range names {
+		provider, ok := p.Providers[name]
+		if !ok {
+			return nil, fmt.Errorf("unknown provider: %s", name)
+		}
+		types = append(types, provider.SupportedTypes()...)
+	}
+	return types, nil
+}
+
 // Compile-time verification that CompositeProvider implements RuleProvider and SpecFactoryProvider
 var _ RuleProvider = (*CompositeProvider)(nil)

--- a/cli/internal/provider/composite_test.go
+++ b/cli/internal/provider/composite_test.go
@@ -337,6 +337,108 @@ func TestCompositeProvider_ResourceGraph(t *testing.T) {
 	}
 }
 
+func TestCompositeProvider_ProviderNames(t *testing.T) {
+	tests := []struct {
+		name      string
+		providers map[string]provider.Provider
+		expected  []string
+	}{
+		{
+			name: "single provider",
+			providers: map[string]provider.Provider{
+				"p1": testutils.NewMockProvider([]string{"kindA"}, []string{"typeA"}),
+			},
+			expected: []string{"p1"},
+		},
+		{
+			name: "multiple providers",
+			providers: map[string]provider.Provider{
+				"retl":        testutils.NewMockProvider([]string{"kindA"}, []string{"typeA"}),
+				"eventstream": testutils.NewMockProvider([]string{"kindB"}, []string{"typeB"}),
+				"datacatalog": testutils.NewMockProvider([]string{"kindC"}, []string{"typeC"}),
+			},
+			expected: []string{"retl", "eventstream", "datacatalog"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cp, err := provider.NewCompositeProvider(tt.providers)
+			assert.NoError(t, err)
+			assert.NotNil(t, cp)
+
+			composite := cp.(*provider.CompositeProvider)
+			actual := composite.ProviderNames()
+			sort.Strings(actual)
+			sort.Strings(tt.expected)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
+func TestCompositeProvider_ResourceTypesForProviders(t *testing.T) {
+	p1 := testutils.NewMockProvider([]string{"kindA"}, []string{"typeA1", "typeA2"})
+	p2 := testutils.NewMockProvider([]string{"kindB"}, []string{"typeB1"})
+	p3 := testutils.NewMockProvider([]string{"kindC"}, []string{"typeC1", "typeC2", "typeC3"})
+
+	cp, err := provider.NewCompositeProvider(map[string]provider.Provider{
+		"providerA": p1,
+		"providerB": p2,
+		"providerC": p3,
+	})
+	assert.NoError(t, err)
+	composite := cp.(*provider.CompositeProvider)
+
+	tests := []struct {
+		name        string
+		providers   []string
+		expected    []string
+		expectedErr string
+	}{
+		{
+			name:      "single provider",
+			providers: []string{"providerA"},
+			expected:  []string{"typeA1", "typeA2"},
+		},
+		{
+			name:      "multiple providers",
+			providers: []string{"providerA", "providerB"},
+			expected:  []string{"typeA1", "typeA2", "typeB1"},
+		},
+		{
+			name:      "all providers",
+			providers: []string{"providerA", "providerB", "providerC"},
+			expected:  []string{"typeA1", "typeA2", "typeB1", "typeC1", "typeC2", "typeC3"},
+		},
+		{
+			name:        "unknown provider returns error",
+			providers:   []string{"providerA", "unknownProvider"},
+			expectedErr: "unknown provider: unknownProvider",
+		},
+		{
+			name:     "empty provider list returns empty types",
+			providers: []string{},
+			expected:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual, err := composite.ResourceTypesForProviders(tt.providers)
+
+			if tt.expectedErr != "" {
+				assert.EqualError(t, err, tt.expectedErr)
+				assert.Nil(t, actual)
+			} else {
+				assert.NoError(t, err)
+				sort.Strings(actual)
+				sort.Strings(tt.expected)
+				assert.Equal(t, tt.expected, actual)
+			}
+		})
+	}
+}
+
 func TestCompositeProvider_ResourceOperations(t *testing.T) {
 	ctx := context.Background()
 	resDataA := resources.ResourceData{"key": "valA"}

--- a/cli/internal/syncer/planner/planner.go
+++ b/cli/internal/syncer/planner/planner.go
@@ -11,6 +11,16 @@ import (
 
 type Planner struct {
 	workspaceId string
+	options     PlanOptions
+}
+
+// PlanOptions configures the planning behavior
+type PlanOptions struct {
+	// SkipDeletes excludes delete operations from the plan
+	SkipDeletes bool
+	// ResourceTypes filters operations to only include these resource types.
+	// If empty, all resource types are included.
+	ResourceTypes []string
 }
 
 type OperationType int
@@ -51,9 +61,32 @@ type Plan struct {
 	Operations []*Operation
 }
 
-func New(workspaceId string) *Planner {
+type PlanOption func(*PlanOptions)
+
+// WithSkipDeletes configures the planner to exclude delete operations
+func WithSkipDeletes(skip bool) PlanOption {
+	return func(o *PlanOptions) {
+		o.SkipDeletes = skip
+	}
+}
+
+// WithResourceTypes configures the planner to only include operations
+// for the specified resource types
+func WithResourceTypes(types []string) PlanOption {
+	return func(o *PlanOptions) {
+		o.ResourceTypes = types
+	}
+}
+
+func New(workspaceId string, opts ...PlanOption) *Planner {
+	options := PlanOptions{}
+	for _, opt := range opts {
+		opt(&options)
+	}
+
 	return &Planner{
 		workspaceId: workspaceId,
+		options:     options,
 	}
 }
 
@@ -67,14 +100,18 @@ func (p *Planner) Plan(source, target *resources.Graph) *Plan {
 	sortedImportable := sortByDependencies(diff.ImportableResources, target)
 	for _, urn := range sortedImportable {
 		resource, _ := target.GetResource(urn)
-		plan.Operations = append(plan.Operations, &Operation{Type: Import, Resource: resource})
+		if p.shouldIncludeResource(resource) {
+			plan.Operations = append(plan.Operations, &Operation{Type: Import, Resource: resource})
+		}
 	}
 
 	// Handle new resources (will be created)
 	sortedNew := sortByDependencies(diff.NewResources, target)
 	for _, urn := range sortedNew {
 		resource, _ := target.GetResource(urn)
-		plan.Operations = append(plan.Operations, &Operation{Type: Create, Resource: resource})
+		if p.shouldIncludeResource(resource) {
+			plan.Operations = append(plan.Operations, &Operation{Type: Create, Resource: resource})
+		}
 	}
 
 	// Handle updated resources
@@ -85,18 +122,39 @@ func (p *Planner) Plan(source, target *resources.Graph) *Plan {
 	sortedUpdated := sortByDependencies(updatedURNs, target)
 	for _, urn := range sortedUpdated {
 		resource, _ := target.GetResource(urn)
-		plan.Operations = append(plan.Operations, &Operation{Type: Update, Resource: resource})
+		if p.shouldIncludeResource(resource) {
+			plan.Operations = append(plan.Operations, &Operation{Type: Update, Resource: resource})
+		}
 	}
 
-	// Handle deleted resources
-	sortedDeleted := sortByDependencies(diff.RemovedResources, source)
-	slices.Reverse(sortedDeleted)
-	for _, urn := range sortedDeleted {
-		resource, _ := source.GetResource(urn)
-		plan.Operations = append(plan.Operations, &Operation{Type: Delete, Resource: resource})
+	// Handle deleted resources (skip if SkipDeletes is enabled)
+	if !p.options.SkipDeletes {
+		sortedDeleted := sortByDependencies(diff.RemovedResources, source)
+		slices.Reverse(sortedDeleted)
+		for _, urn := range sortedDeleted {
+			resource, _ := source.GetResource(urn)
+			if p.shouldIncludeResource(resource) {
+				plan.Operations = append(plan.Operations, &Operation{Type: Delete, Resource: resource})
+			}
+		}
 	}
 
 	return plan
+}
+
+// shouldIncludeResource checks if a resource should be included based on the
+// configured resource type filter
+func (p *Planner) shouldIncludeResource(resource *resources.Resource) bool {
+	if len(p.options.ResourceTypes) == 0 {
+		return true
+	}
+
+	for _, t := range p.options.ResourceTypes {
+		if resource.Type() == t {
+			return true
+		}
+	}
+	return false
 }
 
 // sortByDependencies returns resources ordered by their dependencies,

--- a/cli/internal/syncer/planner/planner_test.go
+++ b/cli/internal/syncer/planner/planner_test.go
@@ -162,3 +162,187 @@ func newResource(id string, name string, dependency *resources.PropertyRef, opts
 	}
 	return resources.NewResource(id, "some-type", data, []string{}, opts...)
 }
+
+func newResourceWithType(id string, name string, resourceType string) *resources.Resource {
+	return resources.NewResource(id, resourceType, resources.ResourceData{"name": name}, []string{})
+}
+
+func TestPlanner_SkipDeletes(t *testing.T) {
+	sourceToBeDeleted := newResource("res0", "source resource 0", nil)
+	sourceToBeUpdated := newResource("res1", "source resource 1", nil)
+	targetToBeUpdated := newResource("res1", "target resource 1", nil)
+	targetToBeCreated := newResource("res2", "target resource 2", nil)
+
+	tests := []struct {
+		name        string
+		skipDeletes bool
+		source      *resources.Graph
+		target      *resources.Graph
+		expected    []*planner.Operation
+	}{
+		{
+			name:        "with skip deletes enabled, delete operations are excluded",
+			skipDeletes: true,
+			source: newGraphWithResources(
+				sourceToBeDeleted,
+				sourceToBeUpdated,
+			),
+			target: newGraphWithResources(
+				targetToBeUpdated,
+				targetToBeCreated,
+			),
+			expected: []*planner.Operation{
+				{Type: planner.Create, Resource: targetToBeCreated},
+				{Type: planner.Update, Resource: targetToBeUpdated},
+			},
+		},
+		{
+			name:        "with skip deletes disabled, delete operations are included",
+			skipDeletes: false,
+			source: newGraphWithResources(
+				sourceToBeDeleted,
+				sourceToBeUpdated,
+			),
+			target: newGraphWithResources(
+				targetToBeUpdated,
+				targetToBeCreated,
+			),
+			expected: []*planner.Operation{
+				{Type: planner.Create, Resource: targetToBeCreated},
+				{Type: planner.Update, Resource: targetToBeUpdated},
+				{Type: planner.Delete, Resource: sourceToBeDeleted},
+			},
+		},
+		{
+			name:        "skip deletes with only deletes results in empty plan",
+			skipDeletes: true,
+			source: newGraphWithResources(
+				sourceToBeDeleted,
+			),
+			target:   newGraph(),
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := planner.New("workspace-id", planner.WithSkipDeletes(tt.skipDeletes))
+			plan := p.Plan(tt.source, tt.target)
+			assert.Equal(t, tt.expected, plan.Operations)
+		})
+	}
+}
+
+func TestPlanner_ResourceTypeFilter(t *testing.T) {
+	// Use resources with identical names in source and target to avoid update operations
+	sourceTypeA := newResourceWithType("res0", "resource 0", "type-a")
+	sourceTypeB := newResourceWithType("res1", "resource 1", "type-b")
+	targetTypeA := newResourceWithType("res0", "resource 0", "type-a")   // Same as source - no update
+	targetTypeB := newResourceWithType("res1", "resource 1", "type-b")   // Same as source - no update
+	targetTypeANew := newResourceWithType("res2", "resource 2", "type-a")
+	targetTypeBNew := newResourceWithType("res3", "resource 3", "type-b")
+
+	tests := []struct {
+		name          string
+		resourceTypes []string
+		source        *resources.Graph
+		target        *resources.Graph
+		expected      []*planner.Operation
+	}{
+		{
+			name:          "filter to single type includes only that type",
+			resourceTypes: []string{"type-a"},
+			source: newGraphWithResources(
+				sourceTypeA,
+				sourceTypeB,
+			),
+			target: newGraphWithResources(
+				targetTypeA,
+				targetTypeANew,
+			),
+			expected: []*planner.Operation{
+				{Type: planner.Create, Resource: targetTypeANew},
+			},
+		},
+		{
+			name:          "filter to multiple types includes all specified types",
+			resourceTypes: []string{"type-a", "type-b"},
+			source: newGraphWithResources(
+				sourceTypeA,
+				sourceTypeB,
+			),
+			target: newGraphWithResources(
+				targetTypeA,
+				targetTypeB,
+				targetTypeANew,
+				targetTypeBNew,
+			),
+			expected: []*planner.Operation{
+				{Type: planner.Create, Resource: targetTypeANew},
+				{Type: planner.Create, Resource: targetTypeBNew},
+			},
+		},
+		{
+			name:          "empty filter includes all types",
+			resourceTypes: []string{},
+			source: newGraphWithResources(
+				sourceTypeA,
+				sourceTypeB,
+			),
+			target: newGraphWithResources(
+				targetTypeA,
+				targetTypeB,
+				targetTypeANew,
+				targetTypeBNew,
+			),
+			expected: []*planner.Operation{
+				{Type: planner.Create, Resource: targetTypeANew},
+				{Type: planner.Create, Resource: targetTypeBNew},
+			},
+		},
+		{
+			name:          "filter excludes deletes for non-matching types",
+			resourceTypes: []string{"type-a"},
+			source: newGraphWithResources(
+				sourceTypeA,
+				sourceTypeB,
+			),
+			target: newGraph(),
+			expected: []*planner.Operation{
+				{Type: planner.Delete, Resource: sourceTypeA},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := planner.New("workspace-id", planner.WithResourceTypes(tt.resourceTypes))
+			plan := p.Plan(tt.source, tt.target)
+			assert.Equal(t, tt.expected, plan.Operations)
+		})
+	}
+}
+
+func TestPlanner_CombinedOptions(t *testing.T) {
+	sourceTypeA := newResourceWithType("res0", "source type-a", "type-a")
+	sourceTypeB := newResourceWithType("res1", "source type-b", "type-b")
+	targetTypeANew := newResourceWithType("res2", "target type-a new", "type-a")
+
+	t.Run("skip deletes with resource type filter", func(t *testing.T) {
+		p := planner.New("workspace-id",
+			planner.WithSkipDeletes(true),
+			planner.WithResourceTypes([]string{"type-a"}),
+		)
+
+		source := newGraphWithResources(sourceTypeA, sourceTypeB)
+		target := newGraphWithResources(targetTypeANew)
+
+		plan := p.Plan(source, target)
+
+		// Should only create type-a, no deletes even though sourceTypeA is removed
+		expected := []*planner.Operation{
+			{Type: planner.Create, Resource: targetTypeANew},
+		}
+		assert.Equal(t, expected, plan.Operations)
+	})
+}

--- a/cli/internal/syncer/syncer.go
+++ b/cli/internal/syncer/syncer.go
@@ -23,6 +23,7 @@ type ProjectSyncer struct {
 	concurrency     int
 	dryRun          bool
 	askConfirmation bool
+	plannerOptions  []planner.PlanOption
 }
 
 type SyncProvider interface {
@@ -97,6 +98,27 @@ func WithAskConfirmation(askConfirmation bool) Option {
 	}
 }
 
+// WithSkipDeletes configures the syncer to skip delete operations
+func WithSkipDeletes(skip bool) Option {
+	return func(s *ProjectSyncer) error {
+		if skip {
+			s.plannerOptions = append(s.plannerOptions, planner.WithSkipDeletes(true))
+		}
+		return nil
+	}
+}
+
+// WithResourceTypes configures the syncer to only apply operations for
+// the specified resource types
+func WithResourceTypes(types []string) Option {
+	return func(s *ProjectSyncer) error {
+		if len(types) > 0 {
+			s.plannerOptions = append(s.plannerOptions, planner.WithResourceTypes(types))
+		}
+		return nil
+	}
+}
+
 type SyncReporter interface {
 	ReportPlan(plan *planner.Plan)
 	AskConfirmation() (bool, error)
@@ -133,7 +155,7 @@ func (s *ProjectSyncer) apply(ctx context.Context, target *resources.Graph, cont
 	}
 	source := StateToGraph(state)
 
-	p := planner.New(s.workspace.ID)
+	p := planner.New(s.workspace.ID, s.plannerOptions...)
 	plan := p.Plan(source, target)
 
 	spinner.Stop()


### PR DESCRIPTION
## 🔗 Ticket

<!-- No ticket linked - internal improvement -->

---

## Summary

Adds new flags to the `apply` command that give users more control over which operations are executed and which providers are affected. These features are gated behind the `applyOptions` experimental flag.

---

## Changes

- Add `--no-delete` flag to skip delete operations during apply
  - Allows users to add new resources without accidentally deleting existing ones
  - Useful for incremental infrastructure buildout
- Add `--provider` flag to filter operations by provider
  - Can be repeated for multiple providers: `--provider retl --provider eventstream`
  - Validates provider names and shows available options on error
- Add `applyOptions` experimental flag to gate the new functionality
- Add `ProviderNames()` and `ResourceTypesForProviders()` methods to CompositeProvider
- Add `PlanOptions` with `SkipDeletes` and `ResourceTypes` filtering in planner
- Add comprehensive unit tests for all new functionality

---

## Testing

- Unit tests added for planner filtering, provider name resolution, and edge cases
- `make lint` passes
- `make test` passes

---

## Risk / Impact

**Low**

- Features are behind experimental flag, disabled by default
- Default behavior unchanged (all operations, all providers)

---

## Checklist

- [ ] Ticket linked
- [x] Tests added/updated
- [x] No breaking changes (or documented)
