### PR TITLE
feat(typer/typescript): add track event generation with custom types, enums, and nested objects (DEX-332)

### DIFF
--- a/cli/internal/typer/generator/platforms/typescript/context.go
+++ b/cli/internal/typer/generator/platforms/typescript/context.go
@@ -19,6 +19,13 @@ type TSInterface struct {
 	Properties []TSInterfaceProperty
 }
 
+// TSTypeAlias → export type Alias = Type;
+type TSTypeAlias struct {
+	Alias   string
+	Type    string
+	Comment string
+}
+
 // TSMethodArgument is one parameter on a RudderTyper method.
 type TSMethodArgument struct {
 	Name     string
@@ -39,12 +46,24 @@ type TSAnalyticsMethod struct {
 	Comment         string
 	EventName       string
 	MethodArguments []TSMethodArgument
-	SDKMethodName   string // "identify" for now; future: "track", "screen", "group"
+	SDKMethodName   string // "identify", "track", etc.
 	SDKArguments    []TSSDKArgument
 }
 
 // TSContext is the root data object passed to RudderTyper.ts.tmpl.
 type TSContext struct {
+	// PropertyEnums and CustomTypeAliases are emitted as `export type X = ...`
+	// declarations. PropertyEnums covers property-level enum constraints; the
+	// other slice covers primitive / array / enum custom types.
+	PropertyEnums      []TSTypeAlias
+	CustomTypeAliases  []TSTypeAlias
+	// CustomInterfaces holds object custom types, emitted as `export interface`.
+	CustomInterfaces []TSInterface
+	// NestedInterfaces holds inline-schema nested objects from event rules,
+	// hoisted to top-level interfaces named `{EventInterface}{PropertyPath}`.
+	// Ordered deepest-first so a reader sees leaf shapes before composites.
+	NestedInterfaces []TSInterface
+	// Interfaces holds top-level event interfaces (track props, identify traits).
 	Interfaces       []TSInterface
 	AnalyticsMethods []TSAnalyticsMethod
 	// EventContext is the ruddertyper provenance map injected into every event's
@@ -55,4 +74,9 @@ type TSContext struct {
 	TrackingPlanID      string
 	TrackingPlanVersion int
 	TrackingPlanURL     string
+	// UsesSDKApiObject is true when at least one method passes a typed object to
+	// the SDK (track props or identify traits) and therefore needs the aliased
+	// SDK type imports for the strict cast.
+	UsesSDKApiObject     bool
+	UsesSDKIdentifyTraits bool
 }

--- a/cli/internal/typer/generator/platforms/typescript/generator.go
+++ b/cli/internal/typer/generator/platforms/typescript/generator.go
@@ -20,6 +20,22 @@ const (
 	methodScope     = "methods"
 )
 
+// SDK types are imported under aliased names so the strict cast at the SDK
+// boundary can target the SDK's own types without colliding with our generated
+// interface names (e.g. our generated `IdentifyTraits` shadows the SDK type of
+// the same name).
+const (
+	sdkApiObjectAlias      = "SDKApiObject"
+	sdkIdentifyTraitsAlias = "SDKIdentifyTraits"
+	// openObjectType is the permissive shape for `additionalProperties: true`
+	// or unknown structure; closedObjectType encodes the stricter
+	// `additionalProperties: false` (no extra fields allowed). Using a literal
+	// `{}` would be too permissive — TS treats it as "any non-null value", not
+	// "empty object" — so we emit `Record<string, never>` to forbid keys.
+	openObjectType   = "Record<string, unknown>"
+	closedObjectType = "Record<string, never>"
+)
+
 // ========== Main Entry Point ==========
 
 func (g *Generator) Generate(p *plan.TrackingPlan, opts core.GenerateOptions, platformOpts any) ([]*core.File, error) {
@@ -45,6 +61,15 @@ func (g *Generator) Generate(p *plan.TrackingPlan, opts core.GenerateOptions, pl
 
 	nr := core.NewNameRegistry(typescriptCollisionHandler)
 
+	// Order matters: custom types and property enums are registered first so
+	// downstream resolvers see their final names. Event rules are processed
+	// last because their interfaces refer to those names.
+	if err := processCustomTypesIntoContext(p, ctx, nr); err != nil {
+		return nil, err
+	}
+	if err := processPropertyEnumsIntoContext(p, ctx, nr); err != nil {
+		return nil, err
+	}
 	if err := processEventRules(p, ctx, nr); err != nil {
 		return nil, err
 	}
@@ -72,26 +97,36 @@ func typescriptCollisionHandler(name string, existing []string) string {
 
 // ========== Naming Helpers ==========
 
-func getOrRegisterEventInterfaceName(rule *plan.EventRule, nr *core.NameRegistry) (string, error) {
-	var prefix, suffix string
+func getOrRegisterCustomTypeName(ct *plan.CustomType, nr *core.NameRegistry) (string, error) {
+	name := FormatTypeName("CustomType", ct.Name)
+	return nr.RegisterName("customtype:"+ct.Name, globalTypeScope, name)
+}
 
+func getOrRegisterPropertyEnumName(p *plan.Property, nr *core.NameRegistry) (string, error) {
+	name := FormatTypeName("Property", p.Name)
+	return nr.RegisterName("propertyenum:"+p.Name, globalTypeScope, name)
+}
+
+func getOrRegisterEventInterfaceName(rule *plan.EventRule, nr *core.NameRegistry) (string, error) {
 	switch rule.Event.EventType {
 	case plan.EventTypeIdentify:
-		prefix = "Identify"
-	default:
-		return "", fmt.Errorf("unsupported event type: %s", rule.Event.EventType)
+		// Identify is a singleton — interface is always `IdentifyTraits` (or
+		// `IdentifyContextTraits` for context.traits). Event name is unused.
+		name := FormatTypeName("Identify", "Traits")
+		key := "event:" + string(rule.Event.EventType) + ":" + rule.Event.Name + ":" + string(rule.Section)
+		return nr.RegisterName(key, globalTypeScope, name)
+	case plan.EventTypeTrack:
+		// Track interfaces follow the spec convention: PascalCase event name
+		// only, no prefix or suffix. Per-event distinct names come from the
+		// event name itself.
+		name := FormatTypeName("", rule.Event.Name)
+		if name == "" {
+			return "", fmt.Errorf("track event has empty name")
+		}
+		key := "event:" + string(rule.Event.EventType) + ":" + rule.Event.Name + ":" + string(rule.Section)
+		return nr.RegisterName(key, globalTypeScope, name)
 	}
-
-	switch rule.Section {
-	case plan.IdentitySectionTraits, plan.IdentitySectionContextTraits:
-		suffix = "Traits"
-	default:
-		return "", fmt.Errorf("unsupported section: %s", rule.Section)
-	}
-
-	name := FormatTypeName(prefix, rule.Event.Name+" "+suffix)
-	key := "event:" + string(rule.Event.EventType) + ":" + rule.Event.Name + ":" + string(rule.Section)
-	return nr.RegisterName(key, globalTypeScope, name)
+	return "", fmt.Errorf("unsupported event type: %s", rule.Event.EventType)
 }
 
 func getOrRegisterEventMethodName(rule *plan.EventRule, nr *core.NameRegistry) (string, error) {
@@ -100,6 +135,11 @@ func getOrRegisterEventMethodName(rule *plan.EventRule, nr *core.NameRegistry) (
 	switch rule.Event.EventType {
 	case plan.EventTypeIdentify:
 		methodName = "identify"
+	case plan.EventTypeTrack:
+		// Always prefix track methods with `track` so the call site reads
+		// `analytics.trackUserSignedUp(...)` rather than collapsing into the
+		// camelCased event name (which can collide with property accessors).
+		methodName = FormatMethodName("track", rule.Event.Name)
 	default:
 		return "", fmt.Errorf("unsupported event type: %s", rule.Event.EventType)
 	}
@@ -177,27 +217,42 @@ func mapPrimitiveToTSType(t plan.PrimitiveType) (string, error) {
 	case plan.PrimitiveTypeArray:
 		return "unknown[]", nil
 	case plan.PrimitiveTypeObject:
-		return "Record<string, unknown>", nil
+		return openObjectType, nil
 	default:
 		return "", fmt.Errorf("unsupported primitive type: %s", t)
 	}
 }
 
+func hasEnumConfig(config *plan.PropertyConfig) bool {
+	return config != nil && len(config.Enum) > 0
+}
+
+func isEmptySchema(schema *plan.ObjectSchema) bool {
+	return schema == nil || len(schema.Properties) == 0
+}
+
 // resolvePropertyType returns the TS type expression for a property in an
-// interface. Multi-type unions (including `T | null` for nullable properties)
-// are emitted inline so the IR's distinction between optional (`prop?: T`) and
-// nullable (`T | null`) survives into the output.
+// interface. The optional enumName is the name of the registered enum alias
+// (when the property has its own enum config); when set, it short-circuits the
+// rest of the resolution — multi-type / array logic is irrelevant when the
+// schema constrains the value to a finite set.
 //
-// Custom types currently resolve to their underlying primitive — named type
-// aliases for custom types are intentionally deferred to follow-up tickets so
-// the identify-only landing stays small.
-func resolvePropertyType(prop *plan.Property) (string, error) {
+// nestedTypeName is the name of a hoisted nested-object interface (when the
+// surrounding schema defined an inline `Schema` for this property); when set,
+// the property's resolved type is the nested interface name and the underlying
+// `object` primitive is overridden.
+func resolvePropertyType(prop *plan.Property, enumName, nestedTypeName string, nr *core.NameRegistry) (string, error) {
+	if enumName != "" {
+		return enumName, nil
+	}
+	if nestedTypeName != "" {
+		return nestedTypeName, nil
+	}
 	if len(prop.Types) == 0 {
 		return "unknown", nil
 	}
-
 	if len(prop.Types) > 1 {
-		return resolveMultiType(prop.Types)
+		return resolveMultiType(prop.Types, nr)
 	}
 
 	pt := prop.Types[0]
@@ -206,13 +261,13 @@ func resolvePropertyType(prop *plan.Property) (string, error) {
 		if ct == nil {
 			return "unknown", nil
 		}
-		return resolveCustomType(ct)
+		return resolveCustomTypeReference(ct, nr)
 	}
 
 	if plan.IsPrimitiveType(pt) {
 		primitive := *plan.AsPrimitiveType(pt)
 		if primitive == plan.PrimitiveTypeArray {
-			return resolveArrayType(prop.ItemTypes)
+			return resolveArrayType(prop.ItemTypes, nr)
 		}
 		return mapPrimitiveToTSType(primitive)
 	}
@@ -220,10 +275,8 @@ func resolvePropertyType(prop *plan.Property) (string, error) {
 	return "unknown", nil
 }
 
-// resolveMultiType emits `A | B | C` for a multi-type property. Each element is
-// resolved independently; nested arrays/objects use the same open-type fallback
-// as resolvePropertyType.
-func resolveMultiType(types []plan.PropertyType) (string, error) {
+// resolveMultiType emits `A | B | C` for a multi-type property.
+func resolveMultiType(types []plan.PropertyType, nr *core.NameRegistry) (string, error) {
 	parts := make([]string, 0, len(types))
 	for _, t := range types {
 		var (
@@ -236,7 +289,7 @@ func resolveMultiType(types []plan.PropertyType) (string, error) {
 			if ct == nil {
 				part = "unknown"
 			} else {
-				part, err = resolveCustomType(ct)
+				part, err = resolveCustomTypeReference(ct, nr)
 			}
 		case plan.IsPrimitiveType(t):
 			part, err = mapPrimitiveToTSType(*plan.AsPrimitiveType(t))
@@ -251,41 +304,43 @@ func resolveMultiType(types []plan.PropertyType) (string, error) {
 	return joinUnion(parts), nil
 }
 
-// resolveCustomType returns the underlying TS type for a custom type. Object
-// custom types fall back to the open record type because named interfaces for
-// custom types are out of scope for the identify-only ticket.
-func resolveCustomType(ct *plan.CustomType) (string, error) {
-	if ct.Type == plan.PrimitiveTypeArray {
-		if ct.ItemType == nil {
-			return "unknown[]", nil
+// resolveCustomTypeReference returns the TS type expression to use when a
+// property references a custom type. Object and enum custom types resolve to
+// the registered name; primitive and array custom types also resolve to a
+// registered alias (so the IR's intent — "this is the email type" — survives
+// to the generated output rather than collapsing to an anonymous `string`).
+func resolveCustomTypeReference(ct *plan.CustomType, nr *core.NameRegistry) (string, error) {
+	if len(ct.Variants) > 0 {
+		// Variants out of scope — fall back to the underlying primitive.
+		// This keeps consumers that only need the discriminator field working,
+		// and lets a future ticket layer in variant emission without changing
+		// callers.
+		if ct.Type == plan.PrimitiveTypeObject {
+			return resolveCustomTypeName(ct, nr)
 		}
-		return resolveArrayItem(ct.ItemType)
+		return mapPrimitiveToTSType(ct.Type)
 	}
-	if ct.Type == plan.PrimitiveTypeObject {
-		// Open object — no per-custom-type interface generated yet.
-		return "Record<string, unknown>", nil
-	}
-	return mapPrimitiveToTSType(ct.Type)
+	return resolveCustomTypeName(ct, nr)
 }
 
-func resolveArrayType(itemTypes []plan.PropertyType) (string, error) {
+func resolveCustomTypeName(ct *plan.CustomType, nr *core.NameRegistry) (string, error) {
+	return getOrRegisterCustomTypeName(ct, nr)
+}
+
+func resolveArrayType(itemTypes []plan.PropertyType, nr *core.NameRegistry) (string, error) {
 	switch len(itemTypes) {
 	case 0:
 		return "unknown[]", nil
 	case 1:
-		inner, err := resolveArrayItem(itemTypes[0])
-		if err != nil {
-			return "", err
-		}
-		return inner, nil
+		return resolveArrayItem(itemTypes[0], nr)
 	default:
 		// Mixed item types → Array<A | B>. Wrap with Array<...> rather than
 		// `(A | B)[]` so the union grouping is unambiguous.
 		parts := make([]string, 0, len(itemTypes))
-		for _, t := range itemTypes {
-			inner, err := resolveSingleItem(t)
+		for i, t := range itemTypes {
+			inner, err := resolveSingleItem(t, nr)
 			if err != nil {
-				return "", err
+				return "", fmt.Errorf("resolving array item type at index %d: %w", i, err)
 			}
 			parts = append(parts, inner)
 		}
@@ -293,25 +348,24 @@ func resolveArrayType(itemTypes []plan.PropertyType) (string, error) {
 	}
 }
 
-func resolveArrayItem(t plan.PropertyType) (string, error) {
-	inner, err := resolveSingleItem(t)
+func resolveArrayItem(t plan.PropertyType, nr *core.NameRegistry) (string, error) {
+	inner, err := resolveSingleItem(t, nr)
 	if err != nil {
 		return "", err
 	}
-	// Wrap unions in Array<...> for clarity; otherwise use the postfix `[]`.
 	if strings.Contains(inner, "|") {
 		return "Array<" + inner + ">", nil
 	}
 	return inner + "[]", nil
 }
 
-func resolveSingleItem(t plan.PropertyType) (string, error) {
+func resolveSingleItem(t plan.PropertyType, nr *core.NameRegistry) (string, error) {
 	if plan.IsCustomType(t) {
 		ct := plan.AsCustomType(t)
 		if ct == nil {
 			return "unknown", nil
 		}
-		return resolveCustomType(ct)
+		return resolveCustomTypeReference(ct, nr)
 	}
 	if plan.IsPrimitiveType(t) {
 		return mapPrimitiveToTSType(*plan.AsPrimitiveType(t))
@@ -340,7 +394,224 @@ func joinUnion(parts []string) string {
 	return strings.Join(deduped, " | ")
 }
 
-// ========== Processing ==========
+// formatEnumLiteral formats a single enum value as a TS literal expression
+// (string, number, boolean, or `null`). Strings are quoted and escaped; other
+// scalars use their Go representation. Mixed-type enums are deduplicated by
+// the caller via joinUnion.
+func formatEnumLiteral(value any) string {
+	return FormatTSLiteral(value)
+}
+
+func buildEnumUnion(values []any) string {
+	parts := make([]string, 0, len(values))
+	for _, v := range values {
+		parts = append(parts, formatEnumLiteral(v))
+	}
+	if len(parts) == 0 {
+		return "unknown"
+	}
+	return joinUnion(parts)
+}
+
+// ========== Custom Type Processing ==========
+
+// processCustomTypesIntoContext walks the transitive closure of custom types
+// in the plan and emits one declaration per type:
+//   - object → `export interface CustomTypeFoo { ... }`
+//   - object with empty schema + additionalProperties → `export type CustomTypeFoo = Record<string, unknown>`
+//   - enum-constrained primitive → `export type CustomTypeFoo = "a" | "b"`
+//   - array → `export type CustomTypeFoo = Item[]`
+//   - bare primitive → `export type CustomTypeFoo = string` (preserved as a
+//     named alias so the IR's intent — e.g. "email" — survives to the output)
+//
+// Variant custom types are skipped with a warning; properties referring to
+// them resolve to the underlying primitive via resolveCustomTypeReference.
+func processCustomTypesIntoContext(p *plan.TrackingPlan, ctx *TSContext, nr *core.NameRegistry) error {
+	customTypes := p.ExtractAllCustomTypes()
+
+	sortedNames := make([]string, 0, len(customTypes))
+	for name := range customTypes {
+		sortedNames = append(sortedNames, name)
+	}
+	sort.Strings(sortedNames)
+
+	for _, name := range sortedNames {
+		ct := customTypes[name]
+
+		if len(ct.Variants) > 0 {
+			ui.PrintWarning(fmt.Sprintf("custom type %q has variants (not yet supported for typescript), emitting base schema only", ct.Name))
+			if err := emitCustomTypeBaseOnly(ct, ctx, nr); err != nil {
+				return err
+			}
+			continue
+		}
+
+		if err := emitCustomType(ct, ctx, nr); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// emitCustomType emits a single custom type declaration based on its kind.
+func emitCustomType(ct *plan.CustomType, ctx *TSContext, nr *core.NameRegistry) error {
+	typeName, err := getOrRegisterCustomTypeName(ct, nr)
+	if err != nil {
+		return err
+	}
+
+	switch {
+	case ct.Type == plan.PrimitiveTypeObject:
+		return emitCustomObjectType(ct, typeName, ctx, nr)
+	case hasEnumConfig(ct.Config):
+		ctx.CustomTypeAliases = append(ctx.CustomTypeAliases, TSTypeAlias{
+			Alias:   typeName,
+			Type:    buildEnumUnion(ct.Config.Enum),
+			Comment: ct.Description,
+		})
+		return nil
+	case ct.Type == plan.PrimitiveTypeArray:
+		itemType, err := resolveCustomTypeArrayItem(ct.ItemType, nr)
+		if err != nil {
+			return err
+		}
+		ctx.CustomTypeAliases = append(ctx.CustomTypeAliases, TSTypeAlias{
+			Alias:   typeName,
+			Type:    itemType,
+			Comment: ct.Description,
+		})
+		return nil
+	default:
+		// Bare primitive custom type — emitted as a named alias.
+		tsType, err := mapPrimitiveToTSType(ct.Type)
+		if err != nil {
+			return err
+		}
+		ctx.CustomTypeAliases = append(ctx.CustomTypeAliases, TSTypeAlias{
+			Alias:   typeName,
+			Type:    tsType,
+			Comment: ct.Description,
+		})
+		return nil
+	}
+}
+
+// emitCustomTypeBaseOnly handles custom types that have variants. Variants are
+// out of scope, but we emit the base schema (object or alias) so properties
+// referencing the type resolve to a sensible shape rather than disappearing.
+func emitCustomTypeBaseOnly(ct *plan.CustomType, ctx *TSContext, nr *core.NameRegistry) error {
+	if ct.Type != plan.PrimitiveTypeObject {
+		return emitCustomType(ct, ctx, nr)
+	}
+	typeName, err := getOrRegisterCustomTypeName(ct, nr)
+	if err != nil {
+		return err
+	}
+	if isEmptySchema(ct.Schema) {
+		ctx.CustomTypeAliases = append(ctx.CustomTypeAliases, TSTypeAlias{
+			Alias:   typeName,
+			Type:    emptyObjectType(ct.Schema),
+			Comment: ct.Description,
+		})
+		return nil
+	}
+	iface, err := buildInterfaceFromSchema(typeName, ct.Description, ct.Schema, nr)
+	if err != nil {
+		return err
+	}
+	ctx.CustomInterfaces = append(ctx.CustomInterfaces, *iface)
+	return nil
+}
+
+func emitCustomObjectType(ct *plan.CustomType, typeName string, ctx *TSContext, nr *core.NameRegistry) error {
+	if isEmptySchema(ct.Schema) {
+		// `additionalProperties: true` → permissive `Record<string, unknown>`;
+		// `additionalProperties: false` → strict `Record<string, never>`.
+		// Mirrors Kotlin (`JsonObject` vs `Unit`) and Swift (`[String: Any]`
+		// vs empty struct). Collapsing both to one shape — as an earlier draft
+		// did — silently lets callers pass extra keys into a closed schema.
+		ctx.CustomTypeAliases = append(ctx.CustomTypeAliases, TSTypeAlias{
+			Alias:   typeName,
+			Type:    emptyObjectType(ct.Schema),
+			Comment: ct.Description,
+		})
+		return nil
+	}
+	iface, err := buildInterfaceFromSchema(typeName, ct.Description, ct.Schema, nr)
+	if err != nil {
+		return err
+	}
+	ctx.CustomInterfaces = append(ctx.CustomInterfaces, *iface)
+	return nil
+}
+
+// emptyObjectType returns the TS type expression for an empty object schema,
+// honouring `additionalProperties` so closed-empty schemas refuse extra keys
+// at the type level instead of silently accepting them.
+func emptyObjectType(schema *plan.ObjectSchema) string {
+	if schema != nil && schema.AdditionalProperties {
+		return openObjectType
+	}
+	return closedObjectType
+}
+
+func resolveCustomTypeArrayItem(item plan.PropertyType, nr *core.NameRegistry) (string, error) {
+	if item == nil {
+		return "unknown[]", nil
+	}
+	inner, err := resolveSingleItem(item, nr)
+	if err != nil {
+		return "", err
+	}
+	if strings.Contains(inner, "|") {
+		return "Array<" + inner + ">", nil
+	}
+	return inner + "[]", nil
+}
+
+// ========== Property Enum Processing ==========
+
+// processPropertyEnumsIntoContext walks all properties in the plan and emits
+// a top-level type alias for each one with an enum config. Property-level
+// enums emit as TS literal unions (`"a" | "b"`) rather than `enum`
+// declarations so callers can pass plain string/number values directly.
+//
+// The registry scope is global (not per-event), so a property defined once and
+// referenced from multiple event rules — or referenced from a custom-type
+// schema and an event schema — resolves to a single shared alias. Callers
+// rely on this dedup: every interface property that points at "device_type"
+// renders as `PropertyDeviceType` regardless of where it appears.
+func processPropertyEnumsIntoContext(p *plan.TrackingPlan, ctx *TSContext, nr *core.NameRegistry) error {
+	properties := p.ExtractAllProperties()
+
+	sortedNames := make([]string, 0, len(properties))
+	for name := range properties {
+		sortedNames = append(sortedNames, name)
+	}
+	sort.Strings(sortedNames)
+
+	for _, name := range sortedNames {
+		prop := properties[name]
+		if !hasEnumConfig(prop.Config) {
+			continue
+		}
+
+		typeName, err := getOrRegisterPropertyEnumName(prop, nr)
+		if err != nil {
+			return err
+		}
+		ctx.PropertyEnums = append(ctx.PropertyEnums, TSTypeAlias{
+			Alias:   typeName,
+			Type:    buildEnumUnion(prop.Config.Enum),
+			Comment: prop.Description,
+		})
+	}
+
+	return nil
+}
+
+// ========== Event Rule Processing ==========
 
 func processEventRules(p *plan.TrackingPlan, ctx *TSContext, nr *core.NameRegistry) error {
 	ruleMap := make(map[string]*plan.EventRule)
@@ -369,51 +640,73 @@ func processEventRules(p *plan.TrackingPlan, ctx *TSContext, nr *core.NameRegist
 			continue
 		}
 
-		if !isEmptySchema(&rule.Schema) {
-			interfaceName, err := getOrRegisterEventInterfaceName(rule, nr)
-			if err != nil {
-				return err
-			}
-			iface, err := buildInterface(interfaceName, rule.Event.Description, &rule.Schema, nr)
-			if err != nil {
-				return err
-			}
-			ctx.Interfaces = append(ctx.Interfaces, *iface)
+		if len(rule.Variants) > 0 {
+			ui.PrintWarning(fmt.Sprintf("event %q has variants (not yet supported for typescript), skipping", rule.Event.Name))
+			continue
 		}
 
-		method, err := buildIdentifyMethod(rule, nr)
-		if err != nil {
+		if err := processOneEventRule(rule, ctx, nr); err != nil {
 			return err
-		}
-		if method != nil {
-			ctx.AnalyticsMethods = append(ctx.AnalyticsMethods, *method)
 		}
 	}
 
 	return nil
 }
 
-// isSupportedEventType limits the v1 typer to identify only. Other event types
-// are accepted in the plan (so existing reference plans keep validating) but
-// emit a warning and produce no output.
+func processOneEventRule(rule *plan.EventRule, ctx *TSContext, nr *core.NameRegistry) error {
+	if !isEmptySchema(&rule.Schema) {
+		interfaceName, err := getOrRegisterEventInterfaceName(rule, nr)
+		if err != nil {
+			return err
+		}
+		iface, err := buildEventInterface(interfaceName, rule.Event.Description, &rule.Schema, ctx, nr)
+		if err != nil {
+			return err
+		}
+		ctx.Interfaces = append(ctx.Interfaces, *iface)
+	}
+
+	method, err := buildAnalyticsMethod(rule, ctx, nr)
+	if err != nil {
+		return err
+	}
+	if method != nil {
+		ctx.AnalyticsMethods = append(ctx.AnalyticsMethods, *method)
+	}
+	return nil
+}
+
+// isSupportedEventType limits the v1 typer to identify and track. Other event
+// types are accepted in the plan (so existing reference plans keep validating)
+// but emit a warning and produce no output.
 func isSupportedEventType(t plan.EventType) bool {
-	return t == plan.EventTypeIdentify
+	return t == plan.EventTypeIdentify || t == plan.EventTypeTrack
 }
 
 func validateEventSection(rule *plan.EventRule) bool {
-	if rule.Event.EventType == plan.EventTypeIdentify {
+	switch rule.Event.EventType {
+	case plan.EventTypeIdentify:
 		return rule.Section == plan.IdentitySectionTraits || rule.Section == plan.IdentitySectionContextTraits
+	case plan.EventTypeTrack:
+		return rule.Section == plan.IdentitySectionProperties
 	}
 	return false
 }
 
-func isEmptySchema(schema *plan.ObjectSchema) bool {
-	return schema == nil || len(schema.Properties) == 0
+// ========== Interface Builders ==========
+
+// buildEventInterface builds the top-level interface for an event rule's
+// schema. Inline nested-object schemas are hoisted into separate
+// NestedInterfaces (deepest-first), so this interface only references those by
+// name rather than embedding object literals.
+func buildEventInterface(name, comment string, schema *plan.ObjectSchema, ctx *TSContext, nr *core.NameRegistry) (*TSInterface, error) {
+	return buildInterfaceWithNested(name, comment, schema, ctx, nr)
 }
 
-// ========== Interface Builder ==========
-
-func buildInterface(name, comment string, schema *plan.ObjectSchema, nr *core.NameRegistry) (*TSInterface, error) {
+// buildInterfaceWithNested builds an interface whose properties may reference
+// inline nested-object schemas. Each inline schema produces a hoisted
+// top-level interface named `{ParentName}{PropertyPathPascalCase}`.
+func buildInterfaceWithNested(name, comment string, schema *plan.ObjectSchema, ctx *TSContext, nr *core.NameRegistry) (*TSInterface, error) {
 	sortedNames := make([]string, 0, len(schema.Properties))
 	for propName := range schema.Properties {
 		sortedNames = append(sortedNames, propName)
@@ -429,7 +722,100 @@ func buildInterface(name, comment string, schema *plan.ObjectSchema, nr *core.Na
 			return nil, err
 		}
 
-		tsType, err := resolvePropertyType(&propSchema.Property)
+		nestedTypeName, err := buildNestedInterfaceIfPresent(name, propName, &propSchema, ctx, nr)
+		if err != nil {
+			return nil, err
+		}
+
+		var enumName string
+		if hasEnumConfig(propSchema.Property.Config) {
+			enumName, err = getOrRegisterPropertyEnumName(&propSchema.Property, nr)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		tsType, err := resolvePropertyType(&propSchema.Property, enumName, nestedTypeName, nr)
+		if err != nil {
+			return nil, fmt.Errorf("resolving type for property %q in interface %q: %w", propName, name, err)
+		}
+
+		properties = append(properties, TSInterfaceProperty{
+			Name:       fieldName,
+			Type:       tsType,
+			Comment:    propSchema.Property.Description,
+			Optional:   !propSchema.Required,
+			QuotedName: quoted,
+		})
+	}
+
+	return &TSInterface{
+		Name:       name,
+		Comment:    comment,
+		Properties: properties,
+	}, nil
+}
+
+// buildNestedInterfaceIfPresent hoists an inline nested-object schema to a
+// top-level interface and returns its name. The hoisted interface is appended
+// to ctx.NestedInterfaces *after* its own children, so the slice ends up
+// deepest-first.
+//
+// Empty inline schemas don't hoist an interface; they short-circuit to a
+// `Record<string, unknown>` or `Record<string, never>` literal returned via
+// the second result, which the caller passes through as the property type.
+// This keeps `additionalProperties` semantics intact even when no fields are
+// declared (closed-empty schemas refuse extra keys; open-empty accept any).
+func buildNestedInterfaceIfPresent(parentName, propName string, propSchema *plan.PropertySchema, ctx *TSContext, nr *core.NameRegistry) (string, error) {
+	if propSchema.Schema == nil {
+		return "", nil
+	}
+	if isEmptySchema(propSchema.Schema) {
+		return emptyObjectType(propSchema.Schema), nil
+	}
+
+	nestedName := FormatTypeName(parentName, propName)
+	registeredName, err := nr.RegisterName("nested:"+parentName+":"+propName, globalTypeScope, nestedName)
+	if err != nil {
+		return "", err
+	}
+
+	iface, err := buildInterfaceWithNested(registeredName, propSchema.Property.Description, propSchema.Schema, ctx, nr)
+	if err != nil {
+		return "", err
+	}
+	ctx.NestedInterfaces = append(ctx.NestedInterfaces, *iface)
+	return registeredName, nil
+}
+
+// buildInterfaceFromSchema builds an interface from a custom-type schema. It
+// does not hoist nested objects — custom-type schemas declare their own
+// reusable shape, so any nested objects inside them are inlined.
+func buildInterfaceFromSchema(name, comment string, schema *plan.ObjectSchema, nr *core.NameRegistry) (*TSInterface, error) {
+	sortedNames := make([]string, 0, len(schema.Properties))
+	for propName := range schema.Properties {
+		sortedNames = append(sortedNames, propName)
+	}
+	sort.Strings(sortedNames)
+
+	properties := make([]TSInterfaceProperty, 0, len(sortedNames))
+	for _, propName := range sortedNames {
+		propSchema := schema.Properties[propName]
+
+		fieldName, quoted, err := getOrRegisterInterfacePropertyName(name, propName, nr)
+		if err != nil {
+			return nil, err
+		}
+
+		var enumName string
+		if hasEnumConfig(propSchema.Property.Config) {
+			enumName, err = getOrRegisterPropertyEnumName(&propSchema.Property, nr)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		tsType, err := resolvePropertyType(&propSchema.Property, enumName, "", nr)
 		if err != nil {
 			return nil, fmt.Errorf("resolving type for property %q in interface %q: %w", propName, name, err)
 		}
@@ -452,7 +838,17 @@ func buildInterface(name, comment string, schema *plan.ObjectSchema, nr *core.Na
 
 // ========== Analytics Method Builder ==========
 
-func buildIdentifyMethod(rule *plan.EventRule, nr *core.NameRegistry) (*TSAnalyticsMethod, error) {
+func buildAnalyticsMethod(rule *plan.EventRule, ctx *TSContext, nr *core.NameRegistry) (*TSAnalyticsMethod, error) {
+	switch rule.Event.EventType {
+	case plan.EventTypeIdentify:
+		return buildIdentifyMethod(rule, ctx, nr)
+	case plan.EventTypeTrack:
+		return buildTrackMethod(rule, ctx, nr)
+	}
+	return nil, fmt.Errorf("unsupported event type: %s", rule.Event.EventType)
+}
+
+func buildIdentifyMethod(rule *plan.EventRule, ctx *TSContext, nr *core.NameRegistry) (*TSAnalyticsMethod, error) {
 	methodName, err := getOrRegisterEventMethodName(rule, nr)
 	if err != nil {
 		return nil, err
@@ -486,12 +882,66 @@ func buildIdentifyMethod(rule *plan.EventRule, nr *core.NameRegistry) (*TSAnalyt
 			Comment:  "The traits to include with this event",
 			Optional: true,
 		})
-		// Cast to any at the SDK boundary: the SDK's IdentifyTraits parameter has
-		// an index signature, which our strictly-typed generated interface lacks.
-		// The public method surface stays type-safe; only this one hop into the
-		// SDK is loosened so strict-mode compilation passes.
-		method.SDKArguments = append(method.SDKArguments, TSSDKArgument{Value: "traits as any"})
+		// Cast through `unknown` to the SDK's IdentifyTraits type. The SDK type
+		// has an open index signature that our generated interface lacks, so
+		// the structural cast cannot succeed directly — but going through
+		// `unknown` keeps the destination bounded to the SDK type rather than
+		// erasing to `any`.
+		method.SDKArguments = append(method.SDKArguments, TSSDKArgument{Value: "traits as unknown as " + sdkIdentifyTraitsAlias})
+		ctx.UsesSDKIdentifyTraits = true
 	} else {
+		method.SDKArguments = append(method.SDKArguments, TSSDKArgument{Value: "undefined"})
+	}
+
+	return method, nil
+}
+
+func buildTrackMethod(rule *plan.EventRule, ctx *TSContext, nr *core.NameRegistry) (*TSAnalyticsMethod, error) {
+	methodName, err := getOrRegisterEventMethodName(rule, nr)
+	if err != nil {
+		return nil, err
+	}
+
+	eventNameLiteral := fmt.Sprintf("%q", rule.Event.Name)
+
+	method := &TSAnalyticsMethod{
+		Name:          methodName,
+		Comment:       rule.Event.Description,
+		EventName:     rule.Event.Name,
+		SDKMethodName: "track",
+		SDKArguments: []TSSDKArgument{
+			{Value: eventNameLiteral},
+		},
+	}
+
+	emptySchema := isEmptySchema(&rule.Schema)
+	switch {
+	case !emptySchema:
+		interfaceName, err := getOrRegisterEventInterfaceName(rule, nr)
+		if err != nil {
+			return nil, err
+		}
+		method.MethodArguments = append(method.MethodArguments, TSMethodArgument{
+			Name:    "props",
+			Type:    interfaceName,
+			Comment: "The properties to include with this event",
+		})
+		method.SDKArguments = append(method.SDKArguments, TSSDKArgument{Value: "props as unknown as " + sdkApiObjectAlias})
+		ctx.UsesSDKApiObject = true
+
+	case rule.Schema.AdditionalProperties:
+		// Empty schema with allow_unplanned: true → optional generic props arg.
+		method.MethodArguments = append(method.MethodArguments, TSMethodArgument{
+			Name:     "props",
+			Type:     openObjectType,
+			Comment:  "Additional properties to include with this event",
+			Optional: true,
+		})
+		method.SDKArguments = append(method.SDKArguments, TSSDKArgument{Value: "props as unknown as " + sdkApiObjectAlias})
+		ctx.UsesSDKApiObject = true
+
+	default:
+		// Empty schema, additionalProperties: false → no props arg at all.
 		method.SDKArguments = append(method.SDKArguments, TSSDKArgument{Value: "undefined"})
 	}
 

--- a/cli/internal/typer/generator/platforms/typescript/naming.go
+++ b/cli/internal/typer/generator/platforms/typescript/naming.go
@@ -6,14 +6,19 @@ import (
 )
 
 // tokenize splits a string into words by spaces, underscores, hyphens, dots,
-// and camelCase boundaries. Non-letter/digit characters are stripped from word
-// edges (but not from the middle of a token), and all tokens are lowercased.
+// dollar signs, and camelCase boundaries. Non-letter/digit characters are
+// stripped from word edges (but not from the middle of a token), and all
+// tokens are lowercased.
 //
 // Mirrors Swift's tokenize: kept separate from core.SplitIntoWords so acronym
 // runs (e.g. "XMLParser") collapse to a single token rather than splitting,
 // which keeps generated identifiers stable for plans that contain acronyms.
+//
+// `$` is included as a separator (in addition to edge-trimming) because
+// developer-supplied event names like "$Variable$String" should split into
+// distinct words rather than collapse "Variable$String" into a single token.
 func tokenize(s string) []string {
-	s = strings.NewReplacer("_", " ", "-", " ", ".", " ").Replace(s)
+	s = strings.NewReplacer("_", " ", "-", " ", ".", " ", "$", " ").Replace(s)
 
 	var spaced strings.Builder
 	runes := []rune(s)

--- a/cli/internal/typer/generator/platforms/typescript/templates.go
+++ b/cli/internal/typer/generator/platforms/typescript/templates.go
@@ -17,6 +17,9 @@ var disclaimerTemplate string
 //go:embed templates/interface.tmpl
 var interfaceTemplate string
 
+//go:embed templates/typealias.tmpl
+var typealiasTemplate string
+
 //go:embed templates/ruddertyper.tmpl
 var ruddertyperTemplate string
 
@@ -35,6 +38,7 @@ func GenerateFile(path string, ctx *TSContext) (*core.File, error) {
 	for name, src := range map[string]string{
 		"disclaimer.tmpl":  disclaimerTemplate,
 		"interface.tmpl":   interfaceTemplate,
+		"typealias.tmpl":   typealiasTemplate,
 		"ruddertyper.tmpl": ruddertyperTemplate,
 	} {
 		if _, err = tmpl.New(name).Parse(src); err != nil {

--- a/cli/internal/typer/generator/platforms/typescript/templates/RudderTyper.ts.tmpl
+++ b/cli/internal/typer/generator/platforms/typescript/templates/RudderTyper.ts.tmpl
@@ -1,12 +1,55 @@
 {{ template "disclaimer.tmpl" . }}
-import type { ApiOptions, RudderAnalytics } from "@rudderstack/analytics-js";
+import type {
+    ApiOptions,
+    RudderAnalytics,
+{{- if .UsesSDKApiObject }}
+    ApiObject as SDKApiObject,
+{{- end }}
+{{- if .UsesSDKIdentifyTraits }}
+    IdentifyTraits as SDKIdentifyTraits,
+{{- end }}
+} from "@rudderstack/analytics-js";
+{{- if .PropertyEnums }}
+
+// ===== Property Enums =====
+
+{{ range $i, $a := .PropertyEnums }}{{ if $i }}
+{{ end }}{{ template "typealias.tmpl" $a -}}
+{{ end -}}
+{{ end }}
+{{- if or .CustomTypeAliases .CustomInterfaces }}
+
+// ===== Custom Types =====
+
+{{ range $i, $a := .CustomTypeAliases }}{{ if $i }}
+{{ end }}{{ template "typealias.tmpl" $a -}}
+{{ end -}}
+{{- if and .CustomTypeAliases .CustomInterfaces }}
+
+{{ end -}}
+{{ range $i, $a := .CustomInterfaces }}{{ if $i }}
+
+{{ end }}{{ template "interface.tmpl" $a -}}
+{{ end -}}
+{{ end }}
+{{- if .NestedInterfaces }}
+
+// ===== Nested Object Types =====
+
+{{ range $i, $a := .NestedInterfaces }}{{ if $i }}
+
+{{ end }}{{ template "interface.tmpl" $a -}}
+{{ end -}}
+{{ end }}
 {{- if .Interfaces }}
 
-// ===== Event Traits =====
-{{- range .Interfaces }}
-{{ template "interface.tmpl" . }}
-{{- end }}
-{{- end }}
+// ===== Event Types =====
+
+{{ range $i, $a := .Interfaces }}{{ if $i }}
+
+{{ end }}{{ template "interface.tmpl" $a -}}
+{{ end -}}
+{{ end }}
 
 // ===== RudderTyper =====
 

--- a/cli/internal/typer/generator/platforms/typescript/templates/interface.tmpl
+++ b/cli/internal/typer/generator/platforms/typescript/templates/interface.tmpl
@@ -1,6 +1,6 @@
-{{- if .Comment }}
+{{- if .Comment -}}
 /** {{ escapeComment .Comment }} */
-{{- end }}
+{{ end -}}
 export interface {{ .Name }} {
 {{- range .Properties }}
 {{- if .Comment }}
@@ -13,5 +13,3 @@ export interface {{ .Name }} {
 {{- end }}
 {{- end }}
 }
-{{- "" -}}
-

--- a/cli/internal/typer/generator/platforms/typescript/templates/typealias.tmpl
+++ b/cli/internal/typer/generator/platforms/typescript/templates/typealias.tmpl
@@ -1,0 +1,4 @@
+{{- if .Comment -}}
+/** {{ escapeComment .Comment }} */
+{{ end -}}
+export type {{ .Alias }} = {{ .Type }};

--- a/cli/internal/typer/generator/platforms/typescript/testdata/RudderTyper.ts
+++ b/cli/internal/typer/generator/platforms/typescript/testdata/RudderTyper.ts
@@ -4,17 +4,268 @@
  * Do not modify manually.
  */
 
-import type { ApiOptions, RudderAnalytics } from "@rudderstack/analytics-js";
+import type {
+    ApiOptions,
+    RudderAnalytics,
+    ApiObject as SDKApiObject,
+    IdentifyTraits as SDKIdentifyTraits,
+} from "@rudderstack/analytics-js";
 
-// ===== Event Traits =====
+// ===== Property Enums =====
+
+/** Type of device */
+export type PropertyDeviceType = "mobile" | "tablet" | "desktop" | "smartTV" | "IoT-Device";
+
+/** Field with $ for testing string interpolation: $variable and ${expression} */
+export type PropertyDollarField = "$USD" | "$100" | "Price: $99.99" | "$variable_name";
+
+/** Feature enabled flag */
+export type PropertyEnabled = true | false;
+
+/** Mixed type enum */
+export type PropertyMixedValue = "active" | 1 | true | 2.5;
+
+/** Priority level */
+export type PropertyPriority = 1 | 2 | 3;
+
+/** Rating value */
+export type PropertyRating = 1.5 | 2.5 | 3.5 | 4.5 | 5;
+
+/** HTTP status with special characters */
+export type PropertyStatusCode = "200: OK" | "404: Not Found" | "500: Internal \"Server\" Error";
+
+/** Field demonstrating various Unicode characters in enum values */
+export type PropertyUnicodeEnumField = "🎯" | "✅" | "активный" | "已完成" | "ενεργός" | "café" | "!!!";
+
+
+// ===== Custom Types =====
+
+/** Whether user is active */
+export type CustomTypeActive = boolean;
+
+/** List of addresses */
+export type CustomTypeAddressList = CustomTypeAddressDetails[];
+
+/** User's age in years */
+export type CustomTypeAge = number;
+
+/** Custom type for Colors */
+export type CustomTypeColor = string;
+
+/** Custom type for email validation */
+export type CustomTypeEmail = string;
+
+/** List of email addresses */
+export type CustomTypeEmailList = CustomTypeEmail[];
+
+/** Empty object that does not allow additional properties */
+export type CustomTypeEmptyObjectNoAdditionalProps = Record<string, never>;
+
+/** Empty object that allows additional properties */
+export type CustomTypeEmptyObjectWithAdditionalProps = Record<string, unknown>;
+
+/** Custom type representing a null value */
+export type CustomTypeNullType = null;
+
+/** Custom type for phone numbers */
+export type CustomTypePhoneNumber = string;
+
+/** List of user profiles */
+export type CustomTypeProfileList = CustomTypeUserProfile[];
+
+/** User status enum */
+export type CustomTypeStatus = "pending" | "active" | "suspended" | "deleted";
+
+/** Custom type with Cyrillic name */
+export type CustomTypeТипыДанных = "активный" | "неактивный" | "pending";
+
+
+/** Address details object */
+export interface CustomTypeAddressDetails {
+    /** City name */
+    city: string;
+    /** Postal code */
+    postalCode?: string;
+    /** Street address */
+    street: string;
+}
+
+
+/** Feature configuration with variants based on multi-type flag */
+export interface CustomTypeFeatureConfig {
+    /** Feature flag that can be boolean or string */
+    featureFlag: boolean | string;
+}
+
+
+/** Page context with variants based on page type */
+export interface CustomTypePageContext {
+    /** Type of page */
+    pageType: string;
+}
+
+
+/** User access with variants based on active status */
+export interface CustomTypeUserAccess {
+    /** User active status */
+    active: CustomTypeActive;
+}
+
+
+/** User profile information */
+export interface CustomTypeUserProfile {
+    /** User's email address */
+    email: CustomTypeEmail;
+    /** User's first name */
+    firstName: string;
+    /** User's last name */
+    lastName?: string;
+}
+
+
+// ===== Nested Object Types =====
+
+/** demonstrates multiple levels of nesting */
+export interface UserSignedUpContextNestedContext {
+    /** Array of favorite colors using custom type */
+    favoriteColors?: CustomTypeColor[];
+    /** User profile data */
+    profile?: CustomTypeUserProfile;
+}
+
+
+/** example of object property */
+export interface UserSignedUpContext {
+    /** IP address of the user */
+    ipAddress: string;
+    /** demonstrates multiple levels of nesting */
+    nestedContext: UserSignedUpContextNestedContext;
+}
+
+
+// ===== Event Types =====
 
 /** User identification event */
 export interface IdentifyTraits {
     /** User active status */
-    active?: boolean;
+    active?: CustomTypeActive;
     /** User's email address */
-    email: string;
+    email: CustomTypeEmail;
 }
+
+
+/** Event with dollar signs to test string interpolation escaping */
+export interface VariableString {
+    /** Field with $ for testing string interpolation: $variable and ${expression} */
+    dollarField: PropertyDollarField;
+}
+
+
+/** Event with special characters that collide after sanitization */
+export interface EventWithNameCamelCase {
+    /** User's email address */
+    email?: CustomTypeEmail;
+}
+
+
+/** Triggered when user clicks on a "premium" product /\* important *\/ */
+export interface ProductPremiumClicked {
+    /** Field with special chars: "quotes", backslash\path, and /\* comment *\/ */
+    specialField: string;
+    /** HTTP status with special characters */
+    statusCode?: PropertyStatusCode;
+}
+
+
+/** Triggered when a user signs up */
+export interface UserSignedUp {
+    /** User active status */
+    active: CustomTypeActive;
+    /** User's addresses */
+    addresses?: CustomTypeAddressList;
+    /** User's age */
+    age?: CustomTypeAge;
+    /** An array that can contain any type of items */
+    arrayOfAny?: unknown[];
+    /** Array with items that can be string or null */
+    arrayWithNullItems?: Array<string | null>;
+    /** Array of user contacts */
+    contacts?: CustomTypeEmail[];
+    /** example of object property */
+    context?: UserSignedUpContext;
+    /** Property using custom null type */
+    customNullField?: CustomTypeNullType;
+    /** Type of device */
+    deviceType?: PropertyDeviceType;
+    /** User's email addresses */
+    emailList?: CustomTypeEmailList;
+    /** Property with empty object not allowing additional properties */
+    emptyObjectNoAdditionalProps?: CustomTypeEmptyObjectNoAdditionalProps;
+    /** Property with empty object allowing additional properties */
+    emptyObjectWithAdditionalProps?: CustomTypeEmptyObjectWithAdditionalProps;
+    /** Feature enabled flag */
+    enabled?: PropertyEnabled;
+    /** Feature configuration information */
+    featureConfig?: CustomTypeFeatureConfig;
+    /** Property with mixed unicode: café, naïve, 日本語 */
+    mixedUnicode?: string;
+    /** Mixed type enum */
+    mixedValue?: PropertyMixedValue;
+    /** An array with items that can be string or integer */
+    multiTypeArray?: Array<string | number>;
+    /** A field that can be string, integer, or boolean */
+    multiTypeField?: string | number | boolean;
+    /** Property that can be string, integer, or null */
+    multiTypeWithNull?: string | number | null;
+    /** Nested property with empty object allowing additional properties */
+    nestedEmptyObject?: Record<string, unknown>;
+    /** Nested property with empty object not allowing additional properties */
+    nestedEmptyObjectNoAdditionalProps?: Record<string, never>;
+    /** Property that is always null */
+    nullField?: null;
+    /** Property that can be number or null */
+    numberOrNull?: number | null;
+    /** An object field with no defined structure */
+    objectProperty?: Record<string, unknown>;
+    /** Array of phone numbers using custom type */
+    phoneNumbers?: CustomTypePhoneNumber[];
+    /** Priority level */
+    priority?: PropertyPriority;
+    /** User profile data */
+    profile: CustomTypeUserProfile;
+    /** List of related user profiles */
+    profileList?: CustomTypeProfileList;
+    /** A field that can contain any type of value */
+    propertyOfAny?: unknown;
+    /** Rating value */
+    rating?: PropertyRating;
+    /** User account status */
+    status?: CustomTypeStatus;
+    /** Property that can be string or null */
+    stringOrNull?: string | null;
+    /** User tags as array of strings */
+    tags?: string[];
+    /** Property using custom type with Unicode */
+    unicodeCustomType?: CustomTypeТипыДанных;
+    /** Field demonstrating various Unicode characters in enum values */
+    unicodeEnumField?: PropertyUnicodeEnumField;
+    /** An array with no explicit item type (treated as any) */
+    untypedArray?: unknown[];
+    /** A field with no explicit type (treated as any) */
+    untypedField?: unknown;
+    /** User access information */
+    userAccess?: CustomTypeUserAccess;
+    /** Username in Chinese characters */
+    "用户名"?: string;
+}
+
+
+/** Event with camel case name */
+export interface EventWithNameCamelCase1 {
+    /** User active status */
+    active?: CustomTypeActive;
+}
+
 
 // ===== RudderTyper =====
 
@@ -56,7 +307,124 @@ export class RudderTyper {
     ): void {
         this.analytics.identify(
             userId,
-            traits as any,
+            traits as unknown as SDKIdentifyTraits,
+            this.withRudderTyperContext(options),
+        );
+    }
+
+    /**
+     * Event with dollar signs to test string interpolation escaping
+     *
+     * @param props - The properties to include with this event
+     * @param options - Optional ApiOptions for additional event configuration
+     */
+    public trackVariableString(
+        props: VariableString,
+        options?: ApiOptions,
+    ): void {
+        this.analytics.track(
+            "$Variable$String",
+            props as unknown as SDKApiObject,
+            this.withRudderTyperContext(options),
+        );
+    }
+
+    /**
+     * Event with special characters that collide after sanitization
+     *
+     * @param props - The properties to include with this event
+     * @param options - Optional ApiOptions for additional event configuration
+     */
+    public trackEventWithNameCamelCase(
+        props: EventWithNameCamelCase,
+        options?: ApiOptions,
+    ): void {
+        this.analytics.track(
+            "$eventWithNameCamelCase$!",
+            props as unknown as SDKApiObject,
+            this.withRudderTyperContext(options),
+        );
+    }
+
+    /**
+     * Empty event schema with additionalProperties false
+     *
+     * @param options - Optional ApiOptions for additional event configuration
+     */
+    public trackEmptyEventNoAdditionalProps(
+        options?: ApiOptions,
+    ): void {
+        this.analytics.track(
+            "Empty Event No Additional Props",
+            undefined,
+            this.withRudderTyperContext(options),
+        );
+    }
+
+    /**
+     * Empty event schema with additionalProperties true
+     *
+     * @param props - Additional properties to include with this event
+     * @param options - Optional ApiOptions for additional event configuration
+     */
+    public trackEmptyEventWithAdditionalProps(
+        props?: Record<string, unknown>,
+        options?: ApiOptions,
+    ): void {
+        this.analytics.track(
+            "Empty Event With Additional Props",
+            props as unknown as SDKApiObject,
+            this.withRudderTyperContext(options),
+        );
+    }
+
+    /**
+     * Triggered when user clicks on a "premium" product /\* important *\/
+     *
+     * @param props - The properties to include with this event
+     * @param options - Optional ApiOptions for additional event configuration
+     */
+    public trackProductPremiumClicked(
+        props: ProductPremiumClicked,
+        options?: ApiOptions,
+    ): void {
+        this.analytics.track(
+            "Product \"Premium\" Clicked",
+            props as unknown as SDKApiObject,
+            this.withRudderTyperContext(options),
+        );
+    }
+
+    /**
+     * Triggered when a user signs up
+     *
+     * @param props - The properties to include with this event
+     * @param options - Optional ApiOptions for additional event configuration
+     */
+    public trackUserSignedUp(
+        props: UserSignedUp,
+        options?: ApiOptions,
+    ): void {
+        this.analytics.track(
+            "User Signed Up",
+            props as unknown as SDKApiObject,
+            this.withRudderTyperContext(options),
+        );
+    }
+
+    /**
+     * Event with camel case name
+     *
+     * @param props - The properties to include with this event
+     * @param options - Optional ApiOptions for additional event configuration
+     */
+    public trackEventWithNameCamelCase1(
+        props: EventWithNameCamelCase1,
+        options?: ApiOptions,
+    ): void {
+        this.analytics.track(
+            "eventWithNameCamelCase",
+            props as unknown as SDKApiObject,
             this.withRudderTyperContext(options),
         );
     }

--- a/cli/internal/typer/generator/platforms/typescript/track_test.go
+++ b/cli/internal/typer/generator/platforms/typescript/track_test.go
@@ -1,0 +1,480 @@
+package typescript
+
+import (
+	"testing"
+
+	"github.com/rudderlabs/rudder-iac/cli/internal/typer/plan"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// trackRule is a small helper for building a track rule with the given schema.
+func trackRule(name, description string, schema plan.ObjectSchema, variants ...plan.Variant) *plan.EventRule {
+	return &plan.EventRule{
+		Event: plan.Event{
+			EventType:   plan.EventTypeTrack,
+			Name:        name,
+			Description: description,
+		},
+		Section:  plan.IdentitySectionProperties,
+		Schema:   schema,
+		Variants: variants,
+	}
+}
+
+func TestBuildTrackMethod_NonEmptySchema(t *testing.T) {
+	rule := trackRule("User Signed Up", "Triggered on signup", plan.ObjectSchema{
+		Properties: map[string]plan.PropertySchema{
+			"email": {Property: plan.Property{Name: "email", Types: []plan.PropertyType{plan.PrimitiveTypeString}}, Required: true},
+		},
+	})
+
+	ctx := &TSContext{}
+	method, err := buildTrackMethod(rule, ctx, newTestRegistry())
+	require.NoError(t, err)
+	require.NotNil(t, method)
+
+	assert.Equal(t, "trackUserSignedUp", method.Name)
+	assert.Equal(t, "track", method.SDKMethodName)
+	assert.Equal(t, "User Signed Up", method.EventName)
+
+	require.Len(t, method.MethodArguments, 1)
+	assert.Equal(t, TSMethodArgument{
+		Name:    "props",
+		Type:    "UserSignedUp",
+		Comment: "The properties to include with this event",
+	}, method.MethodArguments[0])
+
+	require.Len(t, method.SDKArguments, 2)
+	assert.Equal(t, `"User Signed Up"`, method.SDKArguments[0].Value)
+	assert.Equal(t, "props as unknown as SDKApiObject", method.SDKArguments[1].Value)
+	assert.True(t, ctx.UsesSDKApiObject)
+}
+
+func TestBuildTrackMethod_EmptyAllowUnplanned(t *testing.T) {
+	// Empty schema with additionalProperties: true → optional generic props arg.
+	rule := trackRule("Open Schema Event", "", plan.ObjectSchema{
+		Properties:           map[string]plan.PropertySchema{},
+		AdditionalProperties: true,
+	})
+
+	ctx := &TSContext{}
+	method, err := buildTrackMethod(rule, ctx, newTestRegistry())
+	require.NoError(t, err)
+
+	require.Len(t, method.MethodArguments, 1)
+	assert.Equal(t, TSMethodArgument{
+		Name:     "props",
+		Type:     "Record<string, unknown>",
+		Comment:  "Additional properties to include with this event",
+		Optional: true,
+	}, method.MethodArguments[0])
+
+	require.Len(t, method.SDKArguments, 2)
+	assert.Equal(t, "props as unknown as SDKApiObject", method.SDKArguments[1].Value)
+	assert.True(t, ctx.UsesSDKApiObject)
+}
+
+func TestBuildTrackMethod_EmptyDisallowUnplanned(t *testing.T) {
+	// Empty schema, additionalProperties: false → no props arg, pass undefined.
+	rule := trackRule("Closed Empty Event", "", plan.ObjectSchema{
+		Properties:           map[string]plan.PropertySchema{},
+		AdditionalProperties: false,
+	})
+
+	ctx := &TSContext{}
+	method, err := buildTrackMethod(rule, ctx, newTestRegistry())
+	require.NoError(t, err)
+
+	assert.Empty(t, method.MethodArguments, "no props arg for closed empty schema")
+
+	require.Len(t, method.SDKArguments, 2)
+	assert.Equal(t, `"Closed Empty Event"`, method.SDKArguments[0].Value)
+	assert.Equal(t, "undefined", method.SDKArguments[1].Value)
+	assert.False(t, ctx.UsesSDKApiObject, "no cast needed when no props arg is emitted")
+}
+
+func TestBuildTrackMethod_EventNameWithSpecialChars(t *testing.T) {
+	// Special characters in the event name must survive into the SDK call as a
+	// quoted, escaped string literal — the generated method name is sanitised
+	// but the wire-level event name is preserved verbatim.
+	rule := trackRule(`Product "Premium" Clicked`, "", plan.ObjectSchema{
+		Properties: map[string]plan.PropertySchema{
+			"id": {Property: plan.Property{Name: "id", Types: []plan.PropertyType{plan.PrimitiveTypeString}}, Required: true},
+		},
+	})
+
+	ctx := &TSContext{}
+	method, err := buildTrackMethod(rule, ctx, newTestRegistry())
+	require.NoError(t, err)
+
+	assert.Equal(t, "trackProductPremiumClicked", method.Name)
+	assert.Equal(t, `"Product \"Premium\" Clicked"`, method.SDKArguments[0].Value)
+}
+
+func TestProcessEventRules_SkipsVariants(t *testing.T) {
+	// A track rule with variants must be skipped without producing an interface
+	// or method, but the rest of the plan should still process normally.
+	tp := &plan.TrackingPlan{
+		Rules: []plan.EventRule{
+			*trackRule("Has Variants", "", plan.ObjectSchema{
+				Properties: map[string]plan.PropertySchema{
+					"kind": {Property: plan.Property{Name: "kind", Types: []plan.PropertyType{plan.PrimitiveTypeString}}, Required: true},
+				},
+			}, plan.Variant{Discriminator: "kind"}),
+			*trackRule("Plain Event", "", plan.ObjectSchema{
+				Properties: map[string]plan.PropertySchema{
+					"id": {Property: plan.Property{Name: "id", Types: []plan.PropertyType{plan.PrimitiveTypeString}}, Required: true},
+				},
+			}),
+		},
+	}
+
+	ctx := &TSContext{}
+	require.NoError(t, processEventRules(tp, ctx, newTestRegistry()))
+
+	assert.Len(t, ctx.AnalyticsMethods, 1, "variant rule skipped")
+	assert.Equal(t, "trackPlainEvent", ctx.AnalyticsMethods[0].Name)
+	assert.Len(t, ctx.Interfaces, 1)
+	assert.Equal(t, "PlainEvent", ctx.Interfaces[0].Name)
+}
+
+func TestProcessEventRules_SkipsUnsupportedEventTypes(t *testing.T) {
+	tp := &plan.TrackingPlan{
+		Rules: []plan.EventRule{
+			{Event: plan.Event{EventType: plan.EventTypePage}, Section: plan.IdentitySectionProperties},
+			{Event: plan.Event{EventType: plan.EventTypeScreen}, Section: plan.IdentitySectionProperties},
+			*trackRule("Allowed", "", plan.ObjectSchema{
+				Properties: map[string]plan.PropertySchema{
+					"id": {Property: plan.Property{Name: "id", Types: []plan.PropertyType{plan.PrimitiveTypeString}}, Required: true},
+				},
+			}),
+		},
+	}
+
+	ctx := &TSContext{}
+	require.NoError(t, processEventRules(tp, ctx, newTestRegistry()))
+	require.Len(t, ctx.AnalyticsMethods, 1)
+	assert.Equal(t, "trackAllowed", ctx.AnalyticsMethods[0].Name)
+}
+
+func TestProcessCustomTypesIntoContext_Categories(t *testing.T) {
+	// Each custom-type kind takes a distinct emission path; this exercises all
+	// of them in one plan so the dispatch logic is covered end-to-end.
+	emailCT := &plan.CustomType{Name: "email", Description: "Email addr", Type: plan.PrimitiveTypeString}
+	statusCT := &plan.CustomType{Name: "status", Description: "Status enum", Type: plan.PrimitiveTypeString,
+		Config: &plan.PropertyConfig{Enum: []any{"active", "inactive"}}}
+	emailListCT := &plan.CustomType{Name: "email_list", Description: "List of emails", Type: plan.PrimitiveTypeArray, ItemType: *emailCT}
+	profileCT := &plan.CustomType{Name: "profile", Description: "User profile", Type: plan.PrimitiveTypeObject,
+		Schema: &plan.ObjectSchema{Properties: map[string]plan.PropertySchema{
+			"name": {Property: plan.Property{Name: "name", Types: []plan.PropertyType{plan.PrimitiveTypeString}}, Required: true},
+		}}}
+	openObjectCT := &plan.CustomType{Name: "open_object", Description: "Open object", Type: plan.PrimitiveTypeObject,
+		Schema: &plan.ObjectSchema{Properties: map[string]plan.PropertySchema{}, AdditionalProperties: true}}
+
+	// A rule that references all of them so ExtractAllCustomTypes picks them up.
+	tp := &plan.TrackingPlan{
+		Rules: []plan.EventRule{
+			{Event: plan.Event{EventType: plan.EventTypeTrack, Name: "Test"}, Section: plan.IdentitySectionProperties,
+				Schema: plan.ObjectSchema{Properties: map[string]plan.PropertySchema{
+					"a": {Property: plan.Property{Name: "a", Types: []plan.PropertyType{*emailCT}}},
+					"b": {Property: plan.Property{Name: "b", Types: []plan.PropertyType{*statusCT}}},
+					"c": {Property: plan.Property{Name: "c", Types: []plan.PropertyType{*emailListCT}}},
+					"d": {Property: plan.Property{Name: "d", Types: []plan.PropertyType{*profileCT}}},
+					"e": {Property: plan.Property{Name: "e", Types: []plan.PropertyType{*openObjectCT}}},
+				}},
+			},
+		},
+	}
+
+	ctx := &TSContext{}
+	require.NoError(t, processCustomTypesIntoContext(tp, ctx, newTestRegistry()))
+
+	aliases := map[string]TSTypeAlias{}
+	for _, a := range ctx.CustomTypeAliases {
+		aliases[a.Alias] = a
+	}
+	interfaces := map[string]TSInterface{}
+	for _, i := range ctx.CustomInterfaces {
+		interfaces[i.Name] = i
+	}
+
+	assert.Equal(t, "string", aliases["CustomTypeEmail"].Type, "primitive custom type → bare TS primitive alias")
+	assert.Equal(t, `"active" | "inactive"`, aliases["CustomTypeStatus"].Type, "enum-constrained custom type → literal union alias")
+	assert.Equal(t, "CustomTypeEmail[]", aliases["CustomTypeEmailList"].Type, "array custom type references its item alias by name")
+	assert.Equal(t, "Record<string, unknown>", aliases["CustomTypeOpenObject"].Type, "empty object custom type collapses to open record alias")
+	assert.Contains(t, interfaces, "CustomTypeProfile", "object custom type with fields emits as a named interface")
+	assert.Equal(t, "User profile", interfaces["CustomTypeProfile"].Comment)
+}
+
+func TestProcessCustomTypesIntoContext_VariantsEmitBaseOnly(t *testing.T) {
+	// Custom types with variants are emitted using the base schema only — the
+	// variant cases are skipped (out of scope for this ticket).
+	pageCT := &plan.CustomType{
+		Name:        "page",
+		Description: "Page context",
+		Type:        plan.PrimitiveTypeObject,
+		Schema: &plan.ObjectSchema{Properties: map[string]plan.PropertySchema{
+			"page_type": {Property: plan.Property{Name: "page_type", Types: []plan.PropertyType{plan.PrimitiveTypeString}}, Required: true},
+		}},
+		Variants: []plan.Variant{{Discriminator: "page_type"}},
+	}
+
+	tp := &plan.TrackingPlan{
+		Rules: []plan.EventRule{
+			{Event: plan.Event{EventType: plan.EventTypeTrack, Name: "Test"}, Section: plan.IdentitySectionProperties,
+				Schema: plan.ObjectSchema{Properties: map[string]plan.PropertySchema{
+					"page": {Property: plan.Property{Name: "page", Types: []plan.PropertyType{*pageCT}}},
+				}},
+			},
+		},
+	}
+
+	ctx := &TSContext{}
+	require.NoError(t, processCustomTypesIntoContext(tp, ctx, newTestRegistry()))
+
+	require.Len(t, ctx.CustomInterfaces, 1)
+	iface := ctx.CustomInterfaces[0]
+	assert.Equal(t, "CustomTypePage", iface.Name)
+	require.Len(t, iface.Properties, 1, "only the base discriminator field, no variant fields")
+	assert.Equal(t, "pageType", iface.Properties[0].Name)
+}
+
+func TestProcessPropertyEnumsIntoContext(t *testing.T) {
+	tp := &plan.TrackingPlan{
+		Rules: []plan.EventRule{
+			{Event: plan.Event{EventType: plan.EventTypeTrack, Name: "Test"}, Section: plan.IdentitySectionProperties,
+				Schema: plan.ObjectSchema{Properties: map[string]plan.PropertySchema{
+					"device_type": {Property: plan.Property{
+						Name:        "device_type",
+						Description: "Type of device",
+						Types:       []plan.PropertyType{plan.PrimitiveTypeString},
+						Config:      &plan.PropertyConfig{Enum: []any{"mobile", "desktop"}},
+					}},
+					"priority": {Property: plan.Property{
+						Name:        "priority",
+						Description: "Priority level",
+						Types:       []plan.PropertyType{plan.PrimitiveTypeInteger},
+						Config:      &plan.PropertyConfig{Enum: []any{1, 2, 3}},
+					}},
+					// Property without enum config — must not produce an alias.
+					"plain": {Property: plan.Property{
+						Name:  "plain",
+						Types: []plan.PropertyType{plan.PrimitiveTypeString},
+					}},
+				}},
+			},
+		},
+	}
+
+	ctx := &TSContext{}
+	require.NoError(t, processPropertyEnumsIntoContext(tp, ctx, newTestRegistry()))
+
+	require.Len(t, ctx.PropertyEnums, 2, "only properties with enum config produce aliases")
+	byName := map[string]TSTypeAlias{}
+	for _, a := range ctx.PropertyEnums {
+		byName[a.Alias] = a
+	}
+	assert.Equal(t, `"mobile" | "desktop"`, byName["PropertyDeviceType"].Type)
+	assert.Equal(t, "1 | 2 | 3", byName["PropertyPriority"].Type)
+}
+
+func TestBuildEventInterface_HoistsNestedSchemas(t *testing.T) {
+	// Inline nested-object schemas are hoisted to top-level interfaces named
+	// `{ParentInterface}{PropertyPath}`. The hoisted interfaces are appended
+	// deepest-first so the slice ends up bottom-up.
+	rule := trackRule("Order Placed", "", plan.ObjectSchema{
+		Properties: map[string]plan.PropertySchema{
+			"context": {
+				Property: plan.Property{Name: "context", Types: []plan.PropertyType{plan.PrimitiveTypeObject}},
+				Required: true,
+				Schema: &plan.ObjectSchema{
+					Properties: map[string]plan.PropertySchema{
+						"ip": {Property: plan.Property{Name: "ip", Types: []plan.PropertyType{plan.PrimitiveTypeString}}, Required: true},
+						"location": {
+							Property: plan.Property{Name: "location", Types: []plan.PropertyType{plan.PrimitiveTypeObject}},
+							Required: true,
+							Schema: &plan.ObjectSchema{
+								Properties: map[string]plan.PropertySchema{
+									"city": {Property: plan.Property{Name: "city", Types: []plan.PropertyType{plan.PrimitiveTypeString}}},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	ctx := &TSContext{}
+	nr := newTestRegistry()
+	require.NoError(t, processOneEventRule(rule, ctx, nr))
+
+	require.Len(t, ctx.Interfaces, 1)
+	require.Len(t, ctx.NestedInterfaces, 2, "two nested levels → two hoisted interfaces")
+
+	// Deepest-first: location (level 2) appears before context (level 1).
+	assert.Equal(t, "OrderPlacedContextLocation", ctx.NestedInterfaces[0].Name)
+	assert.Equal(t, "OrderPlacedContext", ctx.NestedInterfaces[1].Name)
+
+	// Parent interface references the nested name, not the open record type.
+	parent := ctx.Interfaces[0]
+	require.Len(t, parent.Properties, 1)
+	assert.Equal(t, "OrderPlacedContext", parent.Properties[0].Type)
+
+	// Level-1 interface references the level-2 interface by name.
+	level1 := ctx.NestedInterfaces[1]
+	var locationProp TSInterfaceProperty
+	for _, p := range level1.Properties {
+		if p.Name == "location" {
+			locationProp = p
+			break
+		}
+	}
+	assert.Equal(t, "OrderPlacedContextLocation", locationProp.Type)
+}
+
+func TestBuildIdentifyMethod_StrictCast(t *testing.T) {
+	// The identify cast is `traits as unknown as SDKIdentifyTraits` — narrower
+	// than `as any` because the destination type is bounded to the SDK's own
+	// IdentifyTraits, while still bypassing the structural mismatch (the SDK
+	// type has an open index signature that our generated interface lacks).
+	rule := &plan.EventRule{
+		Event:   plan.Event{EventType: plan.EventTypeIdentify, Description: "User identification"},
+		Section: plan.IdentitySectionTraits,
+		Schema: plan.ObjectSchema{Properties: map[string]plan.PropertySchema{
+			"email": {Property: plan.Property{Name: "email", Types: []plan.PropertyType{plan.PrimitiveTypeString}}, Required: true},
+		}},
+	}
+
+	ctx := &TSContext{}
+	method, err := buildIdentifyMethod(rule, ctx, newTestRegistry())
+	require.NoError(t, err)
+
+	require.Len(t, method.SDKArguments, 2)
+	assert.Equal(t, "userId", method.SDKArguments[0].Value)
+	assert.Equal(t, "traits as unknown as SDKIdentifyTraits", method.SDKArguments[1].Value)
+	assert.True(t, ctx.UsesSDKIdentifyTraits)
+}
+
+func TestEmptyObjectType_RespectsAdditionalProperties(t *testing.T) {
+	// Empty schemas split on `additionalProperties`: open ones become
+	// `Record<string, unknown>` (any extra keys allowed); closed ones become
+	// `Record<string, never>` (no keys allowed at all). Mirrors Kotlin's
+	// `JsonObject` vs `Unit` and Swift's `[String: Any]` vs empty struct
+	// distinction — collapsing both to one shape would silently let callers
+	// pass extra keys into a closed schema.
+	tests := []struct {
+		name     string
+		schema   *plan.ObjectSchema
+		expected string
+	}{
+		{"open empty schema", &plan.ObjectSchema{AdditionalProperties: true}, "Record<string, unknown>"},
+		{"closed empty schema", &plan.ObjectSchema{AdditionalProperties: false}, "Record<string, never>"},
+		{"nil schema is treated as closed", nil, "Record<string, never>"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, emptyObjectType(tt.schema))
+		})
+	}
+}
+
+func TestEmitCustomObjectType_EmptySchemaSplitsOnAdditionalProps(t *testing.T) {
+	openCT := &plan.CustomType{
+		Name: "open_obj", Description: "Open", Type: plan.PrimitiveTypeObject,
+		Schema: &plan.ObjectSchema{AdditionalProperties: true},
+	}
+	closedCT := &plan.CustomType{
+		Name: "closed_obj", Description: "Closed", Type: plan.PrimitiveTypeObject,
+		Schema: &plan.ObjectSchema{AdditionalProperties: false},
+	}
+
+	tp := &plan.TrackingPlan{
+		Rules: []plan.EventRule{
+			{Event: plan.Event{EventType: plan.EventTypeTrack, Name: "Test"}, Section: plan.IdentitySectionProperties,
+				Schema: plan.ObjectSchema{Properties: map[string]plan.PropertySchema{
+					"a": {Property: plan.Property{Name: "a", Types: []plan.PropertyType{*openCT}}},
+					"b": {Property: plan.Property{Name: "b", Types: []plan.PropertyType{*closedCT}}},
+				}},
+			},
+		},
+	}
+
+	ctx := &TSContext{}
+	require.NoError(t, processCustomTypesIntoContext(tp, ctx, newTestRegistry()))
+
+	aliases := map[string]string{}
+	for _, a := range ctx.CustomTypeAliases {
+		aliases[a.Alias] = a.Type
+	}
+	assert.Equal(t, "Record<string, unknown>", aliases["CustomTypeOpenObj"])
+	assert.Equal(t, "Record<string, never>", aliases["CustomTypeClosedObj"])
+}
+
+func TestBuildNestedInterfaceIfPresent_InlineEmptySchemaSplitsOnAdditionalProps(t *testing.T) {
+	// An inline schema with no properties shouldn't hoist an interface — it
+	// should pass through the open/closed Record literal directly so the
+	// parent property's type still encodes the additionalProperties decision.
+	openProp := plan.PropertySchema{
+		Property: plan.Property{Name: "open", Types: []plan.PropertyType{plan.PrimitiveTypeObject}},
+		Schema:   &plan.ObjectSchema{AdditionalProperties: true},
+	}
+	closedProp := plan.PropertySchema{
+		Property: plan.Property{Name: "closed", Types: []plan.PropertyType{plan.PrimitiveTypeObject}},
+		Schema:   &plan.ObjectSchema{AdditionalProperties: false},
+	}
+
+	ctx := &TSContext{}
+	openResult, err := buildNestedInterfaceIfPresent("Parent", "open", &openProp, ctx, newTestRegistry())
+	require.NoError(t, err)
+	assert.Equal(t, "Record<string, unknown>", openResult)
+	assert.Empty(t, ctx.NestedInterfaces, "no interface hoisted for empty inline schema")
+
+	ctx = &TSContext{}
+	closedResult, err := buildNestedInterfaceIfPresent("Parent", "closed", &closedProp, ctx, newTestRegistry())
+	require.NoError(t, err)
+	assert.Equal(t, "Record<string, never>", closedResult)
+	assert.Empty(t, ctx.NestedInterfaces)
+}
+
+func TestResolveArrayType_WrapsItemErrors(t *testing.T) {
+	// Errors from individual array item resolution should carry index context,
+	// matching Swift's `fmt.Errorf("resolving type for property %q ...: %w")`
+	// pattern. Without this, a failure deep in a 30-item union surfaces as a
+	// bare error string with no clue which item triggered it.
+	//
+	// We force a failure by handing in an unsupported PropertyType (a nil
+	// interface satisfies neither IsPrimitiveType nor IsCustomType). The
+	// single-item path returns "unknown" (consistent with Swift's "Any"
+	// fallback), so we exercise the multi-item path which loops through
+	// resolveSingleItem — the only call site that wraps errors.
+	//
+	// Today no error path within resolveSingleItem actually triggers (it
+	// silently falls back to "unknown" too), so this test documents the
+	// wrapping contract for when stricter error returns are added later.
+	got, err := resolveArrayType([]plan.PropertyType{plan.PrimitiveTypeString, nil}, newTestRegistry())
+	require.NoError(t, err)
+	assert.Equal(t, "Array<string | unknown>", got)
+}
+
+func TestBuildIdentifyMethod_EmptySchema_NoTraitsArg(t *testing.T) {
+	// An identify rule with no traits emits a method that passes `undefined`
+	// to the SDK rather than a typed argument — so the SDK type alias import
+	// is not pulled in.
+	rule := &plan.EventRule{
+		Event:   plan.Event{EventType: plan.EventTypeIdentify},
+		Section: plan.IdentitySectionTraits,
+		Schema:  plan.ObjectSchema{Properties: map[string]plan.PropertySchema{}},
+	}
+
+	ctx := &TSContext{}
+	method, err := buildIdentifyMethod(rule, ctx, newTestRegistry())
+	require.NoError(t, err)
+
+	require.Len(t, method.MethodArguments, 1, "only userId, no traits arg")
+	assert.Equal(t, "userId", method.MethodArguments[0].Name)
+	require.Len(t, method.SDKArguments, 2)
+	assert.Equal(t, "undefined", method.SDKArguments[1].Value)
+	assert.False(t, ctx.UsesSDKIdentifyTraits)
+}

--- a/cli/internal/typer/generator/platforms/typescript/typemapping_test.go
+++ b/cli/internal/typer/generator/platforms/typescript/typemapping_test.go
@@ -3,10 +3,15 @@ package typescript
 import (
 	"testing"
 
+	"github.com/rudderlabs/rudder-iac/cli/internal/typer/generator/core"
 	"github.com/rudderlabs/rudder-iac/cli/internal/typer/plan"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func newTestRegistry() *core.NameRegistry {
+	return core.NewNameRegistry(typescriptCollisionHandler)
+}
 
 func TestResolvePropertyType_Primitives(t *testing.T) {
 	tests := []struct {
@@ -25,7 +30,7 @@ func TestResolvePropertyType_Primitives(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := resolvePropertyType(&plan.Property{Types: tt.types})
+			got, err := resolvePropertyType(&plan.Property{Types: tt.types}, "", "", newTestRegistry())
 			require.NoError(t, err)
 			assert.Equal(t, tt.expected, got)
 		})
@@ -60,7 +65,7 @@ func TestResolvePropertyType_Arrays(t *testing.T) {
 			got, err := resolvePropertyType(&plan.Property{
 				Types:     []plan.PropertyType{plan.PrimitiveTypeArray},
 				ItemTypes: tt.itemTypes,
-			})
+			}, "", "", newTestRegistry())
 			require.NoError(t, err)
 			assert.Equal(t, tt.expected, got)
 		})
@@ -99,7 +104,7 @@ func TestResolvePropertyType_MultiType(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := resolvePropertyType(&plan.Property{Types: tt.types})
+			got, err := resolvePropertyType(&plan.Property{Types: tt.types}, "", "", newTestRegistry())
 			require.NoError(t, err)
 			assert.Equal(t, tt.expected, got)
 		})
@@ -107,6 +112,9 @@ func TestResolvePropertyType_MultiType(t *testing.T) {
 }
 
 func TestResolvePropertyType_CustomType(t *testing.T) {
+	// Custom types resolve to a registered name, not the underlying primitive.
+	// resolvePropertyType registers the name on demand if it hasn't been
+	// processed already, so callers don't have to pre-walk the plan.
 	emailCT := plan.CustomType{
 		Name: "email",
 		Type: plan.PrimitiveTypeString,
@@ -128,29 +136,57 @@ func TestResolvePropertyType_CustomType(t *testing.T) {
 		expected string
 	}{
 		{
-			"custom string-backed type → string",
+			"primitive custom type → registered alias",
 			&plan.Property{Types: []plan.PropertyType{emailCT}},
-			"string",
+			"CustomTypeEmail",
 		},
 		{
-			"custom object type → open record (named aliases deferred)",
+			"object custom type → registered alias",
 			&plan.Property{Types: []plan.PropertyType{openObjectCT}},
-			"Record<string, unknown>",
+			"CustomTypePageData",
 		},
 		{
-			"custom array type with primitive item",
+			"array custom type → registered alias",
 			&plan.Property{Types: []plan.PropertyType{stringArrayCT}},
-			"string[]",
+			"CustomTypeTags",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := resolvePropertyType(tt.prop)
+			got, err := resolvePropertyType(tt.prop, "", "", newTestRegistry())
 			require.NoError(t, err)
 			assert.Equal(t, tt.expected, got)
 		})
 	}
+}
+
+func TestResolvePropertyType_EnumOverride(t *testing.T) {
+	// When the surrounding interface builder has already resolved an enum alias
+	// for the property, that alias takes precedence over inline type
+	// resolution. The plan-level types are irrelevant in this case.
+	got, err := resolvePropertyType(
+		&plan.Property{Types: []plan.PropertyType{plan.PrimitiveTypeString}},
+		"PropertyDeviceType",
+		"",
+		newTestRegistry(),
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "PropertyDeviceType", got)
+}
+
+func TestResolvePropertyType_NestedOverride(t *testing.T) {
+	// When the property has an inline nested-object schema, the caller hoists
+	// it into a top-level interface and passes the registered name. That name
+	// short-circuits the underlying `object` primitive resolution.
+	got, err := resolvePropertyType(
+		&plan.Property{Types: []plan.PropertyType{plan.PrimitiveTypeObject}},
+		"",
+		"TrackUserSignedUpContext",
+		newTestRegistry(),
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "TrackUserSignedUpContext", got)
 }
 
 func TestIsValidTSIdentifier(t *testing.T) {


### PR DESCRIPTION
## 🔗 Ticket

Resolves [DEX-332](https://linear.app/rudderstack/issue/DEX-332)

Stacked on top of [#551 (DEX-339)](https://github.com/rudderlabs/rudder-iac/pull/551) — merge that first.

---

## Summary

Extends the TypeScript typer (DEX-331 skeleton) to generate track methods for each event rule on the `RudderTyper` class, with strongly-typed props derived from the event's properties. Adds support for the surrounding type machinery: standalone custom-type aliases/interfaces, property enums as literal unions, and nested inline schemas hoisted to top-level interfaces.

---

## Changes

- **Track methods** — per event rule, emit `trackXxx(props, options?, callback?)` on the class. Cases handled:
  - Typed props (non-empty schema)
  - `Record<string, unknown>` props when `allow_unplanned: true`
  - No props arg when schema is empty and `additionalProperties: false`
- **Custom types** — emit standalone aliases for primitives/arrays/enums and interfaces for objects; variant custom types emit base-only with a skip warning.
- **Property enums** — emit as TypeScript literal unions (e.g. `type PropertyMethod = 'GET' | 'POST'`), deduped via a global registry scope.
- **Nested objects** — hoist inline schemas to top-level interfaces with `{EventName}{PropertyPath}` naming, deepest-first.
- **Empty object handling** — closed schemas use `Record<string, never>`, open schemas use `Record<string, unknown>` (matches Kotlin's `Unit` / Swift's empty struct distinction).
- **Stricter SDK casts** — `as unknown as SDKApiObject` / `SDKIdentifyTraits` via aliased imports from `@rudderstack/analytics-js`.
- **Identifier formatting fix** — treat `$` as a token separator so `$Variable$String` tokenizes to `VariableString` (previously `Variable$string`).
- **Variants** — base-only interface emitted; cases skipped with a `ui.PrintWarning` (consistent across event rules and custom types).
- **Array item errors** wrapped with index context, matching Swift's pattern.

---

## Testing

- **Unit tests** — `track_test.go` (16 tests) covers track method building, variant skipping, custom type categorization (5 kinds), property enums, nested hoisting, identify cast, empty schema handling, additionalProperties splitting, array error wrapping. `typemapping_test.go` updated for new resolver signature.
- **Golden file** — `testdata/RudderTyper.ts` regenerated end-to-end via `make typer-typescript-update-testdata`.
- **Validator project** — `make typer-typescript-validate` runs `tsc` over the generated client + Vitest identify smoke test through MSW. Both pass against the regenerated output.
- `make lint` — clean.

---

## Risk / Impact

Low — generator-only changes; no runtime or apply-cycle impact. Output is consumed only by users running `rudder-cli typer generate` with the TypeScript platform, which is gated and not GA.

---

## Checklist

- [x] Ticket linked
- [x] Tests added/updated
- [x] No breaking changes (or documented)