### PR TITLE
Add validator coverage for multi-type, group, and page events

### DIFF
--- a/cli/internal/typer/generator/platforms/typescript/generator.go
+++ b/cli/internal/typer/generator/platforms/typescript/generator.go
@@ -1164,7 +1164,7 @@ func buildIdentityCallBranches(spec identityCallSpec) []TSDispatcherBranch {
 
 func buildIdentityCallBranchesContextTraits(spec identityCallSpec) []TSDispatcherBranch {
 	contextTraitsCast := func(argName string) string {
-		return argName + " as unknown as Record<string, unknown>"
+		return argName + " as unknown as SDKApiObject"
 	}
 
 	withID := TSDispatcherBranch{
@@ -1181,7 +1181,7 @@ func buildIdentityCallBranchesContextTraits(spec identityCallSpec) []TSDispatche
 	if spec.AllowAnonymous {
 		branches = append(branches, TSDispatcherBranch{
 			SDKArguments: []TSSDKArgument{
-				{Value: "undefined"},
+				{Value: "null"},
 				{Value: "this.withRudderTyperContext(traitsOrOptions as ApiOptions | undefined, " + contextTraitsCast(spec.IDArgName) + ")"},
 				{Value: "optionsOrCallback as ApiCallback | undefined"},
 			},

--- a/cli/internal/typer/generator/platforms/typescript/identity_test.go
+++ b/cli/internal/typer/generator/platforms/typescript/identity_test.go
@@ -143,14 +143,14 @@ func TestBuildIdentifyMethod_ContextTraitsRoutesToContext(t *testing.T) {
 			SDKArguments: []TSSDKArgument{
 				{Value: "userIdOrTraits"},
 				{Value: "undefined"},
-				{Value: "this.withRudderTyperContext(optionsOrCallback as ApiOptions | undefined, traitsOrOptions as unknown as Record<string, unknown>)"},
+				{Value: "this.withRudderTyperContext(optionsOrCallback as ApiOptions | undefined, traitsOrOptions as unknown as SDKApiObject)"},
 				{Value: "callback"},
 			},
 		},
 		{
 			SDKArguments: []TSSDKArgument{
-				{Value: "undefined"},
-				{Value: "this.withRudderTyperContext(traitsOrOptions as ApiOptions | undefined, userIdOrTraits as unknown as Record<string, unknown>)"},
+				{Value: "null"},
+				{Value: "this.withRudderTyperContext(traitsOrOptions as ApiOptions | undefined, userIdOrTraits as unknown as SDKApiObject)"},
 				{Value: "optionsOrCallback as ApiCallback | undefined"},
 			},
 		},
@@ -271,14 +271,14 @@ func TestBuildGroupMethod_ContextTraitsRoutesToContext(t *testing.T) {
 			SDKArguments: []TSSDKArgument{
 				{Value: "groupIdOrTraits"},
 				{Value: "undefined"},
-				{Value: "this.withRudderTyperContext(optionsOrCallback as ApiOptions | undefined, traitsOrOptions as unknown as Record<string, unknown>)"},
+				{Value: "this.withRudderTyperContext(optionsOrCallback as ApiOptions | undefined, traitsOrOptions as unknown as SDKApiObject)"},
 				{Value: "callback"},
 			},
 		},
 		{
 			SDKArguments: []TSSDKArgument{
-				{Value: "undefined"},
-				{Value: "this.withRudderTyperContext(traitsOrOptions as ApiOptions | undefined, groupIdOrTraits as unknown as Record<string, unknown>)"},
+				{Value: "null"},
+				{Value: "this.withRudderTyperContext(traitsOrOptions as ApiOptions | undefined, groupIdOrTraits as unknown as SDKApiObject)"},
 				{Value: "optionsOrCallback as ApiCallback | undefined"},
 			},
 		},

--- a/cli/internal/typer/generator/platforms/typescript/templates/ruddertyper.tmpl
+++ b/cli/internal/typer/generator/platforms/typescript/templates/ruddertyper.tmpl
@@ -95,8 +95,8 @@ export class RudderTyper {
     }
 {{- end }}
 {{ end }}
-    private withRudderTyperContext(options?: ApiOptions, contextTraits?: Record<string, unknown>): ApiOptions {
-        const rudderTyperContext: Record<string, unknown> = {
+    private withRudderTyperContext(options?: ApiOptions, contextTraits?: SDKApiObject): ApiOptions {
+        const rudderTyperContext: SDKApiObject = {
             ruddertyper: {
 {{- range $key, $value := .EventContext }}
                 "{{ escapeString $key }}": {{ $value }},
@@ -109,7 +109,7 @@ export class RudderTyper {
         return {
             ...(options ?? {}),
             context: {
-                ...((options?.context ?? {}) as Record<string, unknown>),
+                ...((options?.context ?? {}) as SDKApiObject),
                 ...rudderTyperContext,
             },
         };

--- a/cli/internal/typer/generator/platforms/typescript/testdata/RudderTyper.ts
+++ b/cli/internal/typer/generator/platforms/typescript/testdata/RudderTyper.ts
@@ -334,13 +334,13 @@ export class RudderTyper {
             this.analytics.group(
                 groupIdOrTraits,
                 undefined,
-                this.withRudderTyperContext(optionsOrCallback as ApiOptions | undefined, traitsOrOptions as unknown as Record<string, unknown>),
+                this.withRudderTyperContext(optionsOrCallback as ApiOptions | undefined, traitsOrOptions as unknown as SDKApiObject),
                 callback,
             );
         } else {
             this.analytics.group(
-                undefined,
-                this.withRudderTyperContext(traitsOrOptions as ApiOptions | undefined, groupIdOrTraits as unknown as Record<string, unknown>),
+                null,
+                this.withRudderTyperContext(traitsOrOptions as ApiOptions | undefined, groupIdOrTraits as unknown as SDKApiObject),
                 optionsOrCallback as ApiCallback | undefined,
             );
         }
@@ -572,8 +572,8 @@ export class RudderTyper {
         );
     }
 
-    private withRudderTyperContext(options?: ApiOptions, contextTraits?: Record<string, unknown>): ApiOptions {
-        const rudderTyperContext: Record<string, unknown> = {
+    private withRudderTyperContext(options?: ApiOptions, contextTraits?: SDKApiObject): ApiOptions {
+        const rudderTyperContext: SDKApiObject = {
             ruddertyper: {
                 "platform": "typescript",
                 "rudderCLIVersion": "1.0.0",
@@ -587,7 +587,7 @@ export class RudderTyper {
         return {
             ...(options ?? {}),
             context: {
-                ...((options?.context ?? {}) as Record<string, unknown>),
+                ...((options?.context ?? {}) as SDKApiObject),
                 ...rudderTyperContext,
             },
         };

--- a/cli/internal/typer/generator/platforms/typescript/testdata/validator/src/__tests__/group.test.ts
+++ b/cli/internal/typer/generator/platforms/typescript/testdata/validator/src/__tests__/group.test.ts
@@ -1,0 +1,62 @@
+import { RudderAnalytics } from "@rudderstack/analytics-js/bundled";
+import { beforeEach, describe, expect, it } from "vitest";
+import { RudderTyper } from "../RudderTyper/RudderTyper.ts";
+import {
+  TEST_CONFIG_BE_URL,
+  TEST_DATA_PLANE_URL,
+  TEST_WRITE_KEY,
+  interceptor,
+} from "./eventInterceptor.ts";
+
+describe("RudderTyper.group", () => {
+  let typer: RudderTyper;
+
+  beforeEach(async () => {
+    const analytics = new RudderAnalytics();
+    analytics.load(TEST_WRITE_KEY, TEST_DATA_PLANE_URL, {
+      configUrl: TEST_CONFIG_BE_URL,
+      logLevel: "ERROR",
+      queueOptions: { maxItems: 100, batch: { enabled: false } },
+      sessions: { autoTrack: false },
+      uaChTrackLevel: "none",
+    });
+    await new Promise<void>((resolve) => analytics.ready(() => resolve()));
+    typer = new RudderTyper(analytics);
+  });
+
+  it("dispatches a group event with groupId and traits routed through context.traits", async () => {
+    typer.group("company-xyz-789", { active: true, status: "active" });
+
+    const [event] = await interceptor.waitForEvents(1);
+
+    expect(event.type).toBe("group");
+    expect(event.groupId).toBe("company-xyz-789");
+    const contextTraits = (event.context as Record<string, unknown>)?.traits;
+    expect(contextTraits).toEqual({ active: true, status: "active" });
+  });
+
+  it("dispatches a group event with required-only traits", async () => {
+    typer.group("org-456", { active: false });
+
+    const [event] = await interceptor.waitForEvents(1);
+
+    expect(event.type).toBe("group");
+    expect(event.groupId).toBe("org-456");
+    const contextTraits = (event.context as Record<string, unknown>)?.traits;
+    expect(contextTraits).toEqual({ active: false });
+  });
+
+  it("merges the ruddertyper context into the dispatched group event", async () => {
+    typer.group("company-xyz-789", { active: true });
+
+    const [event] = await interceptor.waitForEvents(1);
+
+    const ctx = (event.context ?? {}) as Record<string, unknown>;
+    expect(ctx.ruddertyper).toEqual({
+      platform: "typescript",
+      rudderCLIVersion: "1.0.0",
+      trackingPlanId: "plan_12345",
+      trackingPlanVersion: 13,
+    });
+  });
+});

--- a/cli/internal/typer/generator/platforms/typescript/testdata/validator/src/__tests__/multitype.test.ts
+++ b/cli/internal/typer/generator/platforms/typescript/testdata/validator/src/__tests__/multitype.test.ts
@@ -1,0 +1,213 @@
+import { RudderAnalytics } from "@rudderstack/analytics-js/bundled";
+import { beforeEach, describe, expect, it } from "vitest";
+import { RudderTyper } from "../RudderTyper/RudderTyper.ts";
+import {
+  TEST_CONFIG_BE_URL,
+  TEST_DATA_PLANE_URL,
+  TEST_WRITE_KEY,
+  interceptor,
+} from "./eventInterceptor.ts";
+
+describe("RudderTyper.track (multi-type properties)", () => {
+  let typer: RudderTyper;
+
+  beforeEach(async () => {
+    const analytics = new RudderAnalytics();
+    analytics.load(TEST_WRITE_KEY, TEST_DATA_PLANE_URL, {
+      configUrl: TEST_CONFIG_BE_URL,
+      logLevel: "ERROR",
+      queueOptions: { maxItems: 100, batch: { enabled: false } },
+      sessions: { autoTrack: false },
+      uaChTrackLevel: "none",
+    });
+    await new Promise<void>((resolve) => analytics.ready(() => resolve()));
+    typer = new RudderTyper(analytics);
+  });
+
+  // ---- multiTypeField: string | number | boolean ----
+
+  it("multiTypeField serializes each variant type correctly", async () => {
+    typer.trackUserSignedUp({
+      active: true,
+      profile: { email: "string@example.com", firstName: "String" },
+      multiTypeField: "hello world",
+    });
+    typer.trackUserSignedUp({
+      active: true,
+      profile: { email: "number@example.com", firstName: "Number" },
+      multiTypeField: 42,
+    });
+    typer.trackUserSignedUp({
+      active: true,
+      profile: { email: "bool@example.com", firstName: "Bool" },
+      multiTypeField: false,
+    });
+
+    const events = await interceptor.waitForEvents(3);
+
+    expect(events.map((e) => e.properties)).toEqual([
+      {
+        active: true,
+        profile: { email: "string@example.com", firstName: "String" },
+        multiTypeField: "hello world",
+      },
+      {
+        active: true,
+        profile: { email: "number@example.com", firstName: "Number" },
+        multiTypeField: 42,
+      },
+      {
+        active: true,
+        profile: { email: "bool@example.com", firstName: "Bool" },
+        multiTypeField: false,
+      },
+    ]);
+  });
+
+  // ---- multiTypeArray: Array<string | number> ----
+
+  it("multiTypeArray serializes mixed string and number items", async () => {
+    typer.trackUserSignedUp({
+      active: true,
+      profile: { email: "array@example.com", firstName: "Array" },
+      multiTypeArray: ["alpha", 1, "beta", 2, "gamma", 3],
+    });
+
+    const [event] = await interceptor.waitForEvents(1);
+
+    expect(event.type).toBe("track");
+    expect(event.properties).toEqual({
+      active: true,
+      profile: { email: "array@example.com", firstName: "Array" },
+      multiTypeArray: ["alpha", 1, "beta", 2, "gamma", 3],
+    });
+  });
+
+  // ---- multiTypeWithNull: string | number | null ----
+
+  it("multiTypeWithNull serializes string, number, and null variants", async () => {
+    typer.trackUserSignedUp({
+      active: true,
+      profile: { email: "mtn@example.com", firstName: "MTN" },
+      multiTypeWithNull: "not-null",
+    });
+    typer.trackUserSignedUp({
+      active: true,
+      profile: { email: "mtn@example.com", firstName: "MTN" },
+      multiTypeWithNull: 99,
+    });
+    typer.trackUserSignedUp({
+      active: true,
+      profile: { email: "mtn@example.com", firstName: "MTN" },
+      multiTypeWithNull: null,
+    });
+
+    const events = await interceptor.waitForEvents(3);
+
+    // The SDK strips null top-level property values from the payload,
+    // so the null variant results in the property being absent.
+    expect(events.map((e) => e.properties)).toEqual([
+      {
+        active: true,
+        profile: { email: "mtn@example.com", firstName: "MTN" },
+        multiTypeWithNull: "not-null",
+      },
+      {
+        active: true,
+        profile: { email: "mtn@example.com", firstName: "MTN" },
+        multiTypeWithNull: 99,
+      },
+      {
+        active: true,
+        profile: { email: "mtn@example.com", firstName: "MTN" },
+      },
+    ]);
+  });
+
+  // ---- stringOrNull / numberOrNull ----
+
+  it("stringOrNull and numberOrNull serialize both value and null variants", async () => {
+    typer.trackUserSignedUp({
+      active: true,
+      profile: { email: "sn@example.com", firstName: "SN" },
+      stringOrNull: "present",
+      numberOrNull: 3.14,
+    });
+    typer.trackUserSignedUp({
+      active: true,
+      profile: { email: "sn@example.com", firstName: "SN" },
+      stringOrNull: null,
+      numberOrNull: null,
+    });
+
+    const events = await interceptor.waitForEvents(2);
+
+    // The SDK strips null top-level property values from the payload.
+    expect(events.map((e) => e.properties)).toEqual([
+      {
+        active: true,
+        profile: { email: "sn@example.com", firstName: "SN" },
+        stringOrNull: "present",
+        numberOrNull: 3.14,
+      },
+      {
+        active: true,
+        profile: { email: "sn@example.com", firstName: "SN" },
+      },
+    ]);
+  });
+
+  // ---- arrayWithNullItems: Array<string | null> ----
+
+  it("arrayWithNullItems serializes an array mixing string and null items", async () => {
+    typer.trackUserSignedUp({
+      active: true,
+      profile: { email: "arr@example.com", firstName: "Arr" },
+      arrayWithNullItems: ["one", null, "three", null],
+    });
+
+    const [event] = await interceptor.waitForEvents(1);
+
+    expect(event.type).toBe("track");
+    expect(event.properties).toEqual({
+      active: true,
+      profile: { email: "arr@example.com", firstName: "Arr" },
+      arrayWithNullItems: ["one", null, "three", null],
+    });
+  });
+
+  // ---- combined: multi-type fields alongside nested objects ----
+
+  it("multi-type properties coexist with nested object and array properties", async () => {
+    typer.trackUserSignedUp({
+      active: true,
+      profile: { email: "combo@example.com", firstName: "Combo" },
+      multiTypeField: "text",
+      multiTypeArray: [100, "mixed"],
+      numberOrNull: 2.718,
+      context: {
+        ipAddress: "10.0.0.1",
+        nestedContext: {
+          profile: { email: "nested@example.com", firstName: "Nested" },
+        },
+      },
+    });
+
+    const [event] = await interceptor.waitForEvents(1);
+
+    expect(event.type).toBe("track");
+    expect(event.properties).toEqual({
+      active: true,
+      profile: { email: "combo@example.com", firstName: "Combo" },
+      multiTypeField: "text",
+      multiTypeArray: [100, "mixed"],
+      numberOrNull: 2.718,
+      context: {
+        ipAddress: "10.0.0.1",
+        nestedContext: {
+          profile: { email: "nested@example.com", firstName: "Nested" },
+        },
+      },
+    });
+  });
+});

--- a/cli/internal/typer/generator/platforms/typescript/testdata/validator/src/__tests__/page.test.ts
+++ b/cli/internal/typer/generator/platforms/typescript/testdata/validator/src/__tests__/page.test.ts
@@ -1,0 +1,109 @@
+import { RudderAnalytics } from "@rudderstack/analytics-js/bundled";
+import { beforeEach, describe, expect, it } from "vitest";
+import { RudderTyper } from "../RudderTyper/RudderTyper.ts";
+import {
+  TEST_CONFIG_BE_URL,
+  TEST_DATA_PLANE_URL,
+  TEST_WRITE_KEY,
+  interceptor,
+} from "./eventInterceptor.ts";
+
+describe("RudderTyper.page", () => {
+  let typer: RudderTyper;
+
+  beforeEach(async () => {
+    const analytics = new RudderAnalytics();
+    analytics.load(TEST_WRITE_KEY, TEST_DATA_PLANE_URL, {
+      configUrl: TEST_CONFIG_BE_URL,
+      logLevel: "ERROR",
+      queueOptions: { maxItems: 100, batch: { enabled: false } },
+      sessions: { autoTrack: false },
+      uaChTrackLevel: "none",
+    });
+    await new Promise<void>((resolve) => analytics.ready(() => resolve()));
+    typer = new RudderTyper(analytics);
+  });
+
+  it("dispatches a page event with name and typed properties", async () => {
+    typer.page("Dashboard", {
+      profile: {
+        email: "user@example.com",
+        firstName: "Alice",
+        lastName: "Johnson",
+      },
+    });
+
+    const [event] = await interceptor.waitForEvents(1);
+
+    expect(event.type).toBe("page");
+    expect(event.name).toBe("Dashboard");
+    expect(event.properties).toMatchObject({
+      profile: {
+        email: "user@example.com",
+        firstName: "Alice",
+        lastName: "Johnson",
+      },
+      name: "Dashboard",
+    });
+  });
+
+  it("dispatches a page event with category, name, and properties", async () => {
+    typer.page("Main Navigation", "Dashboard", {
+      profile: {
+        email: "user@example.com",
+        firstName: "Alice",
+        lastName: "Johnson",
+      },
+    });
+
+    const [event] = await interceptor.waitForEvents(1);
+
+    expect(event.type).toBe("page");
+    expect(event.name).toBe("Dashboard");
+    expect(event.category).toBe("Main Navigation");
+    expect(event.properties).toMatchObject({
+      profile: {
+        email: "user@example.com",
+        firstName: "Alice",
+        lastName: "Johnson",
+      },
+      name: "Dashboard",
+      category: "Main Navigation",
+    });
+  });
+
+  it("dispatches a page event with properties only (no name)", async () => {
+    typer.page({
+      profile: {
+        email: "anon@example.com",
+        firstName: "Anonymous",
+      },
+    });
+
+    const [event] = await interceptor.waitForEvents(1);
+
+    expect(event.type).toBe("page");
+    expect(event.properties).toMatchObject({
+      profile: {
+        email: "anon@example.com",
+        firstName: "Anonymous",
+      },
+    });
+  });
+
+  it("merges the ruddertyper context into the dispatched page event", async () => {
+    typer.page("Settings", {
+      profile: { email: "ctx@example.com", firstName: "Ctx" },
+    });
+
+    const [event] = await interceptor.waitForEvents(1);
+
+    const ctx = (event.context ?? {}) as Record<string, unknown>;
+    expect(ctx.ruddertyper).toEqual({
+      platform: "typescript",
+      rudderCLIVersion: "1.0.0",
+      trackingPlanId: "plan_12345",
+      trackingPlanVersion: 13,
+    });
+  });
+});


### PR DESCRIPTION
## 🔗 Ticket

Resolves [DEX-341](https://linear.app/rudderstack/issue/DEX-341/add-multi-type-property-validator-coverage)
Resolves [DEX-342](https://linear.app/rudderstack/issue/DEX-342/add-group-and-screen-validator-coverage)

---

## Summary

End-to-end validator tests for multi-type property unions (DEX-341) and group/page event methods (DEX-342). Also fixes two type errors in the generated `withRudderTyperContext` helper introduced during context.traits routing.

---

## Changes

- **fix**: Use `null` instead of `undefined` for the anonymous branch's first SDK arg in context-traits routing — the SDK's `Nullable<T>` excludes `undefined`
- **fix**: Use `SDKApiObject` instead of `Record<string, unknown>` in `withRudderTyperContext` to satisfy the SDK's `ApiOptions` index signature
- **test**: `multitype.test.ts` — exercises each variant of `multiTypeField` (string/number/boolean), `multiTypeArray` (mixed items), nullable unions (`stringOrNull`, `numberOrNull`, `multiTypeWithNull`), `arrayWithNullItems`, and combined multi-type with nested objects
- **test**: `group.test.ts` — asserts `type === "group"`, correct `groupId`, traits routed through `context.traits`, and ruddertyper context merge
- **test**: `page.test.ts` — asserts `type === "page"`, correct name/category, typed properties, properties-only overload, and ruddertyper context merge

---

## Testing

- `make typer-typescript-validate` — 25/25 tests pass (typecheck + vitest)
- `go test ./cli/internal/typer/generator/platforms/typescript/...` — all Go tests pass
- `make lint` — clean

---

## Risk / Impact

Low — validator tests only, plus targeted type fixes in generated output.

---

## Checklist

- [x] Ticket linked
- [x] Tests added/updated
- [x] No breaking changes (or documented)