### PR TITLE
feat(project): add import manifest validation with unified engine approach

### DIFF
--- a/cli/internal/project/manifest.go
+++ b/cli/internal/project/manifest.go
@@ -2,33 +2,109 @@ package project
 
 import (
 	"fmt"
+	"path/filepath"
 
 	"github.com/go-viper/mapstructure/v2"
 
 	"github.com/rudderlabs/rudder-iac/cli/internal/project/specs"
 	"github.com/rudderlabs/rudder-iac/cli/internal/provider"
+	"github.com/rudderlabs/rudder-iac/cli/internal/validation"
+	"github.com/rudderlabs/rudder-iac/cli/internal/validation/pathindex"
 	"github.com/rudderlabs/rudder-iac/cli/internal/validation/rules"
+
+	prules "github.com/rudderlabs/rudder-iac/cli/internal/project/rules"
 )
 
-// appendImportManifestPattern adds the import-manifest pattern to provider
-// patterns when providers have declared their own. When providers return nil
-// (meaning "no pattern-based restriction"), the result stays nil to preserve
-// that unrestricted behaviour for gatekeeper rules.
-func appendImportManifestPattern(providerPatterns []rules.MatchPattern) []rules.MatchPattern {
-	if len(providerPatterns) == 0 {
-		return nil
+// manifestRegistry builds the validation registry exclusively for import-manifest specs.
+// Manifest validation is separate from resource validation to avoid coupling
+// manifest rules with provider-specific concerns like ParseSpec dispatch.
+func manifestRegistry() (rules.Registry, error) {
+	manifestPatterns := []rules.MatchPattern{
+		rules.MatchKindVersion(specs.KindImportManifest, specs.SpecVersionV1),
 	}
-	result := make([]rules.MatchPattern, 0, len(providerPatterns)+1)
-	result = append(result, providerPatterns...)
-	result = append(result, rules.MatchKindVersion(specs.KindImportManifest, specs.SpecVersionV1))
-	return result
+	registry := rules.NewRegistry(manifestPatterns)
+
+	syntactic := []rules.Rule{
+		prules.NewSpecSyntaxValidRule(manifestPatterns),
+		prules.NewResourceKindVersionValidRule(manifestPatterns),
+		prules.NewImportManifestSyntaxRule(),
+		prules.NewImportManifestProjectRule(),
+	}
+	for _, rule := range syntactic {
+		if err := registry.RegisterSyntactic(rule); err != nil {
+			return nil, fmt.Errorf("registering manifest syntactic rule %s: %w", rule.ID(), err)
+		}
+	}
+
+	semantic := []rules.Rule{
+		prules.NewImportManifestSemanticRule(),
+	}
+	for _, rule := range semantic {
+		if err := registry.RegisterSemantic(rule); err != nil {
+			return nil, fmt.Errorf("registering manifest semantic rule %s: %w", rule.ID(), err)
+		}
+	}
+
+	return registry, nil
 }
 
-func parseManifestSpec() (*specs.ParsedSpec, error) {
-	return &specs.ParsedSpec{
-		URNs:               nil,
-		LegacyResourceType: "",
-	}, nil
+// checkInlineManifestConflicts detects URNs that appear in both manifest files
+// and inline metadata.import blocks in resource specs. This is a temporary
+// migration concern — once inline metadata is removed, this check becomes a no-op.
+func checkInlineManifestConflicts(
+	resourceSpecs map[string]*specs.RawSpec,
+	manifestSpecs map[string]*specs.RawSpec,
+) validation.Diagnostics {
+	if len(manifestSpecs) == 0 {
+		return nil
+	}
+
+	// Collect all URNs from manifests with their source file
+	type urnSource struct {
+		filePath  string
+		reference string
+	}
+	manifestURNs := make(map[string]urnSource)
+
+	for path, rawSpec := range manifestSpecs {
+		for _, entry := range prules.ExtractManifestURNs(rawSpec.Parsed().Spec) {
+			manifestURNs[entry.URN] = urnSource{filePath: path, reference: entry.Reference}
+		}
+	}
+
+	if len(manifestURNs) == 0 {
+		return nil
+	}
+
+	// Check resource specs' inline metadata.import for conflicts
+	var diags validation.Diagnostics
+	for resourcePath, rawSpec := range resourceSpecs {
+		inlineURNs := prules.ExtractInlineImportURNs(rawSpec.Parsed().Metadata)
+		for _, urn := range inlineURNs {
+			src, exists := manifestURNs[urn]
+			if !exists {
+				continue
+			}
+
+			pos := pathindex.StartingPosition
+			if pi, err := rawSpec.PathIndexer(); err == nil {
+				pos = *pi.NearestPosition("/metadata/import")
+			}
+
+			diags = append(diags, validation.Diagnostic{
+				RuleID:   "project/import-manifest-inline-conflict",
+				Severity: rules.Error,
+				Message: fmt.Sprintf(
+					"URN '%s' found in both manifest %s and inline metadata in %s",
+					urn, filepath.Base(src.filePath), filepath.Base(resourcePath),
+				),
+				File:     resourcePath,
+				Position: pos,
+			})
+		}
+	}
+
+	return diags
 }
 
 func separateManifests(

--- a/cli/internal/project/manifest.go
+++ b/cli/internal/project/manifest.go
@@ -1,0 +1,101 @@
+package project
+
+import (
+	"fmt"
+
+	"github.com/go-viper/mapstructure/v2"
+
+	"github.com/rudderlabs/rudder-iac/cli/internal/project/specs"
+	"github.com/rudderlabs/rudder-iac/cli/internal/provider"
+	"github.com/rudderlabs/rudder-iac/cli/internal/validation/rules"
+)
+
+// appendImportManifestPattern adds the import-manifest pattern to provider
+// patterns when providers have declared their own. When providers return nil
+// (meaning "no pattern-based restriction"), the result stays nil to preserve
+// that unrestricted behaviour for gatekeeper rules.
+func appendImportManifestPattern(providerPatterns []rules.MatchPattern) []rules.MatchPattern {
+	if len(providerPatterns) == 0 {
+		return nil
+	}
+	result := make([]rules.MatchPattern, 0, len(providerPatterns)+1)
+	result = append(result, providerPatterns...)
+	result = append(result, rules.MatchKindVersion(specs.KindImportManifest, specs.SpecVersionV1))
+	return result
+}
+
+func parseManifestSpec() (*specs.ParsedSpec, error) {
+	return &specs.ParsedSpec{
+		URNs:               nil,
+		LegacyResourceType: "",
+	}, nil
+}
+
+func separateManifests(
+	rawSpecs map[string]*specs.RawSpec,
+) (resourceSpecs, manifestSpecs map[string]*specs.RawSpec) {
+	resourceSpecs = make(map[string]*specs.RawSpec, len(rawSpecs))
+	manifestSpecs = make(map[string]*specs.RawSpec)
+	for path, rawSpec := range rawSpecs {
+		if rawSpec.Parsed().IsImportManifest() {
+			manifestSpecs[path] = rawSpec
+			continue
+		}
+		resourceSpecs[path] = rawSpec
+	}
+	return resourceSpecs, manifestSpecs
+}
+
+func parseManifests(
+	manifestSpecs map[string]*specs.RawSpec,
+) (*specs.WorkspacesImportMetadata, error) {
+	if len(manifestSpecs) == 0 {
+		return nil, nil
+	}
+
+	var allWorkspaces []specs.WorkspaceImportMetadata
+	for path, rawSpec := range manifestSpecs {
+		ws, err := decodeManifestWorkspaces(rawSpec.Parsed().Spec)
+		if err != nil {
+			return nil, fmt.Errorf("parsing manifest %s: %w", path, err)
+		}
+		allWorkspaces = append(allWorkspaces, ws...)
+	}
+
+	return &specs.WorkspacesImportMetadata{Workspaces: allWorkspaces}, nil
+}
+
+func decodeManifestWorkspaces(specMap map[string]any) ([]specs.WorkspaceImportMetadata, error) {
+	var payload struct {
+		Workspaces []specs.WorkspaceImportMetadata `yaml:"workspaces"`
+	}
+	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		TagName:     "yaml",
+		ErrorUnused: true,
+		Result:      &payload,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("creating decoder: %w", err)
+	}
+	if err := decoder.Decode(specMap); err != nil {
+		return nil, fmt.Errorf("decoding workspaces: %w", err)
+	}
+	return payload.Workspaces, nil
+}
+
+// broadcastImportManifest sends parsed manifest data to providers that opt in
+// via the ImportManifestLoader interface. Providers that don't implement it are skipped.
+func broadcastImportManifest(
+	pp ProjectProvider,
+	manifest *specs.WorkspacesImportMetadata,
+) error {
+	if manifest == nil {
+		return nil
+	}
+
+	loader, ok := pp.(provider.ImportManifestLoader)
+	if !ok {
+		return nil
+	}
+	return loader.LoadImportManifest(manifest)
+}

--- a/cli/internal/project/manifest_test.go
+++ b/cli/internal/project/manifest_test.go
@@ -37,18 +37,6 @@ func (m *manifestCapableProvider) LoadImportManifest(manifest *specs.WorkspacesI
 
 var _ provider.ImportManifestLoader = (*manifestCapableProvider)(nil)
 
-func TestParseManifestSpec(t *testing.T) {
-	t.Parallel()
-
-	result, err := parseManifestSpec()
-
-	require.NoError(t, err)
-	assert.Equal(t, &specs.ParsedSpec{
-		URNs:               nil,
-		LegacyResourceType: "",
-	}, result)
-}
-
 func TestSeparateManifests(t *testing.T) {
 	t.Parallel()
 
@@ -197,5 +185,54 @@ func TestBroadcastImportManifest(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.Equal(t, manifest, pp.manifest)
+	})
+}
+
+func TestCheckInlineManifestConflicts(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no manifests returns nil", func(t *testing.T) {
+		t.Parallel()
+
+		diags := checkInlineManifestConflicts(
+			map[string]*specs.RawSpec{},
+			map[string]*specs.RawSpec{},
+		)
+		assert.Nil(t, diags)
+	})
+
+	t.Run("no conflicts returns nil", func(t *testing.T) {
+		t.Parallel()
+
+		manifestSpec := &specs.RawSpec{Data: []byte("version: rudder/v1\nkind: import-manifest\nmetadata:\n  name: m\nspec:\n  workspaces:\n    - workspace_id: ws-1\n      resources:\n        - urn: \"source:a\"\n          remote_id: r1\n")}
+		_, _ = manifestSpec.Parse()
+
+		resourceSpec := &specs.RawSpec{Data: []byte("version: rudder/v1\nkind: event-stream-source\nmetadata:\n  name: src\nspec:\n  id: my-source\n")}
+		_, _ = resourceSpec.Parse()
+
+		diags := checkInlineManifestConflicts(
+			map[string]*specs.RawSpec{"source.yaml": resourceSpec},
+			map[string]*specs.RawSpec{"manifest.yaml": manifestSpec},
+		)
+		assert.Empty(t, diags)
+	})
+
+	t.Run("conflict detected between manifest and inline metadata", func(t *testing.T) {
+		t.Parallel()
+
+		manifestSpec := &specs.RawSpec{Data: []byte("version: rudder/v1\nkind: import-manifest\nmetadata:\n  name: m\nspec:\n  workspaces:\n    - workspace_id: ws-1\n      resources:\n        - urn: \"source:shared\"\n          remote_id: r1\n")}
+		_, _ = manifestSpec.Parse()
+
+		resourceSpec := &specs.RawSpec{Data: []byte("version: rudder/v1\nkind: event-stream-source\nmetadata:\n  name: src\n  import:\n    workspaces:\n      - workspace_id: ws-1\n        resources:\n          - urn: \"source:shared\"\n            remote_id: r2\nspec:\n  id: my-source\n")}
+		_, _ = resourceSpec.Parse()
+
+		diags := checkInlineManifestConflicts(
+			map[string]*specs.RawSpec{"source.yaml": resourceSpec},
+			map[string]*specs.RawSpec{"manifest.yaml": manifestSpec},
+		)
+
+		require.Len(t, diags, 1)
+		assert.Contains(t, diags[0].Message, "source:shared")
+		assert.Equal(t, "project/import-manifest-inline-conflict", diags[0].RuleID)
 	})
 }

--- a/cli/internal/project/manifest_test.go
+++ b/cli/internal/project/manifest_test.go
@@ -1,0 +1,201 @@
+package project
+
+import (
+	"testing"
+
+	"github.com/rudderlabs/rudder-iac/cli/internal/project/specs"
+	"github.com/rudderlabs/rudder-iac/cli/internal/provider"
+	"github.com/rudderlabs/rudder-iac/cli/internal/resources"
+	"github.com/rudderlabs/rudder-iac/cli/internal/validation/rules"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stubProjectProvider is a minimal ProjectProvider that does not implement ImportManifestLoader.
+type stubProjectProvider struct{}
+
+func (s *stubProjectProvider) LoadSpec(_ string, _ *specs.Spec) error                        { return nil }
+func (s *stubProjectProvider) LoadLegacySpec(_ string, _ *specs.Spec) error                  { return nil }
+func (s *stubProjectProvider) ParseSpec(_ string, _ *specs.Spec) (*specs.ParsedSpec, error)  { return nil, nil }
+func (s *stubProjectProvider) ResourceGraph() (*resources.Graph, error)                      { return nil, nil }
+func (s *stubProjectProvider) SupportedKinds() []string                                      { return nil }
+func (s *stubProjectProvider) SupportedTypes() []string                                      { return nil }
+func (s *stubProjectProvider) SupportedMatchPatterns() []rules.MatchPattern                  { return nil }
+func (s *stubProjectProvider) SyntacticRules() []rules.Rule                                  { return nil }
+func (s *stubProjectProvider) SemanticRules() []rules.Rule                                   { return nil }
+
+// manifestCapableProvider is a ProjectProvider that also implements ImportManifestLoader.
+type manifestCapableProvider struct {
+	stubProjectProvider
+	manifest *specs.WorkspacesImportMetadata
+}
+
+func (m *manifestCapableProvider) LoadImportManifest(manifest *specs.WorkspacesImportMetadata) error {
+	m.manifest = manifest
+	return nil
+}
+
+var _ provider.ImportManifestLoader = (*manifestCapableProvider)(nil)
+
+func TestParseManifestSpec(t *testing.T) {
+	t.Parallel()
+
+	result, err := parseManifestSpec()
+
+	require.NoError(t, err)
+	assert.Equal(t, &specs.ParsedSpec{
+		URNs:               nil,
+		LegacyResourceType: "",
+	}, result)
+}
+
+func TestSeparateManifests(t *testing.T) {
+	t.Parallel()
+
+	manifestSpec := &specs.RawSpec{Data: []byte("version: rudder/v1\nkind: import-manifest\nmetadata:\n  name: test\nspec:\n  workspaces: []\n")}
+	_, _ = manifestSpec.Parse()
+
+	resourceSpec := &specs.RawSpec{Data: []byte("version: rudder/v1\nkind: properties\nmetadata:\n  name: test\nspec:\n  properties: []\n")}
+	_, _ = resourceSpec.Parse()
+
+	rawSpecs := map[string]*specs.RawSpec{
+		"manifest.yaml": manifestSpec,
+		"props.yaml":    resourceSpec,
+	}
+
+	resourceSpecs, manifestSpecs := separateManifests(rawSpecs)
+
+	assert.Len(t, resourceSpecs, 1)
+	assert.Len(t, manifestSpecs, 1)
+	assert.Contains(t, resourceSpecs, "props.yaml")
+	assert.Contains(t, manifestSpecs, "manifest.yaml")
+}
+
+func TestDecodeManifestWorkspaces(t *testing.T) {
+	t.Parallel()
+
+	t.Run("valid input", func(t *testing.T) {
+		t.Parallel()
+
+		specMap := map[string]any{
+			"workspaces": []any{
+				map[string]any{
+					"workspace_id": "ws-123",
+					"resources": []any{
+						map[string]any{
+							"urn":       "source:my-src",
+							"remote_id": "remote-456",
+						},
+					},
+				},
+			},
+		}
+
+		result, err := decodeManifestWorkspaces(specMap)
+
+		require.NoError(t, err)
+		assert.Equal(t, []specs.WorkspaceImportMetadata{
+			{
+				WorkspaceID: "ws-123",
+				Resources: []specs.ImportIds{
+					{URN: "source:my-src", RemoteID: "remote-456"},
+				},
+			},
+		}, result)
+	})
+
+	t.Run("unknown fields rejected", func(t *testing.T) {
+		t.Parallel()
+
+		specMap := map[string]any{
+			"workspaces": []any{
+				map[string]any{
+					"workspace_id":  "ws-123",
+					"unknown_field": "bad",
+				},
+			},
+		}
+
+		_, err := decodeManifestWorkspaces(specMap)
+		assert.Error(t, err)
+	})
+}
+
+func TestParseManifests(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty manifests returns nil", func(t *testing.T) {
+		t.Parallel()
+
+		result, err := parseManifests(map[string]*specs.RawSpec{})
+
+		require.NoError(t, err)
+		assert.Nil(t, result)
+	})
+
+	t.Run("multiple manifest files merged", func(t *testing.T) {
+		t.Parallel()
+
+		spec1 := &specs.RawSpec{Data: []byte("version: rudder/v1\nkind: import-manifest\nmetadata:\n  name: m1\nspec:\n  workspaces:\n    - workspace_id: ws-1\n      resources:\n        - urn: \"source:a\"\n          remote_id: r1\n")}
+		_, _ = spec1.Parse()
+
+		spec2 := &specs.RawSpec{Data: []byte("version: rudder/v1\nkind: import-manifest\nmetadata:\n  name: m2\nspec:\n  workspaces:\n    - workspace_id: ws-2\n      resources:\n        - urn: \"source:b\"\n          remote_id: r2\n")}
+		_, _ = spec2.Parse()
+
+		manifestSpecs := map[string]*specs.RawSpec{
+			"m1.yaml": spec1,
+			"m2.yaml": spec2,
+		}
+
+		result, err := parseManifests(manifestSpecs)
+
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.Len(t, result.Workspaces, 2)
+	})
+}
+
+func TestBroadcastImportManifest(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil manifest is a no-op", func(t *testing.T) {
+		t.Parallel()
+
+		err := broadcastImportManifest(&stubProjectProvider{}, nil)
+		assert.NoError(t, err)
+	})
+
+	t.Run("provider without ImportManifestLoader is silently skipped", func(t *testing.T) {
+		t.Parallel()
+
+		manifest := &specs.WorkspacesImportMetadata{
+			Workspaces: []specs.WorkspaceImportMetadata{
+				{WorkspaceID: "ws-1"},
+			},
+		}
+
+		err := broadcastImportManifest(&stubProjectProvider{}, manifest)
+		assert.NoError(t, err)
+	})
+
+	t.Run("provider implementing ImportManifestLoader receives manifest", func(t *testing.T) {
+		t.Parallel()
+
+		manifest := &specs.WorkspacesImportMetadata{
+			Workspaces: []specs.WorkspaceImportMetadata{
+				{
+					WorkspaceID: "ws-1",
+					Resources: []specs.ImportIds{
+						{URN: "source:a", RemoteID: "r1"},
+					},
+				},
+			},
+		}
+
+		pp := &manifestCapableProvider{}
+		err := broadcastImportManifest(pp, manifest)
+
+		require.NoError(t, err)
+		assert.Equal(t, manifest, pp.manifest)
+	})
+}

--- a/cli/internal/project/project.go
+++ b/cli/internal/project/project.go
@@ -140,8 +140,7 @@ func (p *project) handleValidation(rawSpecs map[string]*specs.RawSpec) error {
 		return fmt.Errorf("initialising validation engine: %w", err)
 	}
 
-	// At this point, rawspecs are successfully parsed as well and information
-	// parsed gets augmented to the base struct
+	// All specs (resource + manifest) go through syntax validation together
 	syntaxDiags, err := engine.ValidateSyntax(ctx, parsedRawSpecs)
 	if err != nil {
 		return fmt.Errorf("syntactic validation: %w", err)
@@ -159,13 +158,26 @@ func (p *project) handleValidation(rawSpecs map[string]*specs.RawSpec) error {
 		return fmt.Errorf("syntax validation failed")
 	}
 
-	for path, rawSpec := range parsedRawSpecs {
+	// Separate manifests from resource specs after syntax validation passes.
+	// Only resource specs are loaded into providers; manifests are parsed separately.
+	resourceSpecs, manifestSpecs := separateManifests(parsedRawSpecs)
+
+	for path, rawSpec := range resourceSpecs {
 		if err := p.loadSpec(
 			path,
 			rawSpec.Parsed(),
 		); err != nil {
 			return fmt.Errorf("loading spec %s: %w", path, err)
 		}
+	}
+
+	manifest, err := parseManifests(manifestSpecs)
+	if err != nil {
+		return fmt.Errorf("parsing import manifests: %w", err)
+	}
+
+	if err := broadcastImportManifest(p.provider, manifest); err != nil {
+		return fmt.Errorf("broadcasting import manifest: %w", err)
 	}
 
 	// Graph is built once here - single source of truth for all resource relationships.
@@ -180,7 +192,7 @@ func (p *project) handleValidation(rawSpecs map[string]*specs.RawSpec) error {
 		return fmt.Errorf("cycle detected in resource graph: %w", err)
 	}
 
-	// Specs which were parsed will now be validated against semantic rules.
+	// All specs (resource + manifest) go through semantic validation together
 	semanticDiags, err := engine.ValidateSemantic(ctx, parsedRawSpecs, graph)
 	if err != nil {
 		return fmt.Errorf("semantic validation: %w", err)
@@ -239,20 +251,31 @@ func (p *project) parseSpecs(raw map[string]*specs.RawSpec) (map[string]*specs.R
 }
 
 func (p *project) registry() (rules.Registry, error) {
-	// Active patterns become the source of truth for the
-	// validation pipeline to determine which unique kinds and versions
-	// are supported in the system.
-	activePatterns := p.provider.SupportedMatchPatterns()
-	baseRegistry := rules.NewRegistry(activePatterns)
+	providerPatterns := p.provider.SupportedMatchPatterns()
+
+	// import-manifest is a project-level kind, not owned by any provider.
+	// The registry always needs it so import-manifest rules can be registered.
+	// Gatekeeper rules use the combined set only when providers declare patterns,
+	// preserving the unrestricted fallback when they don't.
+	importManifestPattern := rules.MatchKindVersion(specs.KindImportManifest, specs.SpecVersionV1)
+	registryPatterns := make([]rules.MatchPattern, 0, len(providerPatterns)+1)
+	registryPatterns = append(registryPatterns, providerPatterns...)
+	registryPatterns = append(registryPatterns, importManifestPattern)
+	gatekeeperPatterns := appendImportManifestPattern(providerPatterns)
+
+	baseRegistry := rules.NewRegistry(registryPatterns)
+
+	dispatcher := p.newParseSpecDispatcher()
 
 	syntactic := []rules.Rule{
-		// GatekeeperRules: MatchAll rules, checks structure + known kinds/versions
-		// independently. They use activePatterns as source of truth for the supported kinds and versions.
-		prules.NewSpecSyntaxValidRule(activePatterns),
-		prules.NewResourceKindVersionValidRule(activePatterns),
-
-		prules.NewMetadataSyntaxValidRule(p.provider.ParseSpec, activePatterns),
-		prules.NewDuplicateURNRule(p.provider.ParseSpec, activePatterns),
+		prules.NewSpecSyntaxValidRule(gatekeeperPatterns),
+		prules.NewResourceKindVersionValidRule(gatekeeperPatterns),
+		// Metadata and URN rules only apply to provider-owned kinds;
+		// import-manifest has its own dedicated rules for structure validation.
+		prules.NewMetadataSyntaxValidRule(dispatcher, providerPatterns),
+		prules.NewDuplicateURNRule(dispatcher, providerPatterns),
+		prules.NewImportManifestSyntaxRule(),
+		prules.NewImportManifestProjectRule(),
 	}
 	syntactic = append(syntactic, p.provider.SyntacticRules()...)
 
@@ -262,7 +285,12 @@ func (p *project) registry() (rules.Registry, error) {
 		}
 	}
 
-	for _, rule := range p.provider.SemanticRules() {
+	semantic := []rules.Rule{
+		prules.NewImportManifestSemanticRule(),
+	}
+	semantic = append(semantic, p.provider.SemanticRules()...)
+
+	for _, rule := range semantic {
 		if err := baseRegistry.RegisterSemantic(rule); err != nil {
 			return nil, fmt.Errorf("registering semantic rule %s: %w", rule.ID(), err)
 		}
@@ -273,4 +301,13 @@ func (p *project) registry() (rules.Registry, error) {
 
 func (p *project) ResourceGraph() (*resources.Graph, error) {
 	return p.provider.ResourceGraph()
+}
+
+func (p *project) newParseSpecDispatcher() prules.ParseSpecFunc {
+	return func(path string, s *specs.Spec) (*specs.ParsedSpec, error) {
+		if s.IsImportManifest() {
+			return parseManifestSpec()
+		}
+		return p.provider.ParseSpec(path, s)
+	}
 }

--- a/cli/internal/project/project.go
+++ b/cli/internal/project/project.go
@@ -1,9 +1,12 @@
 package project
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os"
+
+	"gopkg.in/yaml.v3"
 
 	"github.com/rudderlabs/rudder-iac/cli/internal/logger"
 	"github.com/rudderlabs/rudder-iac/cli/internal/project/loader"
@@ -140,8 +143,7 @@ func (p *project) handleValidation(rawSpecs map[string]*specs.RawSpec) error {
 		return fmt.Errorf("initialising validation engine: %w", err)
 	}
 
-	// At this point, rawspecs are successfully parsed as well and information
-	// parsed gets augmented to the base struct
+	// All specs (resource + manifest) go through syntax validation together
 	syntaxDiags, err := engine.ValidateSyntax(ctx, parsedRawSpecs)
 	if err != nil {
 		return fmt.Errorf("syntactic validation: %w", err)
@@ -159,13 +161,26 @@ func (p *project) handleValidation(rawSpecs map[string]*specs.RawSpec) error {
 		return fmt.Errorf("syntax validation failed")
 	}
 
-	for path, rawSpec := range parsedRawSpecs {
+	// Separate manifests from resource specs after syntax validation passes.
+	// Only resource specs are loaded into providers; manifests are parsed separately.
+	resourceSpecs, manifestSpecs := separateManifests(parsedRawSpecs)
+
+	for path, rawSpec := range resourceSpecs {
 		if err := p.loadSpec(
 			path,
 			rawSpec.Parsed(),
 		); err != nil {
 			return fmt.Errorf("loading spec %s: %w", path, err)
 		}
+	}
+
+	manifest, err := parseManifests(manifestSpecs)
+	if err != nil {
+		return fmt.Errorf("parsing import manifests: %w", err)
+	}
+
+	if err := broadcastImportManifest(p.provider, manifest); err != nil {
+		return fmt.Errorf("broadcasting import manifest: %w", err)
 	}
 
 	// Graph is built once here - single source of truth for all resource relationships.
@@ -180,7 +195,7 @@ func (p *project) handleValidation(rawSpecs map[string]*specs.RawSpec) error {
 		return fmt.Errorf("cycle detected in resource graph: %w", err)
 	}
 
-	// Specs which were parsed will now be validated against semantic rules.
+	// All specs (resource + manifest) go through semantic validation together
 	semanticDiags, err := engine.ValidateSemantic(ctx, parsedRawSpecs, graph)
 	if err != nil {
 		return fmt.Errorf("semantic validation: %w", err)
@@ -239,20 +254,31 @@ func (p *project) parseSpecs(raw map[string]*specs.RawSpec) (map[string]*specs.R
 }
 
 func (p *project) registry() (rules.Registry, error) {
-	// Active patterns become the source of truth for the
-	// validation pipeline to determine which unique kinds and versions
-	// are supported in the system.
-	activePatterns := p.provider.SupportedMatchPatterns()
-	baseRegistry := rules.NewRegistry(activePatterns)
+	providerPatterns := p.provider.SupportedMatchPatterns()
+
+	// import-manifest is a project-level kind, not owned by any provider.
+	// The registry always needs it so import-manifest rules can be registered.
+	// Gatekeeper rules use the combined set only when providers declare patterns,
+	// preserving the unrestricted fallback when they don't.
+	importManifestPattern := rules.MatchKindVersion(specs.KindImportManifest, specs.SpecVersionV1)
+	registryPatterns := make([]rules.MatchPattern, 0, len(providerPatterns)+1)
+	registryPatterns = append(registryPatterns, providerPatterns...)
+	registryPatterns = append(registryPatterns, importManifestPattern)
+	gatekeeperPatterns := appendImportManifestPattern(providerPatterns)
+
+	baseRegistry := rules.NewRegistry(registryPatterns)
+
+	dispatcher := p.newParseSpecDispatcher()
 
 	syntactic := []rules.Rule{
-		// GatekeeperRules: MatchAll rules, checks structure + known kinds/versions
-		// independently. They use activePatterns as source of truth for the supported kinds and versions.
-		prules.NewSpecSyntaxValidRule(activePatterns),
-		prules.NewResourceKindVersionValidRule(activePatterns),
-
-		prules.NewMetadataSyntaxValidRule(p.provider.ParseSpec, activePatterns),
-		prules.NewDuplicateURNRule(p.provider.ParseSpec, activePatterns),
+		prules.NewSpecSyntaxValidRule(gatekeeperPatterns),
+		prules.NewResourceKindVersionValidRule(gatekeeperPatterns),
+		// Metadata and URN rules only apply to provider-owned kinds;
+		// import-manifest has its own dedicated rules for structure validation.
+		prules.NewMetadataSyntaxValidRule(dispatcher, providerPatterns),
+		prules.NewDuplicateURNRule(dispatcher, providerPatterns),
+		prules.NewImportManifestSyntaxRule(),
+		prules.NewImportManifestProjectRule(),
 	}
 	syntactic = append(syntactic, p.provider.SyntacticRules()...)
 
@@ -262,7 +288,12 @@ func (p *project) registry() (rules.Registry, error) {
 		}
 	}
 
-	for _, rule := range p.provider.SemanticRules() {
+	semantic := []rules.Rule{
+		prules.NewImportManifestSemanticRule(),
+	}
+	semantic = append(semantic, p.provider.SemanticRules()...)
+
+	for _, rule := range semantic {
 		if err := baseRegistry.RegisterSemantic(rule); err != nil {
 			return nil, fmt.Errorf("registering semantic rule %s: %w", rule.ID(), err)
 		}
@@ -273,4 +304,101 @@ func (p *project) registry() (rules.Registry, error) {
 
 func (p *project) ResourceGraph() (*resources.Graph, error) {
 	return p.provider.ResourceGraph()
+}
+
+// appendImportManifestPattern adds the import-manifest pattern to provider
+// patterns when providers have declared their own. When providers return nil
+// (meaning "no pattern-based restriction"), the result stays nil to preserve
+// that unrestricted behaviour for gatekeeper rules.
+func appendImportManifestPattern(providerPatterns []rules.MatchPattern) []rules.MatchPattern {
+	if len(providerPatterns) == 0 {
+		return nil
+	}
+	result := make([]rules.MatchPattern, 0, len(providerPatterns)+1)
+	result = append(result, providerPatterns...)
+	result = append(result, rules.MatchKindVersion(specs.KindImportManifest, specs.SpecVersionV1))
+	return result
+}
+
+func (p *project) newParseSpecDispatcher() prules.ParseSpecFunc {
+	return func(path string, s *specs.Spec) (*specs.ParsedSpec, error) {
+		if s.IsImportManifest() {
+			return parseManifestSpec()
+		}
+		return p.provider.ParseSpec(path, s)
+	}
+}
+
+func parseManifestSpec() (*specs.ParsedSpec, error) {
+	return &specs.ParsedSpec{
+		URNs:               nil,
+		LegacyResourceType: "",
+	}, nil
+}
+
+func separateManifests(
+	rawSpecs map[string]*specs.RawSpec,
+) (resourceSpecs, manifestSpecs map[string]*specs.RawSpec) {
+	resourceSpecs = make(map[string]*specs.RawSpec, len(rawSpecs))
+	manifestSpecs = make(map[string]*specs.RawSpec)
+	for path, rawSpec := range rawSpecs {
+		if rawSpec.Parsed().IsImportManifest() {
+			manifestSpecs[path] = rawSpec
+			continue
+		}
+		resourceSpecs[path] = rawSpec
+	}
+	return resourceSpecs, manifestSpecs
+}
+
+func parseManifests(
+	manifestSpecs map[string]*specs.RawSpec,
+) (*specs.WorkspacesImportMetadata, error) {
+	if len(manifestSpecs) == 0 {
+		return nil, nil
+	}
+
+	var allWorkspaces []specs.WorkspaceImportMetadata
+	for path, rawSpec := range manifestSpecs {
+		ws, err := decodeManifestWorkspaces(rawSpec.Parsed().Spec)
+		if err != nil {
+			return nil, fmt.Errorf("parsing manifest %s: %w", path, err)
+		}
+		allWorkspaces = append(allWorkspaces, ws...)
+	}
+
+	return &specs.WorkspacesImportMetadata{Workspaces: allWorkspaces}, nil
+}
+
+func decodeManifestWorkspaces(specMap map[string]any) ([]specs.WorkspaceImportMetadata, error) {
+	raw, err := yaml.Marshal(specMap)
+	if err != nil {
+		return nil, fmt.Errorf("marshalling spec: %w", err)
+	}
+	var payload struct {
+		Workspaces []specs.WorkspaceImportMetadata `yaml:"workspaces"`
+	}
+	decoder := yaml.NewDecoder(bytes.NewReader(raw))
+	decoder.KnownFields(true)
+	if err := decoder.Decode(&payload); err != nil {
+		return nil, fmt.Errorf("decoding workspaces: %w", err)
+	}
+	return payload.Workspaces, nil
+}
+
+// broadcastImportManifest sends parsed manifest data to providers that opt in
+// via the ImportManifestLoader interface. Providers that don't implement it are skipped.
+func broadcastImportManifest(
+	pp ProjectProvider,
+	manifest *specs.WorkspacesImportMetadata,
+) error {
+	if manifest == nil {
+		return nil
+	}
+
+	loader, ok := pp.(provider.ImportManifestLoader)
+	if !ok {
+		return nil
+	}
+	return loader.LoadImportManifest(manifest)
 }

--- a/cli/internal/project/project.go
+++ b/cli/internal/project/project.go
@@ -126,47 +126,56 @@ func (p *project) Load(location string) error {
 func (p *project) handleValidation(rawSpecs map[string]*specs.RawSpec) error {
 	ctx := context.Background()
 
-	// Start with parsing the specs and validating it's syntax.
-	// This is because we get raw specs from the loader and we need to parse them.
 	parsedRawSpecs, specDiags := p.parseSpecs(rawSpecs)
 
-	registry, err := p.registry()
+	// Separate manifests from resource specs — each gets its own engine
+	resourceSpecs, manifestSpecs := separateManifests(parsedRawSpecs)
+
+	resourceRegistry, err := p.resourceRegistry()
 	if err != nil {
-		return fmt.Errorf("setting up registry: %w", err)
+		return fmt.Errorf("setting up resource registry: %w", err)
+	}
+	resourceEngine, err := validation.NewValidationEngine(resourceRegistry, log)
+	if err != nil {
+		return fmt.Errorf("initialising resource validation engine: %w", err)
 	}
 
-	engine, err := validation.NewValidationEngine(registry, log)
+	manifestRegistry, err := manifestRegistry()
 	if err != nil {
-		return fmt.Errorf("initialising validation engine: %w", err)
+		return fmt.Errorf("setting up manifest registry: %w", err)
+	}
+	manifestEngine, err := validation.NewValidationEngine(manifestRegistry, log)
+	if err != nil {
+		return fmt.Errorf("initialising manifest validation engine: %w", err)
 	}
 
-	// All specs (resource + manifest) go through syntax validation together
-	syntaxDiags, err := engine.ValidateSyntax(ctx, parsedRawSpecs)
+	resourceSyntaxDiags, err := resourceEngine.ValidateSyntax(ctx, resourceSpecs)
 	if err != nil {
-		return fmt.Errorf("syntactic validation: %w", err)
+		return fmt.Errorf("resource syntactic validation: %w", err)
 	}
 
-	// If any spec or syntax diagnostic errors exist, render the diagnostics and return
-	// Both of them are part of the syntax validation although done at different places.
-	if specDiags.HasErrors() || syntaxDiags.HasErrors() {
-		if err := p.renderer.Render(append(
-			specDiags,
-			syntaxDiags...,
-		)); err != nil {
+	manifestSyntaxDiags, err := manifestEngine.ValidateSyntax(ctx, manifestSpecs)
+	if err != nil {
+		return fmt.Errorf("manifest syntactic validation: %w", err)
+	}
+
+	// Inline-vs-manifest conflict is a cross-concern check that spans both spec types
+	conflictDiags := checkInlineManifestConflicts(resourceSpecs, manifestSpecs)
+
+	allSyntaxDiags := append(specDiags, resourceSyntaxDiags...)
+	allSyntaxDiags = append(allSyntaxDiags, manifestSyntaxDiags...)
+	allSyntaxDiags = append(allSyntaxDiags, conflictDiags...)
+
+	if allSyntaxDiags.HasErrors() {
+		allSyntaxDiags.Sort()
+		if err := p.renderer.Render(allSyntaxDiags); err != nil {
 			return fmt.Errorf("rendering diagnostics: %w", err)
 		}
 		return fmt.Errorf("syntax validation failed")
 	}
 
-	// Separate manifests from resource specs after syntax validation passes.
-	// Only resource specs are loaded into providers; manifests are parsed separately.
-	resourceSpecs, manifestSpecs := separateManifests(parsedRawSpecs)
-
 	for path, rawSpec := range resourceSpecs {
-		if err := p.loadSpec(
-			path,
-			rawSpec.Parsed(),
-		); err != nil {
+		if err := p.loadSpec(path, rawSpec.Parsed()); err != nil {
 			return fmt.Errorf("loading spec %s: %w", path, err)
 		}
 	}
@@ -186,23 +195,26 @@ func (p *project) handleValidation(rawSpecs map[string]*specs.RawSpec) error {
 		return fmt.Errorf("building resource graph: %w", err)
 	}
 
-	// Cycles make the graph unusable,
-	// so detect them before semantic validation
 	if _, err := graph.DetectCycles(); err != nil {
 		return fmt.Errorf("cycle detected in resource graph: %w", err)
 	}
 
-	// All specs (resource + manifest) go through semantic validation together
-	semanticDiags, err := engine.ValidateSemantic(ctx, parsedRawSpecs, graph)
+	resourceSemanticDiags, err := resourceEngine.ValidateSemantic(ctx, resourceSpecs, graph)
 	if err != nil {
-		return fmt.Errorf("semantic validation: %w", err)
+		return fmt.Errorf("resource semantic validation: %w", err)
 	}
 
-	if err := p.renderer.Render(semanticDiags); err != nil {
+	manifestSemanticDiags, err := manifestEngine.ValidateSemantic(ctx, manifestSpecs, graph)
+	if err != nil {
+		return fmt.Errorf("manifest semantic validation: %w", err)
+	}
+
+	allSemanticDiags := append(resourceSemanticDiags, manifestSemanticDiags...)
+	if err := p.renderer.Render(allSemanticDiags); err != nil {
 		return fmt.Errorf("rendering diagnostics: %w", err)
 	}
 
-	if semanticDiags.HasErrors() {
+	if allSemanticDiags.HasErrors() {
 		return fmt.Errorf("semantic validation failed")
 	}
 
@@ -250,32 +262,17 @@ func (p *project) parseSpecs(raw map[string]*specs.RawSpec) (map[string]*specs.R
 	return parsedRawSpecs, diags
 }
 
-func (p *project) registry() (rules.Registry, error) {
-	providerPatterns := p.provider.SupportedMatchPatterns()
-
-	// import-manifest is a project-level kind, not owned by any provider.
-	// The registry always needs it so import-manifest rules can be registered.
-	// Gatekeeper rules use the combined set only when providers declare patterns,
-	// preserving the unrestricted fallback when they don't.
-	importManifestPattern := rules.MatchKindVersion(specs.KindImportManifest, specs.SpecVersionV1)
-	registryPatterns := make([]rules.MatchPattern, 0, len(providerPatterns)+1)
-	registryPatterns = append(registryPatterns, providerPatterns...)
-	registryPatterns = append(registryPatterns, importManifestPattern)
-	gatekeeperPatterns := appendImportManifestPattern(providerPatterns)
-
-	baseRegistry := rules.NewRegistry(registryPatterns)
-
-	dispatcher := p.newParseSpecDispatcher()
+// resourceRegistry builds the validation registry for resource specs only.
+// Manifest specs have their own engine — see newManifestEngine in manifest.go.
+func (p *project) resourceRegistry() (rules.Registry, error) {
+	activePatterns := p.provider.SupportedMatchPatterns()
+	baseRegistry := rules.NewRegistry(activePatterns)
 
 	syntactic := []rules.Rule{
-		prules.NewSpecSyntaxValidRule(gatekeeperPatterns),
-		prules.NewResourceKindVersionValidRule(gatekeeperPatterns),
-		// Metadata and URN rules only apply to provider-owned kinds;
-		// import-manifest has its own dedicated rules for structure validation.
-		prules.NewMetadataSyntaxValidRule(dispatcher, providerPatterns),
-		prules.NewDuplicateURNRule(dispatcher, providerPatterns),
-		prules.NewImportManifestSyntaxRule(),
-		prules.NewImportManifestProjectRule(),
+		prules.NewSpecSyntaxValidRule(activePatterns),
+		prules.NewResourceKindVersionValidRule(activePatterns),
+		prules.NewMetadataSyntaxValidRule(p.provider.ParseSpec, activePatterns),
+		prules.NewDuplicateURNRule(p.provider.ParseSpec, activePatterns),
 	}
 	syntactic = append(syntactic, p.provider.SyntacticRules()...)
 
@@ -285,12 +282,7 @@ func (p *project) registry() (rules.Registry, error) {
 		}
 	}
 
-	semantic := []rules.Rule{
-		prules.NewImportManifestSemanticRule(),
-	}
-	semantic = append(semantic, p.provider.SemanticRules()...)
-
-	for _, rule := range semantic {
+	for _, rule := range p.provider.SemanticRules() {
 		if err := baseRegistry.RegisterSemantic(rule); err != nil {
 			return nil, fmt.Errorf("registering semantic rule %s: %w", rule.ID(), err)
 		}
@@ -301,13 +293,4 @@ func (p *project) registry() (rules.Registry, error) {
 
 func (p *project) ResourceGraph() (*resources.Graph, error) {
 	return p.provider.ResourceGraph()
-}
-
-func (p *project) newParseSpecDispatcher() prules.ParseSpecFunc {
-	return func(path string, s *specs.Spec) (*specs.ParsedSpec, error) {
-		if s.IsImportManifest() {
-			return parseManifestSpec()
-		}
-		return p.provider.ParseSpec(path, s)
-	}
 }

--- a/cli/internal/project/project_manifest_test.go
+++ b/cli/internal/project/project_manifest_test.go
@@ -1,0 +1,201 @@
+package project
+
+import (
+	"testing"
+
+	"github.com/rudderlabs/rudder-iac/cli/internal/project/specs"
+	"github.com/rudderlabs/rudder-iac/cli/internal/provider"
+	"github.com/rudderlabs/rudder-iac/cli/internal/resources"
+	"github.com/rudderlabs/rudder-iac/cli/internal/validation/rules"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stubProjectProvider is a minimal ProjectProvider that does not implement ImportManifestLoader.
+type stubProjectProvider struct{}
+
+func (s *stubProjectProvider) LoadSpec(_ string, _ *specs.Spec) error                        { return nil }
+func (s *stubProjectProvider) LoadLegacySpec(_ string, _ *specs.Spec) error                  { return nil }
+func (s *stubProjectProvider) ParseSpec(_ string, _ *specs.Spec) (*specs.ParsedSpec, error)  { return nil, nil }
+func (s *stubProjectProvider) ResourceGraph() (*resources.Graph, error)                      { return nil, nil }
+func (s *stubProjectProvider) SupportedKinds() []string                                      { return nil }
+func (s *stubProjectProvider) SupportedTypes() []string                                      { return nil }
+func (s *stubProjectProvider) SupportedMatchPatterns() []rules.MatchPattern                  { return nil }
+func (s *stubProjectProvider) SyntacticRules() []rules.Rule                                  { return nil }
+func (s *stubProjectProvider) SemanticRules() []rules.Rule                                   { return nil }
+
+// manifestCapableProvider is a ProjectProvider that also implements ImportManifestLoader.
+type manifestCapableProvider struct {
+	stubProjectProvider
+	manifest *specs.WorkspacesImportMetadata
+}
+
+func (m *manifestCapableProvider) LoadImportManifest(manifest *specs.WorkspacesImportMetadata) error {
+	m.manifest = manifest
+	return nil
+}
+
+var _ provider.ImportManifestLoader = (*manifestCapableProvider)(nil)
+
+func TestParseManifestSpec(t *testing.T) {
+	t.Parallel()
+
+	result, err := parseManifestSpec()
+
+	require.NoError(t, err)
+	assert.Equal(t, &specs.ParsedSpec{
+		URNs:               nil,
+		LegacyResourceType: "",
+	}, result)
+}
+
+func TestSeparateManifests(t *testing.T) {
+	t.Parallel()
+
+	manifestSpec := &specs.RawSpec{Data: []byte("version: rudder/v1\nkind: import-manifest\nmetadata:\n  name: test\nspec:\n  workspaces: []\n")}
+	_, _ = manifestSpec.Parse()
+
+	resourceSpec := &specs.RawSpec{Data: []byte("version: rudder/v1\nkind: properties\nmetadata:\n  name: test\nspec:\n  properties: []\n")}
+	_, _ = resourceSpec.Parse()
+
+	rawSpecs := map[string]*specs.RawSpec{
+		"manifest.yaml": manifestSpec,
+		"props.yaml":    resourceSpec,
+	}
+
+	resourceSpecs, manifestSpecs := separateManifests(rawSpecs)
+
+	assert.Len(t, resourceSpecs, 1)
+	assert.Len(t, manifestSpecs, 1)
+	assert.Contains(t, resourceSpecs, "props.yaml")
+	assert.Contains(t, manifestSpecs, "manifest.yaml")
+}
+
+func TestDecodeManifestWorkspaces(t *testing.T) {
+	t.Parallel()
+
+	t.Run("valid input", func(t *testing.T) {
+		t.Parallel()
+
+		specMap := map[string]any{
+			"workspaces": []any{
+				map[string]any{
+					"workspace_id": "ws-123",
+					"resources": []any{
+						map[string]any{
+							"urn":       "source:my-src",
+							"remote_id": "remote-456",
+						},
+					},
+				},
+			},
+		}
+
+		result, err := decodeManifestWorkspaces(specMap)
+
+		require.NoError(t, err)
+		assert.Equal(t, []specs.WorkspaceImportMetadata{
+			{
+				WorkspaceID: "ws-123",
+				Resources: []specs.ImportIds{
+					{URN: "source:my-src", RemoteID: "remote-456"},
+				},
+			},
+		}, result)
+	})
+
+	t.Run("unknown fields rejected", func(t *testing.T) {
+		t.Parallel()
+
+		specMap := map[string]any{
+			"workspaces": []any{
+				map[string]any{
+					"workspace_id":  "ws-123",
+					"unknown_field": "bad",
+				},
+			},
+		}
+
+		_, err := decodeManifestWorkspaces(specMap)
+		assert.Error(t, err)
+	})
+}
+
+func TestParseManifests(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty manifests returns nil", func(t *testing.T) {
+		t.Parallel()
+
+		result, err := parseManifests(map[string]*specs.RawSpec{})
+
+		require.NoError(t, err)
+		assert.Nil(t, result)
+	})
+
+	t.Run("multiple manifest files merged", func(t *testing.T) {
+		t.Parallel()
+
+		spec1 := &specs.RawSpec{Data: []byte("version: rudder/v1\nkind: import-manifest\nmetadata:\n  name: m1\nspec:\n  workspaces:\n    - workspace_id: ws-1\n      resources:\n        - urn: \"source:a\"\n          remote_id: r1\n")}
+		_, _ = spec1.Parse()
+
+		spec2 := &specs.RawSpec{Data: []byte("version: rudder/v1\nkind: import-manifest\nmetadata:\n  name: m2\nspec:\n  workspaces:\n    - workspace_id: ws-2\n      resources:\n        - urn: \"source:b\"\n          remote_id: r2\n")}
+		_, _ = spec2.Parse()
+
+		manifestSpecs := map[string]*specs.RawSpec{
+			"m1.yaml": spec1,
+			"m2.yaml": spec2,
+		}
+
+		result, err := parseManifests(manifestSpecs)
+
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.Len(t, result.Workspaces, 2)
+	})
+}
+
+func TestBroadcastImportManifest(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil manifest is a no-op", func(t *testing.T) {
+		t.Parallel()
+
+		err := broadcastImportManifest(&stubProjectProvider{}, nil)
+		assert.NoError(t, err)
+	})
+
+	t.Run("provider without ImportManifestLoader is silently skipped", func(t *testing.T) {
+		t.Parallel()
+
+		manifest := &specs.WorkspacesImportMetadata{
+			Workspaces: []specs.WorkspaceImportMetadata{
+				{WorkspaceID: "ws-1"},
+			},
+		}
+
+		err := broadcastImportManifest(&stubProjectProvider{}, manifest)
+		assert.NoError(t, err)
+	})
+
+	t.Run("provider implementing ImportManifestLoader receives manifest", func(t *testing.T) {
+		t.Parallel()
+
+		manifest := &specs.WorkspacesImportMetadata{
+			Workspaces: []specs.WorkspaceImportMetadata{
+				{
+					WorkspaceID: "ws-1",
+					Resources: []specs.ImportIds{
+						{URN: "source:a", RemoteID: "r1"},
+					},
+				},
+			},
+		}
+
+		pp := &manifestCapableProvider{}
+		err := broadcastImportManifest(pp, manifest)
+
+		require.NoError(t, err)
+		assert.Equal(t, manifest, pp.manifest)
+	})
+}

--- a/cli/internal/project/rules/import_manifest_project_rule.go
+++ b/cli/internal/project/rules/import_manifest_project_rule.go
@@ -7,6 +7,8 @@ import (
 	"github.com/rudderlabs/rudder-iac/cli/internal/validation/rules"
 )
 
+// importManifestProjectRule detects duplicate URNs across multiple manifest files.
+// Implements both Rule and ProjectRule — cross-file logic runs in ValidateProject.
 type importManifestProjectRule struct{}
 
 func NewImportManifestProjectRule() rules.Rule {
@@ -16,19 +18,18 @@ func NewImportManifestProjectRule() rules.Rule {
 func (r *importManifestProjectRule) ID() string               { return "project/import-manifest-cross-file" }
 func (r *importManifestProjectRule) Severity() rules.Severity { return rules.Error }
 func (r *importManifestProjectRule) Description() string {
-	return "import manifest URNs must be unique across files and not conflict with inline metadata"
+	return "import manifest URNs must be unique across files"
 }
 func (r *importManifestProjectRule) AppliesTo() []rules.MatchPattern {
-	return []rules.MatchPattern{rules.MatchAll()}
+	return []rules.MatchPattern{rules.MatchKind(specs.KindImportManifest)}
 }
 func (r *importManifestProjectRule) Examples() rules.Examples { return rules.Examples{} }
 
-// Validate returns nil -- cross-file logic is in ValidateProject
 func (r *importManifestProjectRule) Validate(_ *rules.ValidationContext) []rules.ValidationResult {
 	return nil
 }
 
-// ValidateProject implements ProjectRule for cross-file manifest checks
+// ValidateProject checks for duplicate URNs across manifest files.
 func (r *importManifestProjectRule) ValidateProject(
 	allSpecs map[string]*rules.ValidationContext,
 ) map[string][]rules.ValidationResult {
@@ -45,7 +46,7 @@ func (r *importManifestProjectRule) ValidateProject(
 			continue
 		}
 
-		for _, entry := range extractManifestURNs(ctx.Spec) {
+		for _, entry := range ExtractManifestURNs(ctx.Spec) {
 			if prev, exists := manifestURNs[entry.URN]; exists {
 				results[filePath] = append(results[filePath], rules.ValidationResult{
 					RuleID:    r.ID(),
@@ -61,41 +62,19 @@ func (r *importManifestProjectRule) ValidateProject(
 		}
 	}
 
-	if len(manifestURNs) == 0 {
-		return results
-	}
-
-	// Detect conflicts with inline metadata.import in resource specs
-	for filePath, ctx := range allSpecs {
-		if ctx.Kind == specs.KindImportManifest {
-			continue
-		}
-
-		inlineURNs := extractInlineImportURNs(ctx.Metadata)
-		for _, urn := range inlineURNs {
-			if manifestLoc, exists := manifestURNs[urn]; exists {
-				results[manifestLoc.FilePath] = append(results[manifestLoc.FilePath], rules.ValidationResult{
-					RuleID:    r.ID(),
-					Severity:  r.Severity(),
-					Message:   fmt.Sprintf("URN '%s' found in both manifest %s and inline metadata in %s", urn, manifestLoc.FilePath, filePath),
-					FilePath:  manifestLoc.FilePath,
-					FileName:  manifestLoc.FilePath,
-					Reference: manifestLoc.Reference,
-				})
-			}
-		}
-	}
-
 	return results
 }
 
-type manifestURNEntry struct {
+// ManifestURNEntry holds a URN and its JSON pointer reference within a manifest spec.
+type ManifestURNEntry struct {
 	URN       string
 	Reference string
 }
 
-func extractManifestURNs(specMap map[string]any) []manifestURNEntry {
-	var entries []manifestURNEntry
+// ExtractManifestURNs extracts all URNs from a manifest spec's workspaces.
+// The specMap is the inner spec map (ctx.Spec / rawSpec.Parsed().Spec).
+func ExtractManifestURNs(specMap map[string]any) []ManifestURNEntry {
+	var entries []ManifestURNEntry
 
 	workspacesRaw, ok := specMap["workspaces"]
 	if !ok {
@@ -127,7 +106,7 @@ func extractManifestURNs(specMap map[string]any) []manifestURNEntry {
 			}
 			urn, _ := res["urn"].(string)
 			if urn != "" {
-				entries = append(entries, manifestURNEntry{
+				entries = append(entries, ManifestURNEntry{
 					URN:       urn,
 					Reference: fmt.Sprintf("/spec/workspaces/%d/resources/%d/urn", i, j),
 				})
@@ -138,7 +117,8 @@ func extractManifestURNs(specMap map[string]any) []manifestURNEntry {
 	return entries
 }
 
-func extractInlineImportURNs(metadata map[string]any) []string {
+// ExtractInlineImportURNs extracts URNs from a resource spec's metadata.import block.
+func ExtractInlineImportURNs(metadata map[string]any) []string {
 	var urns []string
 
 	importRaw, ok := metadata["import"]

--- a/cli/internal/project/rules/import_manifest_project_rule.go
+++ b/cli/internal/project/rules/import_manifest_project_rule.go
@@ -1,0 +1,186 @@
+package rules
+
+import (
+	"fmt"
+
+	"github.com/rudderlabs/rudder-iac/cli/internal/project/specs"
+	"github.com/rudderlabs/rudder-iac/cli/internal/validation/rules"
+)
+
+type importManifestProjectRule struct{}
+
+func NewImportManifestProjectRule() rules.Rule {
+	return &importManifestProjectRule{}
+}
+
+func (r *importManifestProjectRule) ID() string               { return "project/import-manifest-cross-file" }
+func (r *importManifestProjectRule) Severity() rules.Severity { return rules.Error }
+func (r *importManifestProjectRule) Description() string {
+	return "import manifest URNs must be unique across files and not conflict with inline metadata"
+}
+func (r *importManifestProjectRule) AppliesTo() []rules.MatchPattern {
+	return []rules.MatchPattern{rules.MatchAll()}
+}
+func (r *importManifestProjectRule) Examples() rules.Examples { return rules.Examples{} }
+
+// Validate returns nil -- cross-file logic is in ValidateProject
+func (r *importManifestProjectRule) Validate(_ *rules.ValidationContext) []rules.ValidationResult {
+	return nil
+}
+
+// ValidateProject implements ProjectRule for cross-file manifest checks
+func (r *importManifestProjectRule) ValidateProject(
+	allSpecs map[string]*rules.ValidationContext,
+) map[string][]rules.ValidationResult {
+	type urnLocation struct {
+		FilePath  string
+		Reference string
+	}
+
+	manifestURNs := make(map[string]urnLocation)
+	results := make(map[string][]rules.ValidationResult)
+
+	for filePath, ctx := range allSpecs {
+		if ctx.Kind != specs.KindImportManifest {
+			continue
+		}
+
+		for _, entry := range extractManifestURNs(ctx.Spec) {
+			if prev, exists := manifestURNs[entry.URN]; exists {
+				results[filePath] = append(results[filePath], rules.ValidationResult{
+					RuleID:    r.ID(),
+					Severity:  r.Severity(),
+					Message:   fmt.Sprintf("URN '%s' defined in both %s and %s", entry.URN, prev.FilePath, filePath),
+					FilePath:  filePath,
+					FileName:  ctx.FileName,
+					Reference: entry.Reference,
+				})
+			} else {
+				manifestURNs[entry.URN] = urnLocation{FilePath: filePath, Reference: entry.Reference}
+			}
+		}
+	}
+
+	if len(manifestURNs) == 0 {
+		return results
+	}
+
+	// Detect conflicts with inline metadata.import in resource specs
+	for filePath, ctx := range allSpecs {
+		if ctx.Kind == specs.KindImportManifest {
+			continue
+		}
+
+		inlineURNs := extractInlineImportURNs(ctx.Metadata)
+		for _, urn := range inlineURNs {
+			if manifestLoc, exists := manifestURNs[urn]; exists {
+				results[manifestLoc.FilePath] = append(results[manifestLoc.FilePath], rules.ValidationResult{
+					RuleID:    r.ID(),
+					Severity:  r.Severity(),
+					Message:   fmt.Sprintf("URN '%s' found in both manifest %s and inline metadata in %s", urn, manifestLoc.FilePath, filePath),
+					FilePath:  manifestLoc.FilePath,
+					FileName:  manifestLoc.FilePath,
+					Reference: manifestLoc.Reference,
+				})
+			}
+		}
+	}
+
+	return results
+}
+
+type manifestURNEntry struct {
+	URN       string
+	Reference string
+}
+
+func extractManifestURNs(specMap map[string]any) []manifestURNEntry {
+	var entries []manifestURNEntry
+
+	workspacesRaw, ok := specMap["workspaces"]
+	if !ok {
+		return nil
+	}
+
+	workspaces, ok := workspacesRaw.([]any)
+	if !ok {
+		return nil
+	}
+
+	for i, wsRaw := range workspaces {
+		ws, ok := wsRaw.(map[string]any)
+		if !ok {
+			continue
+		}
+		resourcesRaw, ok := ws["resources"]
+		if !ok {
+			continue
+		}
+		resources, ok := resourcesRaw.([]any)
+		if !ok {
+			continue
+		}
+		for j, resRaw := range resources {
+			res, ok := resRaw.(map[string]any)
+			if !ok {
+				continue
+			}
+			urn, _ := res["urn"].(string)
+			if urn != "" {
+				entries = append(entries, manifestURNEntry{
+					URN:       urn,
+					Reference: fmt.Sprintf("/spec/workspaces/%d/resources/%d/urn", i, j),
+				})
+			}
+		}
+	}
+
+	return entries
+}
+
+func extractInlineImportURNs(metadata map[string]any) []string {
+	var urns []string
+
+	importRaw, ok := metadata["import"]
+	if !ok {
+		return nil
+	}
+	importMap, ok := importRaw.(map[string]any)
+	if !ok {
+		return nil
+	}
+	workspacesRaw, ok := importMap["workspaces"]
+	if !ok {
+		return nil
+	}
+	workspaces, ok := workspacesRaw.([]any)
+	if !ok {
+		return nil
+	}
+
+	for _, wsRaw := range workspaces {
+		ws, ok := wsRaw.(map[string]any)
+		if !ok {
+			continue
+		}
+		resourcesRaw, ok := ws["resources"]
+		if !ok {
+			continue
+		}
+		resources, ok := resourcesRaw.([]any)
+		if !ok {
+			continue
+		}
+		for _, resRaw := range resources {
+			res, ok := resRaw.(map[string]any)
+			if !ok {
+				continue
+			}
+			if urn, ok := res["urn"].(string); ok && urn != "" {
+				urns = append(urns, urn)
+			}
+		}
+	}
+
+	return urns
+}

--- a/cli/internal/project/rules/import_manifest_project_rule_test.go
+++ b/cli/internal/project/rules/import_manifest_project_rule_test.go
@@ -1,0 +1,169 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/rudderlabs/rudder-iac/cli/internal/project/specs"
+	"github.com/rudderlabs/rudder-iac/cli/internal/validation/rules"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestImportManifestProjectRule_Metadata(t *testing.T) {
+	t.Parallel()
+
+	rule := NewImportManifestProjectRule()
+
+	assert.Equal(t, "project/import-manifest-cross-file", rule.ID())
+	assert.Equal(t, rules.Error, rule.Severity())
+	assert.Equal(t, []rules.MatchPattern{rules.MatchAll()}, rule.AppliesTo())
+	assert.Nil(t, rule.Validate(nil))
+}
+
+func TestImportManifestProjectRule_ValidateProject(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no manifests produces no violations", func(t *testing.T) {
+		t.Parallel()
+
+		rule := NewImportManifestProjectRule()
+		pr := rule.(rules.ProjectRule)
+
+		results := pr.ValidateProject(map[string]*rules.ValidationContext{
+			"props.yaml": {
+				Kind: "properties",
+				Spec: map[string]any{
+					"properties": []any{map[string]any{"id": "email"}},
+				},
+			},
+		})
+
+		assert.Empty(t, results)
+	})
+
+	t.Run("single manifest with no cross-file issues", func(t *testing.T) {
+		t.Parallel()
+
+		rule := NewImportManifestProjectRule()
+		pr := rule.(rules.ProjectRule)
+
+		results := pr.ValidateProject(map[string]*rules.ValidationContext{
+			"manifest.yaml": {
+				Kind: specs.KindImportManifest,
+				Spec: map[string]any{
+					"workspaces": []any{
+						map[string]any{
+							"workspace_id": "ws-1",
+							"resources": []any{
+								map[string]any{"urn": "source:a", "remote_id": "r1"},
+							},
+						},
+					},
+				},
+			},
+			"props.yaml": {
+				Kind:     "properties",
+				Metadata: map[string]any{},
+				Spec:     map[string]any{},
+			},
+		})
+
+		assert.Empty(t, results)
+	})
+
+	t.Run("duplicate URN across two manifest files", func(t *testing.T) {
+		t.Parallel()
+
+		rule := NewImportManifestProjectRule()
+		pr := rule.(rules.ProjectRule)
+
+		results := pr.ValidateProject(map[string]*rules.ValidationContext{
+			"manifest-a.yaml": {
+				Kind: specs.KindImportManifest,
+				Spec: map[string]any{
+					"workspaces": []any{
+						map[string]any{
+							"workspace_id": "ws-1",
+							"resources": []any{
+								map[string]any{"urn": "source:dup", "remote_id": "r1"},
+							},
+						},
+					},
+				},
+			},
+			"manifest-b.yaml": {
+				Kind:     specs.KindImportManifest,
+				FileName: "manifest-b.yaml",
+				Spec: map[string]any{
+					"workspaces": []any{
+						map[string]any{
+							"workspace_id": "ws-2",
+							"resources": []any{
+								map[string]any{"urn": "source:dup", "remote_id": "r2"},
+							},
+						},
+					},
+				},
+			},
+		})
+
+		// One of the two files should have a violation
+		totalViolations := 0
+		for _, fileResults := range results {
+			totalViolations += len(fileResults)
+		}
+		require.Equal(t, 1, totalViolations)
+
+		// Find the violation and verify message
+		for _, fileResults := range results {
+			for _, r := range fileResults {
+				assert.Contains(t, r.Message, "source:dup")
+				assert.Contains(t, r.Message, "defined in both")
+			}
+		}
+	})
+
+	t.Run("URN in both manifest and inline metadata", func(t *testing.T) {
+		t.Parallel()
+
+		rule := NewImportManifestProjectRule()
+		pr := rule.(rules.ProjectRule)
+
+		results := pr.ValidateProject(map[string]*rules.ValidationContext{
+			"manifest.yaml": {
+				Kind: specs.KindImportManifest,
+				Spec: map[string]any{
+					"workspaces": []any{
+						map[string]any{
+							"workspace_id": "ws-1",
+							"resources": []any{
+								map[string]any{"urn": "source:shared", "remote_id": "r1"},
+							},
+						},
+					},
+				},
+			},
+			"source.yaml": {
+				Kind: "event-stream-source",
+				Metadata: map[string]any{
+					"import": map[string]any{
+						"workspaces": []any{
+							map[string]any{
+								"workspace_id": "ws-1",
+								"resources": []any{
+									map[string]any{"urn": "source:shared", "remote_id": "r2"},
+								},
+							},
+						},
+					},
+				},
+				Spec: map[string]any{},
+			},
+		})
+
+		require.Contains(t, results, "manifest.yaml")
+		require.Len(t, results["manifest.yaml"], 1)
+		assert.Contains(t, results["manifest.yaml"][0].Message, "source:shared")
+		assert.Contains(t, results["manifest.yaml"][0].Message, "inline metadata")
+	})
+}

--- a/cli/internal/project/rules/import_manifest_project_rule_test.go
+++ b/cli/internal/project/rules/import_manifest_project_rule_test.go
@@ -16,7 +16,7 @@ func TestImportManifestProjectRule_Metadata(t *testing.T) {
 
 	assert.Equal(t, "project/import-manifest-cross-file", rule.ID())
 	assert.Equal(t, rules.Error, rule.Severity())
-	assert.Equal(t, []rules.MatchPattern{rules.MatchAll()}, rule.AppliesTo())
+	assert.Equal(t, []rules.MatchPattern{rules.MatchKind(specs.KindImportManifest)}, rule.AppliesTo())
 	assert.Nil(t, rule.Validate(nil))
 }
 
@@ -61,11 +61,6 @@ func TestImportManifestProjectRule_ValidateProject(t *testing.T) {
 					},
 				},
 			},
-			"props.yaml": {
-				Kind:     "properties",
-				Metadata: map[string]any{},
-				Spec:     map[string]any{},
-			},
 		})
 
 		assert.Empty(t, results)
@@ -107,63 +102,17 @@ func TestImportManifestProjectRule_ValidateProject(t *testing.T) {
 			},
 		})
 
-		// One of the two files should have a violation
 		totalViolations := 0
 		for _, fileResults := range results {
 			totalViolations += len(fileResults)
 		}
 		require.Equal(t, 1, totalViolations)
 
-		// Find the violation and verify message
 		for _, fileResults := range results {
 			for _, r := range fileResults {
 				assert.Contains(t, r.Message, "source:dup")
 				assert.Contains(t, r.Message, "defined in both")
 			}
 		}
-	})
-
-	t.Run("URN in both manifest and inline metadata", func(t *testing.T) {
-		t.Parallel()
-
-		rule := NewImportManifestProjectRule()
-		pr := rule.(rules.ProjectRule)
-
-		results := pr.ValidateProject(map[string]*rules.ValidationContext{
-			"manifest.yaml": {
-				Kind: specs.KindImportManifest,
-				Spec: map[string]any{
-					"workspaces": []any{
-						map[string]any{
-							"workspace_id": "ws-1",
-							"resources": []any{
-								map[string]any{"urn": "source:shared", "remote_id": "r1"},
-							},
-						},
-					},
-				},
-			},
-			"source.yaml": {
-				Kind: "event-stream-source",
-				Metadata: map[string]any{
-					"import": map[string]any{
-						"workspaces": []any{
-							map[string]any{
-								"workspace_id": "ws-1",
-								"resources": []any{
-									map[string]any{"urn": "source:shared", "remote_id": "r2"},
-								},
-							},
-						},
-					},
-				},
-				Spec: map[string]any{},
-			},
-		})
-
-		require.Contains(t, results, "manifest.yaml")
-		require.Len(t, results["manifest.yaml"], 1)
-		assert.Contains(t, results["manifest.yaml"][0].Message, "source:shared")
-		assert.Contains(t, results["manifest.yaml"][0].Message, "inline metadata")
 	})
 }

--- a/cli/internal/project/rules/import_manifest_semantic_rule.go
+++ b/cli/internal/project/rules/import_manifest_semantic_rule.go
@@ -30,8 +30,7 @@ func (r *importManifestSemanticRule) Validate(ctx *rules.ValidationContext) []ru
 
 	var results []rules.ValidationResult
 
-	// extractManifestURNs is defined in import_manifest_project_rule.go (same package)
-	for _, entry := range extractManifestURNs(ctx.Spec) {
+	for _, entry := range ExtractManifestURNs(ctx.Spec) {
 		if _, exists := ctx.Graph.GetResource(entry.URN); !exists {
 			results = append(results, rules.ValidationResult{
 				RuleID:    r.ID(),

--- a/cli/internal/project/rules/import_manifest_semantic_rule.go
+++ b/cli/internal/project/rules/import_manifest_semantic_rule.go
@@ -1,0 +1,48 @@
+package rules
+
+import (
+	"fmt"
+
+	"github.com/rudderlabs/rudder-iac/cli/internal/project/specs"
+	"github.com/rudderlabs/rudder-iac/cli/internal/validation/rules"
+)
+
+type importManifestSemanticRule struct{}
+
+func NewImportManifestSemanticRule() rules.Rule {
+	return &importManifestSemanticRule{}
+}
+
+func (r *importManifestSemanticRule) ID() string               { return "project/import-manifest-semantic" }
+func (r *importManifestSemanticRule) Severity() rules.Severity { return rules.Error }
+func (r *importManifestSemanticRule) Description() string {
+	return "manifest URNs must reference existing resources"
+}
+func (r *importManifestSemanticRule) AppliesTo() []rules.MatchPattern {
+	return []rules.MatchPattern{rules.MatchKind(specs.KindImportManifest)}
+}
+func (r *importManifestSemanticRule) Examples() rules.Examples { return rules.Examples{} }
+
+func (r *importManifestSemanticRule) Validate(ctx *rules.ValidationContext) []rules.ValidationResult {
+	if !ctx.HasGraph() {
+		return nil
+	}
+
+	var results []rules.ValidationResult
+
+	// extractManifestURNs is defined in import_manifest_project_rule.go (same package)
+	for _, entry := range extractManifestURNs(ctx.Spec) {
+		if _, exists := ctx.Graph.GetResource(entry.URN); !exists {
+			results = append(results, rules.ValidationResult{
+				RuleID:    r.ID(),
+				Severity:  r.Severity(),
+				Message:   fmt.Sprintf("manifest URN '%s' does not match any resource in specs", entry.URN),
+				FilePath:  ctx.FilePath,
+				FileName:  ctx.FileName,
+				Reference: entry.Reference,
+			})
+		}
+	}
+
+	return results
+}

--- a/cli/internal/project/rules/import_manifest_semantic_rule_test.go
+++ b/cli/internal/project/rules/import_manifest_semantic_rule_test.go
@@ -1,0 +1,103 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/rudderlabs/rudder-iac/cli/internal/project/specs"
+	"github.com/rudderlabs/rudder-iac/cli/internal/resources"
+	"github.com/rudderlabs/rudder-iac/cli/internal/validation/rules"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestImportManifestSemanticRule_Metadata(t *testing.T) {
+	t.Parallel()
+
+	rule := NewImportManifestSemanticRule()
+
+	assert.Equal(t, "project/import-manifest-semantic", rule.ID())
+	assert.Equal(t, rules.Error, rule.Severity())
+	assert.Equal(t, []rules.MatchPattern{rules.MatchKind(specs.KindImportManifest)}, rule.AppliesTo())
+}
+
+func TestImportManifestSemanticRule_Validate(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no graph available returns nil", func(t *testing.T) {
+		t.Parallel()
+
+		rule := NewImportManifestSemanticRule()
+		results := rule.Validate(&rules.ValidationContext{
+			Kind: specs.KindImportManifest,
+			Spec: map[string]any{
+				"workspaces": []any{
+					map[string]any{
+						"workspace_id": "ws-1",
+						"resources": []any{
+							map[string]any{"urn": "source:orphan", "remote_id": "r1"},
+						},
+					},
+				},
+			},
+			Graph: nil,
+		})
+
+		assert.Nil(t, results)
+	})
+
+	t.Run("all URNs exist in graph", func(t *testing.T) {
+		t.Parallel()
+
+		graph := resources.NewGraph()
+		graph.AddResource(resources.NewResource("my-source", "source", nil, nil))
+
+		rule := NewImportManifestSemanticRule()
+		results := rule.Validate(&rules.ValidationContext{
+			FilePath: "manifest.yaml",
+			FileName: "manifest.yaml",
+			Kind:     specs.KindImportManifest,
+			Spec: map[string]any{
+				"workspaces": []any{
+					map[string]any{
+						"workspace_id": "ws-1",
+						"resources": []any{
+							map[string]any{"urn": "source:my-source", "remote_id": "r1"},
+						},
+					},
+				},
+			},
+			Graph: graph,
+		})
+
+		assert.Empty(t, results)
+	})
+
+	t.Run("orphaned URN not in graph", func(t *testing.T) {
+		t.Parallel()
+
+		graph := resources.NewGraph()
+
+		rule := NewImportManifestSemanticRule()
+		results := rule.Validate(&rules.ValidationContext{
+			FilePath: "manifest.yaml",
+			FileName: "manifest.yaml",
+			Kind:     specs.KindImportManifest,
+			Spec: map[string]any{
+				"workspaces": []any{
+					map[string]any{
+						"workspace_id": "ws-1",
+						"resources": []any{
+							map[string]any{"urn": "source:orphan", "remote_id": "r1"},
+						},
+					},
+				},
+			},
+			Graph: graph,
+		})
+
+		require.Len(t, results, 1)
+		assert.Contains(t, results[0].Message, "source:orphan")
+		assert.Contains(t, results[0].Message, "does not match any resource")
+		assert.Equal(t, "/spec/workspaces/0/resources/0/urn", results[0].Reference)
+	})
+}

--- a/cli/internal/project/rules/import_manifest_syntax_rule.go
+++ b/cli/internal/project/rules/import_manifest_syntax_rule.go
@@ -1,0 +1,164 @@
+package rules
+
+import (
+	"fmt"
+
+	"github.com/go-viper/mapstructure/v2"
+
+	"github.com/rudderlabs/rudder-iac/cli/internal/project/specs"
+	"github.com/rudderlabs/rudder-iac/cli/internal/validation/rules"
+)
+
+type importManifestSyntaxRule struct{}
+
+func NewImportManifestSyntaxRule() rules.Rule {
+	return &importManifestSyntaxRule{}
+}
+
+func (r *importManifestSyntaxRule) ID() string               { return "project/import-manifest-syntax" }
+func (r *importManifestSyntaxRule) Severity() rules.Severity { return rules.Error }
+func (r *importManifestSyntaxRule) Description() string {
+	return "import manifest syntax must be valid"
+}
+func (r *importManifestSyntaxRule) AppliesTo() []rules.MatchPattern {
+	return []rules.MatchPattern{rules.MatchKind(specs.KindImportManifest)}
+}
+func (r *importManifestSyntaxRule) Examples() rules.Examples { return rules.Examples{} }
+
+func (r *importManifestSyntaxRule) Validate(ctx *rules.ValidationContext) []rules.ValidationResult {
+	var results []rules.ValidationResult
+
+	workspacesRaw, ok := ctx.Spec["workspaces"]
+	if !ok {
+		results = append(results, rules.ValidationResult{
+			RuleID:    r.ID(),
+			Severity:  r.Severity(),
+			Message:   "manifest must contain 'workspaces' field",
+			FilePath:  ctx.FilePath,
+			FileName:  ctx.FileName,
+			Reference: "/spec/workspaces",
+		})
+		return results
+	}
+
+	workspaces, ok := workspacesRaw.([]any)
+	if !ok || len(workspaces) == 0 {
+		results = append(results, rules.ValidationResult{
+			RuleID:    r.ID(),
+			Severity:  r.Severity(),
+			Message:   "manifest must contain at least one workspace",
+			FilePath:  ctx.FilePath,
+			FileName:  ctx.FileName,
+			Reference: "/spec/workspaces",
+		})
+		return results
+	}
+
+	if err := validateManifestPayloadStrict(ctx.Spec); err != nil {
+		results = append(results, rules.ValidationResult{
+			RuleID:    r.ID(),
+			Severity:  r.Severity(),
+			Message:   fmt.Sprintf("manifest contains unknown or invalid fields: %s", err.Error()),
+			FilePath:  ctx.FilePath,
+			FileName:  ctx.FileName,
+			Reference: "/spec",
+		})
+		return results
+	}
+
+	seenURNs := make(map[string]string) // urn -> reference path for first occurrence
+
+	for i, wsRaw := range workspaces {
+		ws, ok := wsRaw.(map[string]any)
+		if !ok {
+			results = append(results, rules.ValidationResult{
+				RuleID:    r.ID(),
+				Severity:  r.Severity(),
+				Message:   fmt.Sprintf("workspace at index %d must be a map", i),
+				FilePath:  ctx.FilePath,
+				FileName:  ctx.FileName,
+				Reference: fmt.Sprintf("/spec/workspaces/%d", i),
+			})
+			continue
+		}
+
+		wsID, _ := ws["workspace_id"].(string)
+		if wsID == "" {
+			results = append(results, rules.ValidationResult{
+				RuleID:    r.ID(),
+				Severity:  r.Severity(),
+				Message:   fmt.Sprintf("missing required field 'workspace_id' in workspace at index %d", i),
+				FilePath:  ctx.FilePath,
+				FileName:  ctx.FileName,
+				Reference: fmt.Sprintf("/spec/workspaces/%d/workspace_id", i),
+			})
+		}
+
+		resourcesRaw, ok := ws["resources"]
+		if !ok {
+			continue
+		}
+		resources, ok := resourcesRaw.([]any)
+		if !ok {
+			continue
+		}
+
+		for j, resRaw := range resources {
+			res, ok := resRaw.(map[string]any)
+			if !ok {
+				continue
+			}
+
+			urn, _ := res["urn"].(string)
+			remoteID, _ := res["remote_id"].(string)
+
+			entry := specs.ImportIds{
+				URN:      urn,
+				RemoteID: remoteID,
+			}
+			if err := entry.Validate(); err != nil {
+				results = append(results, rules.ValidationResult{
+					RuleID:    r.ID(),
+					Severity:  r.Severity(),
+					Message:   fmt.Sprintf("invalid import resource in workspace '%s': %s", wsID, err.Error()),
+					FilePath:  ctx.FilePath,
+					FileName:  ctx.FileName,
+					Reference: fmt.Sprintf("/spec/workspaces/%d/resources/%d", i, j),
+				})
+			}
+
+			if urn != "" {
+				ref := fmt.Sprintf("/spec/workspaces/%d/resources/%d/urn", i, j)
+				if _, exists := seenURNs[urn]; exists {
+					results = append(results, rules.ValidationResult{
+						RuleID:    r.ID(),
+						Severity:  r.Severity(),
+						Message:   fmt.Sprintf("duplicate URN '%s' within manifest", urn),
+						FilePath:  ctx.FilePath,
+						FileName:  ctx.FileName,
+						Reference: ref,
+					})
+				} else {
+					seenURNs[urn] = ref
+				}
+			}
+		}
+	}
+
+	return results
+}
+
+func validateManifestPayloadStrict(specMap map[string]any) error {
+	var payload struct {
+		Workspaces []specs.WorkspaceImportMetadata `yaml:"workspaces"`
+	}
+	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		TagName:     "yaml",
+		ErrorUnused: true,
+		Result:      &payload,
+	})
+	if err != nil {
+		return fmt.Errorf("creating decoder: %w", err)
+	}
+	return decoder.Decode(specMap)
+}

--- a/cli/internal/project/rules/import_manifest_syntax_rule.go
+++ b/cli/internal/project/rules/import_manifest_syntax_rule.go
@@ -1,0 +1,163 @@
+package rules
+
+import (
+	"bytes"
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/rudderlabs/rudder-iac/cli/internal/project/specs"
+	"github.com/rudderlabs/rudder-iac/cli/internal/validation/rules"
+)
+
+type importManifestSyntaxRule struct{}
+
+func NewImportManifestSyntaxRule() rules.Rule {
+	return &importManifestSyntaxRule{}
+}
+
+func (r *importManifestSyntaxRule) ID() string               { return "project/import-manifest-syntax" }
+func (r *importManifestSyntaxRule) Severity() rules.Severity { return rules.Error }
+func (r *importManifestSyntaxRule) Description() string {
+	return "import manifest syntax must be valid"
+}
+func (r *importManifestSyntaxRule) AppliesTo() []rules.MatchPattern {
+	return []rules.MatchPattern{rules.MatchKind(specs.KindImportManifest)}
+}
+func (r *importManifestSyntaxRule) Examples() rules.Examples { return rules.Examples{} }
+
+func (r *importManifestSyntaxRule) Validate(ctx *rules.ValidationContext) []rules.ValidationResult {
+	var results []rules.ValidationResult
+
+	workspacesRaw, ok := ctx.Spec["workspaces"]
+	if !ok {
+		results = append(results, rules.ValidationResult{
+			RuleID:    r.ID(),
+			Severity:  r.Severity(),
+			Message:   "manifest must contain 'workspaces' field",
+			FilePath:  ctx.FilePath,
+			FileName:  ctx.FileName,
+			Reference: "/spec/workspaces",
+		})
+		return results
+	}
+
+	workspaces, ok := workspacesRaw.([]any)
+	if !ok || len(workspaces) == 0 {
+		results = append(results, rules.ValidationResult{
+			RuleID:    r.ID(),
+			Severity:  r.Severity(),
+			Message:   "manifest must contain at least one workspace",
+			FilePath:  ctx.FilePath,
+			FileName:  ctx.FileName,
+			Reference: "/spec/workspaces",
+		})
+		return results
+	}
+
+	if err := validateManifestPayloadStrict(ctx.Spec); err != nil {
+		results = append(results, rules.ValidationResult{
+			RuleID:    r.ID(),
+			Severity:  r.Severity(),
+			Message:   fmt.Sprintf("manifest contains unknown or invalid fields: %s", err.Error()),
+			FilePath:  ctx.FilePath,
+			FileName:  ctx.FileName,
+			Reference: "/spec",
+		})
+		return results
+	}
+
+	seenURNs := make(map[string]string) // urn -> reference path for first occurrence
+
+	for i, wsRaw := range workspaces {
+		ws, ok := wsRaw.(map[string]any)
+		if !ok {
+			results = append(results, rules.ValidationResult{
+				RuleID:    r.ID(),
+				Severity:  r.Severity(),
+				Message:   fmt.Sprintf("workspace at index %d must be a map", i),
+				FilePath:  ctx.FilePath,
+				FileName:  ctx.FileName,
+				Reference: fmt.Sprintf("/spec/workspaces/%d", i),
+			})
+			continue
+		}
+
+		wsID, _ := ws["workspace_id"].(string)
+		if wsID == "" {
+			results = append(results, rules.ValidationResult{
+				RuleID:    r.ID(),
+				Severity:  r.Severity(),
+				Message:   fmt.Sprintf("missing required field 'workspace_id' in workspace at index %d", i),
+				FilePath:  ctx.FilePath,
+				FileName:  ctx.FileName,
+				Reference: fmt.Sprintf("/spec/workspaces/%d/workspace_id", i),
+			})
+		}
+
+		resourcesRaw, ok := ws["resources"]
+		if !ok {
+			continue
+		}
+		resources, ok := resourcesRaw.([]any)
+		if !ok {
+			continue
+		}
+
+		for j, resRaw := range resources {
+			res, ok := resRaw.(map[string]any)
+			if !ok {
+				continue
+			}
+
+			urn, _ := res["urn"].(string)
+			remoteID, _ := res["remote_id"].(string)
+
+			entry := specs.ImportIds{
+				URN:      urn,
+				RemoteID: remoteID,
+			}
+			if err := entry.Validate(); err != nil {
+				results = append(results, rules.ValidationResult{
+					RuleID:    r.ID(),
+					Severity:  r.Severity(),
+					Message:   fmt.Sprintf("invalid import resource in workspace '%s': %s", wsID, err.Error()),
+					FilePath:  ctx.FilePath,
+					FileName:  ctx.FileName,
+					Reference: fmt.Sprintf("/spec/workspaces/%d/resources/%d", i, j),
+				})
+			}
+
+			if urn != "" {
+				ref := fmt.Sprintf("/spec/workspaces/%d/resources/%d/urn", i, j)
+				if _, exists := seenURNs[urn]; exists {
+					results = append(results, rules.ValidationResult{
+						RuleID:    r.ID(),
+						Severity:  r.Severity(),
+						Message:   fmt.Sprintf("duplicate URN '%s' within manifest", urn),
+						FilePath:  ctx.FilePath,
+						FileName:  ctx.FileName,
+						Reference: ref,
+					})
+				} else {
+					seenURNs[urn] = ref
+				}
+			}
+		}
+	}
+
+	return results
+}
+
+func validateManifestPayloadStrict(specMap map[string]any) error {
+	raw, err := yaml.Marshal(specMap)
+	if err != nil {
+		return fmt.Errorf("marshalling spec: %w", err)
+	}
+	var payload struct {
+		Workspaces []specs.WorkspaceImportMetadata `yaml:"workspaces"`
+	}
+	decoder := yaml.NewDecoder(bytes.NewReader(raw))
+	decoder.KnownFields(true)
+	return decoder.Decode(&payload)
+}

--- a/cli/internal/project/rules/import_manifest_syntax_rule_test.go
+++ b/cli/internal/project/rules/import_manifest_syntax_rule_test.go
@@ -1,0 +1,197 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/rudderlabs/rudder-iac/cli/internal/project/specs"
+	"github.com/rudderlabs/rudder-iac/cli/internal/validation/rules"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestImportManifestSyntaxRule_Metadata(t *testing.T) {
+	t.Parallel()
+
+	rule := NewImportManifestSyntaxRule()
+
+	assert.Equal(t, "project/import-manifest-syntax", rule.ID())
+	assert.Equal(t, rules.Error, rule.Severity())
+	assert.Equal(t, []rules.MatchPattern{rules.MatchKind(specs.KindImportManifest)}, rule.AppliesTo())
+}
+
+func TestImportManifestSyntaxRule_Validate(t *testing.T) {
+	t.Parallel()
+
+	t.Run("valid manifest passes", func(t *testing.T) {
+		t.Parallel()
+
+		rule := NewImportManifestSyntaxRule()
+		results := rule.Validate(&rules.ValidationContext{
+			FilePath: "manifest.yaml",
+			FileName: "manifest.yaml",
+			Kind:     specs.KindImportManifest,
+			Version:  specs.SpecVersionV1,
+			Spec: map[string]any{
+				"workspaces": []any{
+					map[string]any{
+						"workspace_id": "ws-123",
+						"resources": []any{
+							map[string]any{
+								"urn":       "source:my-source",
+								"remote_id": "remote-456",
+							},
+						},
+					},
+				},
+			},
+		})
+
+		assert.Empty(t, results)
+	})
+
+	t.Run("missing workspaces field", func(t *testing.T) {
+		t.Parallel()
+
+		rule := NewImportManifestSyntaxRule()
+		results := rule.Validate(&rules.ValidationContext{
+			FilePath: "manifest.yaml",
+			FileName: "manifest.yaml",
+			Kind:     specs.KindImportManifest,
+			Version:  specs.SpecVersionV1,
+			Spec:     map[string]any{},
+		})
+
+		require.Len(t, results, 1)
+		assert.Equal(t, "manifest must contain 'workspaces' field", results[0].Message)
+		assert.Equal(t, "/spec/workspaces", results[0].Reference)
+	})
+
+	t.Run("empty workspaces list", func(t *testing.T) {
+		t.Parallel()
+
+		rule := NewImportManifestSyntaxRule()
+		results := rule.Validate(&rules.ValidationContext{
+			FilePath: "manifest.yaml",
+			FileName: "manifest.yaml",
+			Kind:     specs.KindImportManifest,
+			Version:  specs.SpecVersionV1,
+			Spec: map[string]any{
+				"workspaces": []any{},
+			},
+		})
+
+		require.Len(t, results, 1)
+		assert.Equal(t, "manifest must contain at least one workspace", results[0].Message)
+	})
+
+	t.Run("missing workspace_id", func(t *testing.T) {
+		t.Parallel()
+
+		rule := NewImportManifestSyntaxRule()
+		results := rule.Validate(&rules.ValidationContext{
+			FilePath: "manifest.yaml",
+			FileName: "manifest.yaml",
+			Kind:     specs.KindImportManifest,
+			Version:  specs.SpecVersionV1,
+			Spec: map[string]any{
+				"workspaces": []any{
+					map[string]any{
+						"resources": []any{
+							map[string]any{
+								"urn":       "source:my-source",
+								"remote_id": "remote-456",
+							},
+						},
+					},
+				},
+			},
+		})
+
+		require.Len(t, results, 1)
+		assert.Contains(t, results[0].Message, "missing required field 'workspace_id'")
+		assert.Equal(t, "/spec/workspaces/0/workspace_id", results[0].Reference)
+	})
+
+	t.Run("invalid import ids - missing urn and remote_id", func(t *testing.T) {
+		t.Parallel()
+
+		rule := NewImportManifestSyntaxRule()
+		results := rule.Validate(&rules.ValidationContext{
+			FilePath: "manifest.yaml",
+			FileName: "manifest.yaml",
+			Kind:     specs.KindImportManifest,
+			Version:  specs.SpecVersionV1,
+			Spec: map[string]any{
+				"workspaces": []any{
+					map[string]any{
+						"workspace_id": "ws-123",
+						"resources": []any{
+							map[string]any{},
+						},
+					},
+				},
+			},
+		})
+
+		require.Len(t, results, 1)
+		assert.Contains(t, results[0].Message, "invalid import resource")
+		assert.Equal(t, "/spec/workspaces/0/resources/0", results[0].Reference)
+	})
+
+	t.Run("duplicate URNs within manifest", func(t *testing.T) {
+		t.Parallel()
+
+		rule := NewImportManifestSyntaxRule()
+		results := rule.Validate(&rules.ValidationContext{
+			FilePath: "manifest.yaml",
+			FileName: "manifest.yaml",
+			Kind:     specs.KindImportManifest,
+			Version:  specs.SpecVersionV1,
+			Spec: map[string]any{
+				"workspaces": []any{
+					map[string]any{
+						"workspace_id": "ws-123",
+						"resources": []any{
+							map[string]any{
+								"urn":       "source:my-source",
+								"remote_id": "remote-1",
+							},
+							map[string]any{
+								"urn":       "source:my-source",
+								"remote_id": "remote-2",
+							},
+						},
+					},
+				},
+			},
+		})
+
+		require.Len(t, results, 1)
+		assert.Contains(t, results[0].Message, "duplicate URN 'source:my-source'")
+		assert.Equal(t, "/spec/workspaces/0/resources/1/urn", results[0].Reference)
+	})
+
+	t.Run("unknown fields rejected", func(t *testing.T) {
+		t.Parallel()
+
+		rule := NewImportManifestSyntaxRule()
+		results := rule.Validate(&rules.ValidationContext{
+			FilePath: "manifest.yaml",
+			FileName: "manifest.yaml",
+			Kind:     specs.KindImportManifest,
+			Version:  specs.SpecVersionV1,
+			Spec: map[string]any{
+				"workspaces": []any{
+					map[string]any{
+						"workspace_id":  "ws-123",
+						"unknown_field": "bad",
+					},
+				},
+			},
+		})
+
+		require.Len(t, results, 1)
+		assert.Contains(t, results[0].Message, "manifest contains unknown or invalid fields")
+		assert.Equal(t, "/spec", results[0].Reference)
+	})
+}

--- a/cli/internal/project/specs/spec.go
+++ b/cli/internal/project/specs/spec.go
@@ -14,6 +14,8 @@ const (
 	SpecVersionV0_1        = "rudder/0.1"
 	SpecVersionV0_1Variant = "rudder/v0.1" // Legacy variant with 'v' prefix
 	SpecVersionV1          = "rudder/v1"
+
+	KindImportManifest = "import-manifest"
 )
 
 type RawSpec struct {
@@ -62,6 +64,11 @@ type Spec struct {
 	Kind     string         `yaml:"kind"`
 	Metadata map[string]any `yaml:"metadata"`
 	Spec     map[string]any `yaml:"spec"`
+}
+
+// IsImportManifest returns true if the spec kind is import-manifest
+func (s *Spec) IsImportManifest() bool {
+	return s.Kind == KindImportManifest
 }
 
 // IsLegacyVersion returns true if the spec version is a legacy version (rudder/0.1 or rudder/v0.1)

--- a/cli/internal/provider/baseprovider.go
+++ b/cli/internal/provider/baseprovider.go
@@ -17,6 +17,7 @@ type Handler interface {
 	ResourceType() string
 	SpecKind() string
 	LoadSpec(path string, s *specs.Spec) error
+	LoadImportMetadata(m *specs.WorkspacesImportMetadata) error
 	ParseSpec(path string, s *specs.Spec) (*specs.ParsedSpec, error)
 	Resources() ([]*resources.Resource, error)
 	Create(ctx context.Context, data any) (any, error)
@@ -231,6 +232,16 @@ func (p *BaseProvider) FormatForExport(
 		result = append(result, entities...)
 	}
 	return result, nil
+}
+
+// LoadImportManifest broadcasts import manifest data to all handlers.
+func (p *BaseProvider) LoadImportManifest(manifest *specs.WorkspacesImportMetadata) error {
+	for resourceType, h := range p.handlers {
+		if err := h.LoadImportMetadata(manifest); err != nil {
+			return fmt.Errorf("loading import metadata for handler %s: %w", resourceType, err)
+		}
+	}
+	return nil
 }
 
 // GetHandler returns the handler for a given resource type

--- a/cli/internal/provider/baseprovider.go
+++ b/cli/internal/provider/baseprovider.go
@@ -233,6 +233,20 @@ func (p *BaseProvider) FormatForExport(
 	return result, nil
 }
 
+// LoadImportManifest broadcasts import manifest data to handlers that implement ImportMetadataLoader.
+func (p *BaseProvider) LoadImportManifest(manifest *specs.WorkspacesImportMetadata) error {
+	for resourceType, h := range p.handlers {
+		loader, ok := h.(ImportMetadataLoader)
+		if !ok {
+			continue
+		}
+		if err := loader.LoadImportMetadata(manifest); err != nil {
+			return fmt.Errorf("loading import metadata for handler %s: %w", resourceType, err)
+		}
+	}
+	return nil
+}
+
 // GetHandler returns the handler for a given resource type
 func (p *BaseProvider) GetHandler(resourceType string) (Handler, bool) {
 	handler, ok := p.handlers[resourceType]

--- a/cli/internal/provider/composite.go
+++ b/cli/internal/provider/composite.go
@@ -394,5 +394,19 @@ func (p *CompositeProvider) SemanticRules() []rules.Rule {
 	return allRules
 }
 
+// LoadImportManifest broadcasts manifest data to child providers that implement ImportManifestLoader.
+func (p *CompositeProvider) LoadImportManifest(manifest *specs.WorkspacesImportMetadata) error {
+	for name, prov := range p.Providers {
+		loader, ok := prov.(ImportManifestLoader)
+		if !ok {
+			continue
+		}
+		if err := loader.LoadImportManifest(manifest); err != nil {
+			return fmt.Errorf("loading import manifest into provider %s: %w", name, err)
+		}
+	}
+	return nil
+}
+
 // Compile-time verification that CompositeProvider implements RuleProvider and SpecFactoryProvider
 var _ RuleProvider = (*CompositeProvider)(nil)

--- a/cli/internal/provider/provider.go
+++ b/cli/internal/provider/provider.go
@@ -202,6 +202,18 @@ type RuleProvider interface {
 	SemanticRules() []rules.Rule
 }
 
+// ImportManifestLoader is an optional interface that providers can implement
+// to receive import manifest data for broadcast to their handlers.
+type ImportManifestLoader interface {
+	LoadImportManifest(manifest *specs.WorkspacesImportMetadata) error
+}
+
+// ImportMetadataLoader is an optional interface that handlers can implement
+// to receive import metadata from manifests.
+type ImportMetadataLoader interface {
+	LoadImportMetadata(m *specs.WorkspacesImportMetadata) error
+}
+
 // Provider is the complete interface that all providers must implement.
 // It combines all the individual capabilities required for full resource lifecycle management:
 //

--- a/cli/internal/provider/provider.go
+++ b/cli/internal/provider/provider.go
@@ -202,6 +202,12 @@ type RuleProvider interface {
 	SemanticRules() []rules.Rule
 }
 
+// ImportManifestLoader is an optional interface that providers can implement
+// to receive import manifest data for broadcast to their handlers.
+type ImportManifestLoader interface {
+	LoadImportManifest(manifest *specs.WorkspacesImportMetadata) error
+}
+
 // Provider is the complete interface that all providers must implement.
 // It combines all the individual capabilities required for full resource lifecycle management:
 //

--- a/cli/internal/providers/event-stream/provider.go
+++ b/cli/internal/providers/event-stream/provider.go
@@ -20,6 +20,7 @@ import (
 
 type handler interface {
 	LoadSpec(path string, s *specs.Spec) error
+	LoadImportMetadata(m *specs.WorkspacesImportMetadata) error
 	MigrateSpec(s *specs.Spec) (*specs.Spec, error)
 	ParseSpec(path string, s *specs.Spec) (*specs.ParsedSpec, error)
 	GetResources() ([]*resources.Resource, error)
@@ -233,6 +234,15 @@ func (p *Provider) FormatForExport(
 		result = append(result, entities...)
 	}
 	return result, nil
+}
+
+func (p *Provider) LoadImportManifest(manifest *specs.WorkspacesImportMetadata) error {
+	for _, h := range p.handlers {
+		if err := h.LoadImportMetadata(manifest); err != nil {
+			return fmt.Errorf("loading import metadata: %w", err)
+		}
+	}
+	return nil
 }
 
 func (p *Provider) SyntacticRules() []rules.Rule {

--- a/cli/internal/providers/event-stream/provider.go
+++ b/cli/internal/providers/event-stream/provider.go
@@ -235,6 +235,17 @@ func (p *Provider) FormatForExport(
 	return result, nil
 }
 
+func (p *Provider) LoadImportManifest(manifest *specs.WorkspacesImportMetadata) error {
+	for _, h := range p.handlers {
+		if loader, ok := h.(provider.ImportMetadataLoader); ok {
+			if err := loader.LoadImportMetadata(manifest); err != nil {
+				return fmt.Errorf("loading import metadata: %w", err)
+			}
+		}
+	}
+	return nil
+}
+
 func (p *Provider) SyntacticRules() []rules.Rule {
 	return []rules.Rule{
 		sourceRules.NewSourceSpecSyntaxValidRule(),

--- a/cli/internal/providers/event-stream/source/handler.go
+++ b/cli/internal/providers/event-stream/source/handler.go
@@ -22,18 +22,20 @@ import (
 )
 
 type Handler struct {
-	resources map[string]*sourceResource
-	seenIDs   []string
-	client    esClient.EventStreamStore
-	importDir string
+	resources      map[string]*sourceResource
+	seenIDs        []string
+	client         esClient.EventStreamStore
+	importDir      string
+	importMetadata map[string]*WorkspaceRemoteIDMapping
 }
 
 func NewHandler(client esClient.EventStreamStore, importDir string) *Handler {
 	return &Handler{
-		resources: make(map[string]*sourceResource),
-		seenIDs:   make([]string, 0),
-		client:    client,
-		importDir: filepath.Join(importDir, ImportPath),
+		resources:      make(map[string]*sourceResource),
+		seenIDs:        make([]string, 0),
+		client:         client,
+		importDir:      filepath.Join(importDir, ImportPath),
+		importMetadata: make(map[string]*WorkspaceRemoteIDMapping),
 	}
 }
 
@@ -77,12 +79,11 @@ func (h *Handler) LoadSpec(_ string, s *specs.Spec) error {
 		SourceDefinition: spec.SourceDefinition,
 		Enabled:          enabled,
 		Governance:       &governanceResource{},
-		ImportMetadata:   make(map[string]*WorkspaceRemoteIDMapping),
 	}
 	if err := h.loadTrackingPlanSpec(spec, sourceResource); err != nil {
 		return err
 	}
-	if err := sourceResource.addImportMetadata(s); err != nil {
+	if err := h.addImportMetadata(s); err != nil {
 		return fmt.Errorf("loading import metadata: %w", err)
 	}
 	// When we are at this point, we expect the spec
@@ -211,9 +212,9 @@ func (h *Handler) GetResources() ([]*resources.Resource, error) {
 			resources.WithResourceFileMetadata(ref),
 		}
 		urn := resources.URN(s.LocalID, ResourceType)
-		if importMetadata, ok := s.ImportMetadata[urn]; ok {
+		if meta, ok := h.importMetadata[urn]; ok {
 			opts = []resources.ResourceOpts{
-				resources.WithResourceImportMetadata(importMetadata.RemoteId, importMetadata.WorkspaceId),
+				resources.WithResourceImportMetadata(meta.RemoteId, meta.WorkspaceId),
 			}
 		}
 		r := resources.NewResource(
@@ -667,7 +668,7 @@ func (p *Handler) toImportSpec(
 	}, nil
 }
 
-func (srcResource *sourceResource) addImportMetadata(s *specs.Spec) error {
+func (h *Handler) addImportMetadata(s *specs.Spec) error {
 	metadata, err := s.CommonMetadata()
 	if err != nil {
 		return err
@@ -683,12 +684,30 @@ func (srcResource *sourceResource) addImportMetadata(s *specs.Spec) error {
 				} else {
 					urn = resources.URN(resource.LocalID, ResourceType)
 				}
-				srcResource.ImportMetadata[urn] = &WorkspaceRemoteIDMapping{
+				h.importMetadata[urn] = &WorkspaceRemoteIDMapping{
 					WorkspaceId: workspace.WorkspaceID,
 					RemoteId:    resource.RemoteID,
 				}
 			})
 		})
+	}
+	return nil
+}
+
+// LoadImportMetadata receives import manifest data and populates the handler's
+// central import metadata map. This enables the manifest broadcast to reach
+// event-stream handlers without going through inline metadata.import in specs.
+func (h *Handler) LoadImportMetadata(m *specs.WorkspacesImportMetadata) error {
+	for _, workspace := range m.Workspaces {
+		for _, resource := range workspace.Resources {
+			if resource.URN == "" {
+				continue
+			}
+			h.importMetadata[resource.URN] = &WorkspaceRemoteIDMapping{
+				WorkspaceId: workspace.WorkspaceID,
+				RemoteId:    resource.RemoteID,
+			}
+		}
 	}
 	return nil
 }

--- a/cli/internal/providers/event-stream/source/model.go
+++ b/cli/internal/providers/event-stream/source/model.go
@@ -111,7 +111,6 @@ type sourceResource struct {
 	SourceDefinition string
 	Enabled          bool
 	Governance       *governanceResource
-	ImportMetadata   map[string]*WorkspaceRemoteIDMapping
 }
 
 type WorkspaceRemoteIDMapping struct {

--- a/cli/internal/providers/retl/handler.go
+++ b/cli/internal/providers/retl/handler.go
@@ -24,6 +24,10 @@ type resourceHandler interface {
 	// the parsed spec data. Returns an error if the spec is invalid or cannot be loaded.
 	LoadSpec(path string, s *specs.Spec) error
 
+	// LoadImportMetadata receives import manifest data and populates the handler's
+	// import metadata map for classifying resources as importable during apply.
+	LoadImportMetadata(m *specs.WorkspacesImportMetadata) error
+
 	// GetResources returns all resources managed by this handler.
 	// The returned resources will be added to the resource graph for
 	// dependency resolution and state management.

--- a/cli/internal/providers/retl/provider.go
+++ b/cli/internal/providers/retl/provider.go
@@ -123,6 +123,17 @@ func (p *Provider) MigrateSpec(s *specs.Spec) (*specs.Spec, error) {
 	return s, nil
 }
 
+func (p *Provider) LoadImportManifest(manifest *specs.WorkspacesImportMetadata) error {
+	for _, h := range p.handlers {
+		if loader, ok := h.(provider.ImportMetadataLoader); ok {
+			if err := loader.LoadImportMetadata(manifest); err != nil {
+				return fmt.Errorf("loading import metadata: %w", err)
+			}
+		}
+	}
+	return nil
+}
+
 func (p *Provider) SyntacticRules() []rules.Rule {
 	return []rules.Rule{
 		sqlmodelRules.NewSQLModelSpecSyntaxValidRule(),

--- a/cli/internal/providers/retl/provider.go
+++ b/cli/internal/providers/retl/provider.go
@@ -123,6 +123,15 @@ func (p *Provider) MigrateSpec(s *specs.Spec) (*specs.Spec, error) {
 	return s, nil
 }
 
+func (p *Provider) LoadImportManifest(manifest *specs.WorkspacesImportMetadata) error {
+	for _, h := range p.handlers {
+		if err := h.LoadImportMetadata(manifest); err != nil {
+			return fmt.Errorf("loading import metadata: %w", err)
+		}
+	}
+	return nil
+}
+
 func (p *Provider) SyntacticRules() []rules.Rule {
 	return []rules.Rule{
 		sqlmodelRules.NewSQLModelSpecSyntaxValidRule(),

--- a/cli/internal/providers/retl/sqlmodel/handler.go
+++ b/cli/internal/providers/retl/sqlmodel/handler.go
@@ -23,17 +23,19 @@ const modelSourceTypeFilter = string(retlClient.ModelSourceType)
 
 // Handler implements the resourceHandler interface for SQL Model resources
 type Handler struct {
-	client    retlClient.RETLStore
-	resources map[string]*SQLModelResource
-	importDir string
+	client         retlClient.RETLStore
+	resources      map[string]*SQLModelResource
+	importDir      string
+	importMetadata map[string]*ImportResourceInfo
 }
 
 // NewHandler creates a new SQL Model resource handler
 func NewHandler(client retlClient.RETLStore, importDir string) *Handler {
 	return &Handler{
-		client:    client,
-		resources: make(map[string]*SQLModelResource),
-		importDir: filepath.Join(importDir, ImportPath),
+		client:         client,
+		resources:      make(map[string]*SQLModelResource),
+		importDir:      filepath.Join(importDir, ImportPath),
+		importMetadata: make(map[string]*ImportResourceInfo),
 	}
 }
 
@@ -138,7 +140,7 @@ func (h *Handler) loadImportMetadata(s *specs.Spec) error {
 				} else {
 					urn = resources.URN(resourceMetadata.LocalID, ResourceType)
 				}
-				importMetadata[urn] = &ImportResourceInfo{
+				h.importMetadata[urn] = &ImportResourceInfo{
 					WorkspaceId: workspaceId,
 					RemoteId:    resourceMetadata.RemoteID,
 				}
@@ -146,6 +148,24 @@ func (h *Handler) loadImportMetadata(s *specs.Spec) error {
 		}
 	}
 
+	return nil
+}
+
+// LoadImportMetadata receives import manifest data and populates the handler's
+// central import metadata map. This enables the manifest broadcast to reach
+// retl handlers without going through inline metadata.import in specs.
+func (h *Handler) LoadImportMetadata(m *specs.WorkspacesImportMetadata) error {
+	for _, workspace := range m.Workspaces {
+		for _, resource := range workspace.Resources {
+			if resource.URN == "" {
+				continue
+			}
+			h.importMetadata[resource.URN] = &ImportResourceInfo{
+				WorkspaceId: workspace.WorkspaceID,
+				RemoteId:    resource.RemoteID,
+			}
+		}
+	}
 	return nil
 }
 
@@ -168,7 +188,7 @@ func (h *Handler) GetResources() ([]*resources.Resource, error) {
 
 		var opts []resources.ResourceOpts
 		urn := resources.URN(spec.ID, ResourceType)
-		if importMeta, ok := importMetadata[urn]; ok {
+		if importMeta, ok := h.importMetadata[urn]; ok {
 			opts = []resources.ResourceOpts{
 				resources.WithResourceImportMetadata(importMeta.RemoteId, importMeta.WorkspaceId),
 			}

--- a/cli/internal/providers/retl/sqlmodel/model.go
+++ b/cli/internal/providers/retl/sqlmodel/model.go
@@ -52,8 +52,6 @@ type ImportResourceInfo struct {
 	RemoteId    string
 }
 
-var importMetadata = map[string]*ImportResourceInfo{}
-
 // isValidSourceDefinition checks if the given source definition is valid
 func isValidSourceDefinition(sd SourceDefinition) bool {
 	v, ok := validSourceDefinitions[sd]


### PR DESCRIPTION
## 🔗 Ticket

N/A

---

## Summary

Adds validation support for `kind: import-manifest` YAML specs using a dedicated manifest validation engine, separate from the resource engine. Import manifests decouple import metadata from resource YAML specs by centralising URN-to-remoteID mappings into manifest files. The two-engine approach avoids coupling manifest rules with provider-specific concerns (like ParseSpec dispatch) while keeping each engine's registry clean and self-contained.


```
handleValidation
    ├── parseSpecs(allSpecs)
    ├── separateManifests → resourceSpecs, manifestSpecs
    │
    ├── resourceEngine := buildResourceEngine(providerPatterns)
    ├── manifestEngine := buildManifestEngine()
    │
    ├── resourceEngine.ValidateSyntax(resourceSpecs)
    ├── manifestEngine.ValidateSyntax(manifestSpecs)
    ├── checkInlineManifestConflicts(resourceSpecs, manifestSpecs)  ← standalone
    │   STOP if errors
    │
    ├── loadSpec loop (resourceSpecs only)
    ├── parseManifests + broadcast
    ├── ResourceGraph
    │
    ├── resourceEngine.ValidateSemantic(resourceSpecs, graph)
    └── manifestEngine.ValidateSemantic(manifestSpecs, graph)
```



---

## Changes

- Add `KindImportManifest` constant and `IsImportManifest()` method to `specs.Spec`
- Add dedicated manifest validation engine with its own registry (`manifestRegistry`)
  - `ImportManifestSyntaxRule` — per-file structural checks with strict payload decoding via mapstructure
  - `ImportManifestProjectRule` — cross-file URN uniqueness (ProjectRule)
  - `ImportManifestSemanticRule` — orphaned URN check against resource graph
- Add `checkInlineManifestConflicts` standalone function for cross-engine inline-vs-manifest conflict detection (temporary migration concern)
- Revert resource registry to original logic — no project-level patterns or ParseSpec dispatcher needed
- Add `ImportManifestLoader` optional interface for providers
- Add `LoadImportMetadata` to `Handler` interface (promoted from optional)
- Implement `LoadImportManifest` on `CompositeProvider`, `BaseProvider`, event-stream, and retl providers
- Centralise import metadata in event-stream handler (was per-resource) and retl handler (was package-level global)
- Add `LoadImportMetadata` method to event-stream and retl handlers
- Extract manifest helpers (`separateManifests`, `parseManifests`, `decodeManifestWorkspaces`, `broadcastImportManifest`) to `manifest.go`

---

## Testing

- Unit tests for all three manifest validation rules (syntax, project, semantic)
- Unit tests for manifest helpers: `separateManifests`, `decodeManifestWorkspaces`, `parseManifests`, `broadcastImportManifest`, `checkInlineManifestConflicts`
- All existing tests pass unchanged (47 packages)

---

## Risk / Impact

Medium
- Modifies `handleValidation` flow in `project.go` — now runs two engines instead of one
- Adds `LoadImportMetadata` to `Handler` interface — all handlers using `BaseHandler` already satisfy it
- Centralises import metadata in event-stream and retl handlers — changes internal storage, same external behaviour

---

## Checklist

- [ ] Ticket linked
- [x] Tests added/updated
- [x] No breaking changes (or documented)