### PR TITLE
fix(transformations): resolve telemetry tracking bug and apply convention fixes

### DIFF
--- a/cli/internal/cmd/transformations/test/test.go
+++ b/cli/internal/cmd/transformations/test/test.go
@@ -33,7 +33,6 @@ func NewCmdTest() *cobra.Command {
 	var (
 		deps     app.Deps
 		p        project.Project
-		err      error
 		location string
 		all      bool
 		modified bool
@@ -81,6 +80,7 @@ func NewCmdTest() *cobra.Command {
 			}
 
 			// Initialize dependencies
+			var err error
 			deps, err = app.NewDeps()
 			if err != nil {
 				return fmt.Errorf("initialising dependencies: %w", err)
@@ -97,6 +97,7 @@ func NewCmdTest() *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			var err error
 			defer func() {
 				telemetry.TrackCommand("transformations test", err, []telemetry.KV{
 					{K: "location", V: location},
@@ -167,7 +168,8 @@ func NewCmdTest() *cobra.Command {
 			displayer.Display(results)
 
 			if results.HasFailures() {
-				return ErrTestsFailed
+				err = ErrTestsFailed
+				return err
 			}
 
 			return nil

--- a/cli/internal/providers/transformations/testorchestrator/default_events.go
+++ b/cli/internal/providers/transformations/testorchestrator/default_events.go
@@ -16,7 +16,9 @@ var defaultEventsJSON []byte
 // Each call returns a new map to prevent mutation of shared data.
 func GetDefaultEvents() map[string]any {
 	var events map[string]any
-	json.Unmarshal(defaultEventsJSON, &events)
+	if err := json.Unmarshal(defaultEventsJSON, &events); err != nil {
+		panic(fmt.Sprintf("unmarshaling embedded default events: %v", err))
+	}
 	return events
 }
 

--- a/cli/internal/providers/transformations/testorchestrator/inputs.go
+++ b/cli/internal/providers/transformations/testorchestrator/inputs.go
@@ -12,15 +12,15 @@ import (
 	"github.com/rudderlabs/rudder-iac/cli/internal/providers/transformations/model"
 )
 
-var (
-	JsonExt        = ".json"
-	NoTestsDefined = "No test suites defined for transformation, using default events. Use `rudder-cli transformations test default-events--show` to view default events."
+const (
+	jsonExt        = ".json"
+	noTestsDefined = "No test suites defined for transformation, using default events. Use `rudder-cli transformations show-default-events` to view default events."
 )
 
 // ResolveTestDefinitions resolves test cases for a transformation.
 func ResolveTestDefinitions(transformation *model.TransformationResource) ([]*transformations.TestDefinition, error) {
 	if len(transformation.Tests) == 0 {
-		testLogger.Warn(NoTestsDefined, "transformationID", transformation.ID)
+		testLogger.Warn(noTestsDefined, "transformationID", transformation.ID)
 		return defaultTestDefinitions()
 	}
 
@@ -35,7 +35,7 @@ func ResolveTestDefinitions(transformation *model.TransformationResource) ([]*tr
 	}
 
 	if len(allTestDefs) == 0 {
-		testLogger.Warn(NoTestsDefined, "transformationID", transformation.ID)
+		testLogger.Warn(noTestsDefined, "transformationID", transformation.ID)
 		return defaultTestDefinitions()
 	}
 
@@ -154,7 +154,7 @@ func listJSONFiles(dir string) (map[string]string, error) {
 		}
 
 		name := entry.Name()
-		if strings.HasSuffix(strings.ToLower(name), JsonExt) {
+		if strings.HasSuffix(strings.ToLower(name), jsonExt) {
 			files[name] = filepath.Join(dir, name)
 		}
 	}

--- a/cli/internal/providers/transformations/testorchestrator/planner.go
+++ b/cli/internal/providers/transformations/testorchestrator/planner.go
@@ -1,7 +1,6 @@
 package testorchestrator
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/samber/lo"
@@ -56,7 +55,7 @@ func NewPlanner(graph *resources.Graph) *Planner {
 }
 
 // BuildPlan determines which transformations to test based on mode and remote graph
-func (p *Planner) BuildPlan(ctx context.Context, remoteGraph *resources.Graph, mode Mode, targetID string, workspaceID string) (*TestPlan, error) {
+func (p *Planner) BuildPlan(remoteGraph *resources.Graph, mode Mode, targetID string, workspaceID string) (*TestPlan, error) {
 	var (
 		transformations = p.graph.ResourcesByType(ttypes.TransformationResourceType)
 		libraries       = p.graph.ResourcesByType(ttypes.LibraryResourceType)

--- a/cli/internal/providers/transformations/testorchestrator/planner_test.go
+++ b/cli/internal/providers/transformations/testorchestrator/planner_test.go
@@ -1,7 +1,6 @@
 package testorchestrator
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -19,14 +18,14 @@ func TestBuildPlan_ModeAll(t *testing.T) {
 		local.AddResource(newTransResource("t1", "Trans 1", "code-v1"))
 		local.AddResource(newTransResource("t2", "Trans 2", "code-v1"))
 
-		plan, err := NewPlanner(local).BuildPlan(context.Background(), resources.NewGraph(), ModeAll, "", "ws-1")
+		plan, err := NewPlanner(local).BuildPlan(resources.NewGraph(), ModeAll, "", "ws-1")
 
 		require.NoError(t, err)
 		assert.Len(t, plan.TestUnits, 2)
 	})
 
 	t.Run("empty graph produces empty plan", func(t *testing.T) {
-		plan, err := NewPlanner(resources.NewGraph()).BuildPlan(context.Background(), resources.NewGraph(), ModeAll, "", "ws-1")
+		plan, err := NewPlanner(resources.NewGraph()).BuildPlan(resources.NewGraph(), ModeAll, "", "ws-1")
 
 		require.NoError(t, err)
 		assert.Empty(t, plan.TestUnits)
@@ -41,7 +40,7 @@ func TestBuildPlan_ModeAll(t *testing.T) {
 		local.AddResource(trans)
 		local.AddDependency(trans.URN(), lib.URN())
 
-		plan, err := NewPlanner(local).BuildPlan(context.Background(), resources.NewGraph(), ModeAll, "", "ws-1")
+		plan, err := NewPlanner(local).BuildPlan(resources.NewGraph(), ModeAll, "", "ws-1")
 
 		require.NoError(t, err)
 		assert.Len(t, plan.TestUnits, 1)
@@ -52,7 +51,7 @@ func TestBuildPlan_ModeAll(t *testing.T) {
 		local := resources.NewGraph()
 		local.AddResource(newLibResource("lib-1", "Lib", "code-v1"))
 
-		plan, err := NewPlanner(local).BuildPlan(context.Background(), resources.NewGraph(), ModeAll, "", "ws-1")
+		plan, err := NewPlanner(local).BuildPlan(resources.NewGraph(), ModeAll, "", "ws-1")
 
 		require.NoError(t, err)
 		assert.Empty(t, plan.TestUnits)
@@ -71,7 +70,7 @@ func TestBuildPlan_ModeAll(t *testing.T) {
 		local.AddDependency(trans.URN(), lib1.URN())
 		local.AddDependency(trans.URN(), lib2.URN())
 
-		plan, err := NewPlanner(local).BuildPlan(context.Background(), resources.NewGraph(), ModeAll, "", "ws-1")
+		plan, err := NewPlanner(local).BuildPlan(resources.NewGraph(), ModeAll, "", "ws-1")
 
 		require.NoError(t, err)
 		require.Len(t, plan.TestUnits, 1)
@@ -82,7 +81,7 @@ func TestBuildPlan_ModeAll(t *testing.T) {
 		local := resources.NewGraph()
 		local.AddResource(newTransResource("t1", "Trans", "code-v1"))
 
-		plan, err := NewPlanner(local).BuildPlan(context.Background(), resources.NewGraph(), ModeAll, "", "ws-1")
+		plan, err := NewPlanner(local).BuildPlan(resources.NewGraph(), ModeAll, "", "ws-1")
 
 		require.NoError(t, err)
 		require.Len(t, plan.TestUnits, 1)
@@ -94,7 +93,7 @@ func TestBuildPlan_ModeAll(t *testing.T) {
 		remote := resources.NewGraph()
 		remote.AddResource(newTransResource("t1", "Trans", "same-code"))
 
-		plan, err := NewPlanner(local).BuildPlan(context.Background(), remote, ModeAll, "", "ws-1")
+		plan, err := NewPlanner(local).BuildPlan(remote, ModeAll, "", "ws-1")
 
 		require.NoError(t, err)
 		require.Len(t, plan.TestUnits, 1)
@@ -106,7 +105,7 @@ func TestBuildPlan_ModeAll(t *testing.T) {
 		remote := resources.NewGraph()
 		remote.AddResource(newTransResource("t1", "Trans", "code-v1"))
 
-		plan, err := NewPlanner(local).BuildPlan(context.Background(), remote, ModeAll, "", "ws-1")
+		plan, err := NewPlanner(local).BuildPlan(remote, ModeAll, "", "ws-1")
 
 		require.NoError(t, err)
 		require.Len(t, plan.TestUnits, 1)
@@ -124,7 +123,7 @@ func TestBuildPlan_ModeModified(t *testing.T) {
 		remote := resources.NewGraph()
 		remote.AddResource(newTransResource("t1", "Trans 1", "code-v1"))
 
-		plan, err := NewPlanner(local).BuildPlan(context.Background(), remote, ModeModified, "", "ws-1")
+		plan, err := NewPlanner(local).BuildPlan(remote, ModeModified, "", "ws-1")
 
 		require.NoError(t, err)
 		require.Len(t, plan.TestUnits, 1)
@@ -137,7 +136,7 @@ func TestBuildPlan_ModeModified(t *testing.T) {
 		remote := resources.NewGraph()
 		remote.AddResource(newTransResource("t1", "Trans", "code-v1"))
 
-		plan, err := NewPlanner(local).BuildPlan(context.Background(), remote, ModeModified, "", "ws-1")
+		plan, err := NewPlanner(local).BuildPlan(remote, ModeModified, "", "ws-1")
 
 		require.NoError(t, err)
 		assert.Empty(t, plan.TestUnits)
@@ -158,7 +157,7 @@ func TestBuildPlan_ModeModified(t *testing.T) {
 		remote.AddResource(remoteTrans)
 		remote.AddDependency(remoteTrans.URN(), remoteLib.URN())
 
-		plan, err := NewPlanner(local).BuildPlan(context.Background(), remote, ModeModified, "", "ws-1")
+		plan, err := NewPlanner(local).BuildPlan(remote, ModeModified, "", "ws-1")
 
 		require.NoError(t, err)
 		require.Len(t, plan.TestUnits, 1)
@@ -171,7 +170,7 @@ func TestBuildPlan_ModeModified(t *testing.T) {
 		remote := resources.NewGraph()
 		remote.AddResource(newLibResource("lib-1", "Lib", "code-v1"))
 
-		plan, err := NewPlanner(local).BuildPlan(context.Background(), remote, ModeModified, "", "ws-1")
+		plan, err := NewPlanner(local).BuildPlan(remote, ModeModified, "", "ws-1")
 
 		require.NoError(t, err)
 		assert.Empty(t, plan.TestUnits)
@@ -185,7 +184,7 @@ func TestBuildPlan_ModeModified(t *testing.T) {
 		remote := resources.NewGraph()
 		remote.AddResource(newTransResource("t1", "Trans", "same-code"))
 
-		plan, err := NewPlanner(local).BuildPlan(context.Background(), remote, ModeModified, "", "ws-1")
+		plan, err := NewPlanner(local).BuildPlan(remote, ModeModified, "", "ws-1")
 
 		require.NoError(t, err)
 		assert.Empty(t, plan.TestUnits)
@@ -201,7 +200,7 @@ func TestBuildPlan_ModeSingle(t *testing.T) {
 		local.AddResource(newTransResource("t1", "Trans 1", "code-v1"))
 		local.AddResource(newTransResource("t2", "Trans 2", "code-v1"))
 
-		plan, err := NewPlanner(local).BuildPlan(context.Background(), resources.NewGraph(), ModeSingle, "t1", "ws-1")
+		plan, err := NewPlanner(local).BuildPlan(resources.NewGraph(), ModeSingle, "t1", "ws-1")
 
 		require.NoError(t, err)
 		require.Len(t, plan.TestUnits, 1)
@@ -219,7 +218,7 @@ func TestBuildPlan_ModeSingle(t *testing.T) {
 		local.AddDependency(t1.URN(), lib.URN())
 		// t2 does NOT depend on lib
 
-		plan, err := NewPlanner(local).BuildPlan(context.Background(), resources.NewGraph(), ModeSingle, "lib-1", "ws-1")
+		plan, err := NewPlanner(local).BuildPlan(resources.NewGraph(), ModeSingle, "lib-1", "ws-1")
 
 		require.NoError(t, err)
 		require.Len(t, plan.TestUnits, 1)
@@ -230,7 +229,7 @@ func TestBuildPlan_ModeSingle(t *testing.T) {
 		local := resources.NewGraph()
 		local.AddResource(newLibResource("lib-1", "Lib", "code-v1"))
 
-		plan, err := NewPlanner(local).BuildPlan(context.Background(), resources.NewGraph(), ModeSingle, "lib-1", "ws-1")
+		plan, err := NewPlanner(local).BuildPlan(resources.NewGraph(), ModeSingle, "lib-1", "ws-1")
 
 		require.NoError(t, err)
 		assert.Empty(t, plan.TestUnits)
@@ -239,7 +238,7 @@ func TestBuildPlan_ModeSingle(t *testing.T) {
 	})
 
 	t.Run("unknown ID returns error", func(t *testing.T) {
-		plan, err := NewPlanner(resources.NewGraph()).BuildPlan(context.Background(), resources.NewGraph(), ModeSingle, "no-such-id", "ws-1")
+		plan, err := NewPlanner(resources.NewGraph()).BuildPlan(resources.NewGraph(), ModeSingle, "no-such-id", "ws-1")
 
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "no-such-id")

--- a/cli/internal/providers/transformations/testorchestrator/runner.go
+++ b/cli/internal/providers/transformations/testorchestrator/runner.go
@@ -64,7 +64,7 @@ func (r *Runner) Run(ctx context.Context, mode Mode, targetID string) (*TestResu
 	remoteGraph := syncer.StateToGraph(remoteState)
 
 	testLogger.Debug("Building test plan")
-	testPlan, err := r.planner.BuildPlan(ctx, remoteGraph, mode, targetID, r.workspaceID)
+	testPlan, err := r.planner.BuildPlan(remoteGraph, mode, targetID, r.workspaceID)
 	if err != nil {
 		return nil, fmt.Errorf("building test plan: %w", err)
 	}
@@ -306,7 +306,7 @@ func (r *Runner) runTestUnitTask(ctx context.Context, results *tasker.Results[*t
 			return fmt.Errorf("task is not a test unit task")
 		}
 
-		testLogger.Info("Testing transformation", "id", unitTask.ID, "name", unitTask.Name)
+		testLogger.Debug("Testing transformation", "id", unitTask.ID, "name", unitTask.Name)
 
 		testReq := buildTestRequest(unitTask.transformationVersion, unitTask.testDefs, unitTask.libraryVersionIDs)
 


### PR DESCRIPTION
## 🔗 Ticket

resolves [DAW-3403](https://linear.app/rudderstack/issue/DAW-3403/fix-transformations-test-command-convention-violations-and-bugs)

---

## Summary

Fixes bugs and applies Go repo conventions to the transformations test end-to-end flow. The most critical fix resolves a telemetry tracking bug where errors from `RunE` were never reported due to variable shadowing — a pattern also present in `apply` and `destroy` commands (noted for follow-up).

---

## Changes

* Fix telemetry not tracking `RunE` errors by declaring `var err error` inside the closure (matching `import workspace` pattern)
* Fix incorrect user-facing command hint (`default-events--show` → `show-default-events`)
* Panic on embedded JSON unmarshal failure instead of silently returning nil
* Remove unused `ctx` parameter from `BuildPlan` (pure in-memory computation)
* Downgrade per-transformation hot-path log from `Info` to `Debug`
* Convert exported mutable vars (`JsonExt`, `NoTestsDefined`) to unexported constants

---

## Testing

* Unit tests pass (`planner_test.go` updated for signature change)
* Existing test suite covers the affected code paths

---

## Risk / Impact

Low
- All changes are internal to the transformations test flow
- No API contract changes
- `BuildPlan` signature change is internal (not used outside the package)

---

## Checklist

* [x] Ticket linked
* [x] Tests added/updated
* [x] No breaking changes (or documented)