### PR TITLE
chore(typer/typescript): run typescript typer e2e tests on typer changes (DEX-344)

### DIFF
--- a/.github/workflows/typer-typescript-validate.yml
+++ b/.github/workflows/typer-typescript-validate.yml
@@ -6,12 +6,18 @@ on:
       - "release/*"
     paths:
       - "cli/internal/typer/generator/platforms/typescript/**"
+      - "cli/internal/typer/generator/core/**"
+      - "cli/internal/typer/plan/**"
+      - "Makefile"
       - ".github/workflows/typer-typescript-validate.yml"
   pull_request:
     branches:
       - main
     paths:
       - "cli/internal/typer/generator/platforms/typescript/**"
+      - "cli/internal/typer/generator/core/**"
+      - "cli/internal/typer/plan/**"
+      - "Makefile"
       - ".github/workflows/typer-typescript-validate.yml"
 
 concurrency:

--- a/.github/workflows/typer-typescript-validate.yml
+++ b/.github/workflows/typer-typescript-validate.yml
@@ -39,6 +39,7 @@ jobs:
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
         with:
           go-version-file: 'go.mod'
+          cache: false
 
       - name: regenerate golden file
         run: make typer-typescript-update-testdata

--- a/.github/workflows/typer-typescript-validate.yml
+++ b/.github/workflows/typer-typescript-validate.yml
@@ -1,0 +1,54 @@
+name: typer typescript validate
+on:
+  push:
+    branches:
+      - main
+      - "release/*"
+    paths:
+      - "cli/internal/typer/generator/platforms/typescript/**"
+      - ".github/workflows/typer-typescript-validate.yml"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "cli/internal/typer/generator/platforms/typescript/**"
+      - ".github/workflows/typer-typescript-validate.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  typer-typescript-validate:
+    name: validate generated TypeScript against RudderStack JS SDK
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        with:
+          egress-policy: audit
+
+      - name: checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: setup go
+        uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+        with:
+          go-version-file: 'go.mod'
+
+      - name: regenerate golden file
+        run: make typer-typescript-update-testdata
+
+      - name: assert golden file is unchanged
+        run: |
+          if ! git diff --exit-code cli/internal/typer/generator/platforms/typescript/testdata/RudderTyper.ts; then
+            echo "::error::Golden file is out of date. Run 'make typer-typescript-update-testdata' locally and commit the changes."
+            exit 1
+          fi
+
+      - name: run typer-typescript-validate
+        run: make typer-typescript-validate

--- a/Makefile
+++ b/Makefile
@@ -87,4 +87,4 @@ typer-typescript-validate: ## Validate generated TypeScript code against the Rud
 	mkdir -p cli/internal/typer/generator/platforms/typescript/testdata/validator/src/RudderTyper
 	cp cli/internal/typer/generator/platforms/typescript/testdata/RudderTyper.ts \
 	   cli/internal/typer/generator/platforms/typescript/testdata/validator/src/RudderTyper/RudderTyper.ts
-	cd cli/internal/typer/generator/platforms/typescript/testdata/validator && npm ci && npm run typecheck && npm test
+	cd cli/internal/typer/generator/platforms/typescript/testdata/validator && docker compose run --rm -T validator

--- a/cli/internal/typer/generator/platforms/typescript/testdata/validator/docker-compose.yml
+++ b/cli/internal/typer/generator/platforms/typescript/testdata/validator/docker-compose.yml
@@ -1,0 +1,11 @@
+services:
+  validator:
+    image: node:20-alpine
+    working_dir: /app
+    volumes:
+      - .:/app
+      - validator-node-modules:/app/node_modules
+    command: sh -c "npm ci && npm run typecheck && npm test"
+
+volumes:
+  validator-node-modules:

--- a/cli/internal/typer/generator/platforms/typescript/testdata/validator/docker-compose.yml
+++ b/cli/internal/typer/generator/platforms/typescript/testdata/validator/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   validator:
-    image: node:20-alpine
+    image: node:20-alpine@sha256:fb4cd12c85ee03686f6af5362a0b0d56d50c58a04632e6c0fb8363f609372293
     working_dir: /app
     volumes:
       - .:/app


### PR DESCRIPTION
## 🔗 Ticket

Resolves [DEX-344](https://linear.app/rudderstack/issue/DEX-344/add-validator-github-actions-workflow)

---

## Summary

Adds the first CI gate for the TypeScript typer. A new workflow regenerates the golden `RudderTyper.ts`, fails the build if a PR forgot to commit the regenerated output, and runs the validator project (typecheck + vitest against the JS SDK) inside a docker compose service so the runner doesn't need Node installed. Mirrors the Swift workflow pattern (`typer-swift-validate.yml`).

---

## Changes

- Add `cli/internal/typer/generator/platforms/typescript/testdata/validator/docker-compose.yml` — pulls `node:20-alpine`, mounts the validator dir, and runs `npm ci && npm run typecheck && npm test`.
- Update `typer-typescript-validate` make target to invoke `docker compose run --rm -T validator`, replacing the prior host-side `npm` invocation (matches Kotlin's container-backed pattern).
- Add `.github/workflows/typer-typescript-validate.yml` — path-filtered to the TS typer tree and the workflow itself; runs on `ubuntu-latest`; steps: harden-runner audit, checkout, setup-go, regenerate golden, assert unchanged, run docker compose validate.

---

## Testing

- Manually verified `make typer-typescript-validate` end-to-end on macOS via Docker Desktop — image pull, npm ci, typecheck, and vitest all pass.
- Verified golden regeneration is stable on `main` (no diff after `make typer-typescript-update-testdata`).
- `make lint` clean.
- CI on this PR exercises the new workflow against itself (the workflow file is included in its own path filter).

---

## Risk / Impact

Low. CI-only addition; no generator or validator behavior changes. Local dev now requires Docker to run the TS validator, matching the existing Kotlin requirement.

---

## Checklist

- [x] Ticket linked
- [x] Tests added/updated (workflow itself is the test gate)
- [x] No breaking changes (or documented)