### PR TITLE
fix(api): include details in APIError.Error() for per-field validation messages

### DIFF
--- a/api/client/common.go
+++ b/api/client/common.go
@@ -3,6 +3,7 @@ package client
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 )
 
@@ -28,7 +29,39 @@ type APIError struct {
 }
 
 func (e *APIError) Error() string {
-	return fmt.Sprintf("http status code: %d, error code: '%s', error: '%s'", e.HTTPStatusCode, e.ErrorCode, e.Msg())
+	msg := fmt.Sprintf("http status code: %d, error code: '%s', error: '%s'", e.HTTPStatusCode, e.ErrorCode, e.Msg())
+	if suffix := formatDetails(e.Details); suffix != "" {
+		msg += " " + suffix
+	}
+	return msg
+}
+
+// formatDetails renders APIError.Details as a parenthesised suffix.
+// The common shape from rudder-api is a flat {"field":"message"} object; keys
+// are sorted so the output is deterministic. Anything else (arrays, nested
+// objects, primitives, malformed JSON) falls back to the raw payload so we
+// never lose information.
+func formatDetails(details json.RawMessage) string {
+	trimmed := strings.TrimSpace(string(details))
+	if trimmed == "" || trimmed == "null" || trimmed == "{}" || trimmed == "[]" {
+		return ""
+	}
+
+	var fields map[string]string
+	if err := json.Unmarshal(details, &fields); err == nil && len(fields) > 0 {
+		keys := make([]string, 0, len(fields))
+		for k := range fields {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		parts := make([]string, 0, len(keys))
+		for _, k := range keys {
+			parts = append(parts, fmt.Sprintf("%s: %s", k, fields[k]))
+		}
+		return "(" + strings.Join(parts, ", ") + ")"
+	}
+
+	return "(details: " + trimmed + ")"
 }
 
 func (e *APIError) FeatureNotEnabled() bool {

--- a/api/client/common_test.go
+++ b/api/client/common_test.go
@@ -1,6 +1,7 @@
 package client_test
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/rudderlabs/rudder-iac/api/client"
@@ -40,6 +41,62 @@ func TestAPIError_Error(t *testing.T) {
 				ErrorCode:      "INTERNAL_ERROR",
 			},
 			want: "http status code: 500, error code: 'INTERNAL_ERROR', error: 'Internal server error'",
+		},
+		{
+			name: "details with single field",
+			apiError: &client.APIError{
+				HTTPStatusCode: 400,
+				Message:        "request validation failed",
+				Details:        json.RawMessage(`{"mappings":"Array must contain at least 1 element(s)"}`),
+			},
+			want: "http status code: 400, error code: '', error: 'request validation failed' (mappings: Array must contain at least 1 element(s))",
+		},
+		{
+			name: "details with multiple fields renders sorted by key",
+			apiError: &client.APIError{
+				HTTPStatusCode: 400,
+				Message:        "request validation failed",
+				Details:        json.RawMessage(`{"name":"Required","mappings":"Array must contain at least 1 element(s)"}`),
+			},
+			want: "http status code: 400, error code: '', error: 'request validation failed' (mappings: Array must contain at least 1 element(s), name: Required)",
+		},
+		{
+			name: "empty details object is omitted",
+			apiError: &client.APIError{
+				HTTPStatusCode: 400,
+				Message:        "Invalid request",
+				ErrorCode:      "BAD_REQUEST",
+				Details:        json.RawMessage(`{}`),
+			},
+			want: "http status code: 400, error code: 'BAD_REQUEST', error: 'Invalid request'",
+		},
+		{
+			name: "null details is omitted",
+			apiError: &client.APIError{
+				HTTPStatusCode: 400,
+				Message:        "Invalid request",
+				ErrorCode:      "BAD_REQUEST",
+				Details:        json.RawMessage(`null`),
+			},
+			want: "http status code: 400, error code: 'BAD_REQUEST', error: 'Invalid request'",
+		},
+		{
+			name: "nil details is omitted",
+			apiError: &client.APIError{
+				HTTPStatusCode: 400,
+				Message:        "Invalid request",
+				ErrorCode:      "BAD_REQUEST",
+			},
+			want: "http status code: 400, error code: 'BAD_REQUEST', error: 'Invalid request'",
+		},
+		{
+			name: "non-object details falls back to raw JSON",
+			apiError: &client.APIError{
+				HTTPStatusCode: 400,
+				Message:        "request validation failed",
+				Details:        json.RawMessage(`["a","b"]`),
+			},
+			want: `http status code: 400, error code: '', error: 'request validation failed' (details: ["a","b"])`,
 		},
 	}
 


### PR DESCRIPTION
## 🔗 Ticket

Resolves [PRO-5703](https://linear.app/rudderstack/issue/PRO-5703)

---

## Summary

`rudder-iac`'s `APIError.Error()` already decoded `details` from API responses but never emitted it, so when rudder-api returned per-field validation (e.g. `{"error": "request validation failed", "details": {"mappings": "Array must contain at least 1 element(s)"}}`) Terraform users only saw the generic top-level message and had to guess which field was wrong. This PR surfaces `details` in the stringified error.

This is sub-issue 9b of [PRO-5690](https://linear.app/rudderstack/issue/PRO-5690) (RETL Terraform observations) and is the rudder-iac counterpart to PRO-5701 / PRO-5702. Once PRO-5702 lands and rudder-api forwards precise per-flow messages from config-backend, this PR is what makes those messages reach TF users.

---

## Changes

- `api/client/common.go` — `APIError.Error()` now appends `details` as a parenthesised suffix when present. Flat `{"field":"message"}` shapes (the common Zod response) are rendered as `(field1: msg1, field2: msg2)` with sorted keys for deterministic output; other shapes (arrays, nested objects, primitives, malformed JSON) fall back to `(details: <raw JSON>)`. Empty cases (`""`, `null`, `{}`, `[]`) produce no suffix, preserving the existing format.
- `api/client/common_test.go` — extended `TestAPIError_Error` with six new table cases covering single field, multi-field sort order, empty/null/nil details (backwards-compat), and non-object fallback.

---

## Testing

Unit tests (`make test`) — all packages pass. New cases in `TestAPIError_Error`:

- `details with single field`
- `details with multiple fields renders sorted by key`
- `empty details object is omitted`
- `null details is omitted`
- `nil details is omitted`
- `non-object details falls back to raw JSON`

Existing three cases in `TestAPIError_Error` and all of `TestAPIError_FeatureNotEnabled` continue to pass unchanged. `make lint` and `make build` also pass clean.

---

## Risk / Impact

Low.

Notes: `Error()`'s output format changes only when `Details` is non-empty — the no-details path is byte-for-byte identical to the previous behaviour. A repo-wide search for callers doing string-equality on rudder-iac `APIError` messages turned up nothing outside the test in `common_test.go` itself, and no caller currently reads `APIError.Details`. No public API or struct shape changed.

---

## Checklist

- [x] Ticket linked
- [x] Tests added/updated
- [x] No breaking changes (or documented)