### PR TITLE
fix: add permissions content write to the triggered release please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -35,6 +35,8 @@ jobs:
     needs: release-please
     if: ${{ needs.release-please.outputs.release-created }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0


### PR DESCRIPTION
Scanned-by: gitleaks 8.30.0

## 🔗 Ticket

<!-- Required for traceability -->

Resolves [DEX-348](https://linear.app/rudderstack/issue/DEX-348/add-write-content-permissions-to-the-trigger-release-please)

---

## Summary

Add write permissions to the triggered release please workflow.

---

## Changes

- Key change 1
- Key change 2
- Key change 3

---

## Testing

How was this tested?

- Unit tests / Integration tests / Manual testing

---

## Risk / Impact

Low / Medium / High
Notes (if any):

---

## Checklist

- [ ] Ticket linked
- [ ] Tests added/updated
- [ ] No breaking changes (or documented)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts GitHub Actions job permissions to allow the post-release `repository-dispatch` step to write repository contents; no application/runtime code changes.
> 
> **Overview**
> Adds explicit `permissions: contents: write` to the `trigger-release-workflows` job in `.github/workflows/release-please.yml` so the release-created dispatch can run with the required repository write access.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9e3761f53d983584b46d5bc7fe0b849810e3a27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->