### PR TITLE
feat(data-graph): data graph column metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,3 +84,21 @@ To build the Docker image locally:
 ```sh
 make docker-build
 ```
+
+## Data graph column metadata (experimental)
+
+Manage column display name aliases on data graph models via the public API (`/v2/data-graphs/.../column-metadata`). Requires `experimentalFlags.dataGraph: true` in `~/.rudder/config.json`.
+
+```sh
+rudder-cli data-graphs column-metadata list --data-graph-id <dg-id> --model-id <model-id>
+rudder-cli data-graphs column-metadata list --data-graph-id <dg-id> --model-id <model-id> --json
+
+rudder-cli data-graphs column-metadata set <columnName> \
+  --data-graph-id <dg-id> --model-id <model-id> \
+  --display-name "Lifetime Value"
+
+rudder-cli data-graphs column-metadata clear <columnName> \
+  --data-graph-id <dg-id> --model-id <model-id>
+```
+
+Deployment dependency: rudder-api v2 proxy for column-metadata must be deployed (config-backend apigateway routes alone are not sufficient for the CLI).

--- a/api/client/datagraph/client.go
+++ b/api/client/datagraph/client.go
@@ -11,6 +11,7 @@ type DataGraphClient interface {
 	DataGraphStore
 	ModelStore
 	RelationshipStore
+	ColumnMetadataStore
 }
 
 // rudderDataGraphClient implements the DataGraphStore interface

--- a/api/client/datagraph/column_metadata.go
+++ b/api/client/datagraph/column_metadata.go
@@ -1,0 +1,126 @@
+package datagraph
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+)
+
+// ColumnMetadata is display name metadata for a warehouse column on a model.
+type ColumnMetadata struct {
+	ColumnName  string `json:"columnName"`
+	DisplayName string `json:"displayName"`
+	UpdatedAt   string `json:"updatedAt"`
+}
+
+// ColumnMetadataListResponse is the response for listing column metadata.
+type ColumnMetadataListResponse struct {
+	ColumnMetadata []ColumnMetadata `json:"columnMetadata"`
+}
+
+// ColumnMetadataStore is the interface for column metadata operations.
+type ColumnMetadataStore interface {
+	ListColumnMetadata(ctx context.Context, dataGraphID, modelID string) (*ColumnMetadataListResponse, error)
+	UpsertColumnMetadata(ctx context.Context, dataGraphID, modelID, columnName, displayName string) (*ColumnMetadata, error)
+	DeleteColumnMetadata(ctx context.Context, dataGraphID, modelID, columnName string) error
+}
+
+// ListColumnMetadata lists display name aliases for columns on a model.
+func (s *rudderDataGraphClient) ListColumnMetadata(
+	ctx context.Context,
+	dataGraphID, modelID string,
+) (*ColumnMetadataListResponse, error) {
+	if dataGraphID == "" {
+		return nil, fmt.Errorf("data graph ID cannot be empty")
+	}
+	if modelID == "" {
+		return nil, fmt.Errorf("model ID cannot be empty")
+	}
+
+	path := fmt.Sprintf("%s/%s/models/%s/column-metadata", dataGraphsBasePath, dataGraphID, modelID)
+	resp, err := s.client.Do(ctx, "GET", path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("listing column metadata: %w", err)
+	}
+
+	var result ColumnMetadataListResponse
+	if err := json.Unmarshal(resp, &result); err != nil {
+		return nil, fmt.Errorf("unmarshalling response: %w", err)
+	}
+
+	return &result, nil
+}
+
+// UpsertColumnMetadata sets or updates the display name alias for a column.
+func (s *rudderDataGraphClient) UpsertColumnMetadata(
+	ctx context.Context,
+	dataGraphID, modelID, columnName, displayName string,
+) (*ColumnMetadata, error) {
+	if dataGraphID == "" {
+		return nil, fmt.Errorf("data graph ID cannot be empty")
+	}
+	if modelID == "" {
+		return nil, fmt.Errorf("model ID cannot be empty")
+	}
+	if columnName == "" {
+		return nil, fmt.Errorf("column name cannot be empty")
+	}
+
+	path := fmt.Sprintf(
+		"%s/%s/models/%s/column-metadata/%s",
+		dataGraphsBasePath,
+		dataGraphID,
+		modelID,
+		url.PathEscape(columnName),
+	)
+
+	body, err := json.Marshal(map[string]string{"displayName": displayName})
+	if err != nil {
+		return nil, fmt.Errorf("marshalling request body: %w", err)
+	}
+
+	resp, err := s.client.Do(ctx, "PATCH", path, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("upserting column metadata: %w", err)
+	}
+
+	var result ColumnMetadata
+	if err := json.Unmarshal(resp, &result); err != nil {
+		return nil, fmt.Errorf("unmarshalling response: %w", err)
+	}
+
+	return &result, nil
+}
+
+// DeleteColumnMetadata removes the display name alias for a column.
+func (s *rudderDataGraphClient) DeleteColumnMetadata(
+	ctx context.Context,
+	dataGraphID, modelID, columnName string,
+) error {
+	if dataGraphID == "" {
+		return fmt.Errorf("data graph ID cannot be empty")
+	}
+	if modelID == "" {
+		return fmt.Errorf("model ID cannot be empty")
+	}
+	if columnName == "" {
+		return fmt.Errorf("column name cannot be empty")
+	}
+
+	path := fmt.Sprintf(
+		"%s/%s/models/%s/column-metadata/%s",
+		dataGraphsBasePath,
+		dataGraphID,
+		modelID,
+		url.PathEscape(columnName),
+	)
+
+	_, err := s.client.Do(ctx, "DELETE", path, nil)
+	if err != nil {
+		return fmt.Errorf("deleting column metadata: %w", err)
+	}
+
+	return nil
+}

--- a/api/client/datagraph/column_metadata_test.go
+++ b/api/client/datagraph/column_metadata_test.go
@@ -1,0 +1,142 @@
+package datagraph_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/rudderlabs/rudder-iac/api/internal/testutils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListColumnMetadata(t *testing.T) {
+	httpClient := testutils.NewMockHTTPClient(t, testutils.Call{
+		Validate: func(req *http.Request) bool {
+			return testutils.ValidateRequest(
+				t,
+				req,
+				"GET",
+				"https://api.rudderstack.com/v2/data-graphs/dg-123/models/m-456/column-metadata",
+				"",
+			)
+		},
+		ResponseStatus: 200,
+		ResponseBody: `{
+			"columnMetadata": [
+				{
+					"columnName": "ltv",
+					"displayName": "Lifetime Value",
+					"updatedAt": "2024-01-15T12:00:00Z"
+				}
+			]
+		}`,
+	})
+
+	store := newTestStore(t, httpClient)
+
+	result, err := store.ListColumnMetadata(context.Background(), "dg-123", "m-456")
+	require.NoError(t, err)
+	require.Len(t, result.ColumnMetadata, 1)
+	assert.Equal(t, "ltv", result.ColumnMetadata[0].ColumnName)
+	assert.Equal(t, "Lifetime Value", result.ColumnMetadata[0].DisplayName)
+
+	httpClient.AssertNumberOfCalls()
+}
+
+func TestUpsertColumnMetadata(t *testing.T) {
+	httpClient := testutils.NewMockHTTPClient(t, testutils.Call{
+		Validate: func(req *http.Request) bool {
+			expected := `{"displayName":"Lifetime Value"}`
+			return testutils.ValidateRequest(
+				t,
+				req,
+				"PATCH",
+				"https://api.rudderstack.com/v2/data-graphs/dg-123/models/m-456/column-metadata/ltv",
+				expected,
+			)
+		},
+		ResponseStatus: 200,
+		ResponseBody: `{
+			"columnName": "ltv",
+			"displayName": "Lifetime Value",
+			"updatedAt": "2024-01-15T12:00:00Z"
+		}`,
+	})
+
+	store := newTestStore(t, httpClient)
+
+	result, err := store.UpsertColumnMetadata(
+		context.Background(),
+		"dg-123",
+		"m-456",
+		"ltv",
+		"Lifetime Value",
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "ltv", result.ColumnName)
+	assert.Equal(t, "Lifetime Value", result.DisplayName)
+
+	httpClient.AssertNumberOfCalls()
+}
+
+func TestUpsertColumnMetadata_PathEscape(t *testing.T) {
+	httpClient := testutils.NewMockHTTPClient(t, testutils.Call{
+		Validate: func(req *http.Request) bool {
+			return testutils.ValidateRequest(
+				t,
+				req,
+				"PATCH",
+				"https://api.rudderstack.com/v2/data-graphs/dg-123/models/m-456/column-metadata/col%2Fname",
+				`{"displayName":"Alias"}`,
+			)
+		},
+		ResponseStatus: 200,
+		ResponseBody: `{
+			"columnName": "col/name",
+			"displayName": "Alias",
+			"updatedAt": "2024-01-15T12:00:00Z"
+		}`,
+	})
+
+	store := newTestStore(t, httpClient)
+
+	_, err := store.UpsertColumnMetadata(context.Background(), "dg-123", "m-456", "col/name", "Alias")
+	require.NoError(t, err)
+
+	httpClient.AssertNumberOfCalls()
+}
+
+func TestDeleteColumnMetadata(t *testing.T) {
+	httpClient := testutils.NewMockHTTPClient(t, testutils.Call{
+		Validate: func(req *http.Request) bool {
+			return testutils.ValidateRequest(
+				t,
+				req,
+				"DELETE",
+				"https://api.rudderstack.com/v2/data-graphs/dg-123/models/m-456/column-metadata/ltv",
+				"",
+			)
+		},
+		ResponseStatus: 204,
+	})
+
+	store := newTestStore(t, httpClient)
+
+	err := store.DeleteColumnMetadata(context.Background(), "dg-123", "m-456", "ltv")
+	require.NoError(t, err)
+
+	httpClient.AssertNumberOfCalls()
+}
+
+func TestListColumnMetadata_Validation(t *testing.T) {
+	store := newTestStore(t, testutils.NewMockHTTPClient(t))
+
+	_, err := store.ListColumnMetadata(context.Background(), "", "m-456")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "data graph ID")
+
+	_, err = store.ListColumnMetadata(context.Background(), "dg-123", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "model ID")
+}

--- a/cli/internal/cmd/datagraph/columnmetadata/clear.go
+++ b/cli/internal/cmd/datagraph/columnmetadata/clear.go
@@ -1,0 +1,56 @@
+package columnmetadata
+
+import (
+	"fmt"
+
+	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/rudderlabs/rudder-iac/cli/internal/app"
+	"github.com/rudderlabs/rudder-iac/cli/internal/cmd/telemetry"
+	"github.com/spf13/cobra"
+)
+
+func newCmdClear() *cobra.Command {
+	var (
+		dataGraphID string
+		modelID     string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "clear <columnName>",
+		Short: "Remove a column display name alias",
+		Args:  cobra.ExactArgs(1),
+		Example: heredoc.Doc(`
+			$ rudder-cli data-graphs column-metadata clear ltv --data-graph-id dg-1 --model-id m-1
+		`),
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return requireDataGraphFlag()
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var err error
+			defer func() {
+				telemetry.TrackCommand("data-graphs column-metadata clear", err)
+			}()
+
+			columnName := args[0]
+
+			deps, err := app.NewDeps()
+			if err != nil {
+				return fmt.Errorf("initialising dependencies: %w", err)
+			}
+
+			dgClient := newDataGraphClient(deps.Client())
+			if err := dgClient.DeleteColumnMetadata(cmd.Context(), dataGraphID, modelID, columnName); err != nil {
+				return fmt.Errorf("clearing column metadata: %w", err)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&dataGraphID, "data-graph-id", "", "Data graph ID")
+	cmd.Flags().StringVar(&modelID, "model-id", "", "Model ID")
+	_ = cmd.MarkFlagRequired("data-graph-id")
+	_ = cmd.MarkFlagRequired("model-id")
+
+	return cmd
+}

--- a/cli/internal/cmd/datagraph/columnmetadata/columnmetadata.go
+++ b/cli/internal/cmd/datagraph/columnmetadata/columnmetadata.go
@@ -1,0 +1,19 @@
+package columnmetadata
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func NewCmdColumnMetadata() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "column-metadata",
+		Short: "Manage column display name aliases on data graph models",
+		Long:  "List, set, and clear display name aliases for warehouse columns on a data graph model.",
+	}
+
+	cmd.AddCommand(newCmdList())
+	cmd.AddCommand(newCmdSet())
+	cmd.AddCommand(newCmdClear())
+
+	return cmd
+}

--- a/cli/internal/cmd/datagraph/columnmetadata/common.go
+++ b/cli/internal/cmd/datagraph/columnmetadata/common.go
@@ -1,0 +1,21 @@
+package columnmetadata
+
+import (
+	"fmt"
+
+	"github.com/rudderlabs/rudder-iac/api/client"
+	dgClient "github.com/rudderlabs/rudder-iac/api/client/datagraph"
+	"github.com/rudderlabs/rudder-iac/cli/internal/config"
+)
+
+func requireDataGraphFlag() error {
+	cfg := config.GetConfig()
+	if !cfg.ExperimentalFlags.DataGraph {
+		return fmt.Errorf("data-graphs commands require the experimental flag 'dataGraph' to be enabled in your configuration")
+	}
+	return nil
+}
+
+func newDataGraphClient(c *client.Client) dgClient.DataGraphClient {
+	return dgClient.NewRudderDataGraphClient(c)
+}

--- a/cli/internal/cmd/datagraph/columnmetadata/list.go
+++ b/cli/internal/cmd/datagraph/columnmetadata/list.go
@@ -1,0 +1,89 @@
+package columnmetadata
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+
+	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/charmbracelet/bubbles/table"
+	"github.com/rudderlabs/rudder-iac/cli/internal/app"
+	"github.com/rudderlabs/rudder-iac/cli/internal/cmd/telemetry"
+	"github.com/rudderlabs/rudder-iac/cli/internal/ui"
+	"github.com/spf13/cobra"
+)
+
+func newCmdList() *cobra.Command {
+	var (
+		dataGraphID string
+		modelID     string
+		jsonOutput  bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List column display name aliases for a model",
+		Example: heredoc.Doc(`
+			$ rudder-cli data-graphs column-metadata list --data-graph-id dg-1 --model-id m-1
+			$ rudder-cli data-graphs column-metadata list --data-graph-id dg-1 --model-id m-1 --json
+		`),
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return requireDataGraphFlag()
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var err error
+			defer func() {
+				telemetry.TrackCommand("data-graphs column-metadata list", err, []telemetry.KV{
+					{K: "json", V: jsonOutput},
+				}...)
+			}()
+
+			deps, err := app.NewDeps()
+			if err != nil {
+				return fmt.Errorf("initialising dependencies: %w", err)
+			}
+
+			dgClient := newDataGraphClient(deps.Client())
+			result, err := dgClient.ListColumnMetadata(cmd.Context(), dataGraphID, modelID)
+			if err != nil {
+				return fmt.Errorf("listing column metadata: %w", err)
+			}
+
+			if jsonOutput {
+				enc := json.NewEncoder(cmd.OutOrStdout())
+				enc.SetIndent("", "  ")
+				return enc.Encode(result)
+			}
+
+			if len(result.ColumnMetadata) == 0 {
+				fmt.Fprintln(cmd.OutOrStdout(), "No column metadata found.")
+				return nil
+			}
+
+			rows := make([]table.Row, len(result.ColumnMetadata))
+			items := result.ColumnMetadata
+			sort.Slice(items, func(i, j int) bool {
+				return items[i].ColumnName < items[j].ColumnName
+			})
+			for i, item := range items {
+				rows[i] = table.Row{item.ColumnName, item.DisplayName, item.UpdatedAt}
+			}
+
+			ui.PrintTable([]table.Column{
+				{Title: "Column", Width: 30},
+				{Title: "Display Name", Width: 40},
+				{Title: "Updated At", Width: 30},
+			}, rows)
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&dataGraphID, "data-graph-id", "", "Data graph ID")
+	cmd.Flags().StringVar(&modelID, "model-id", "", "Model ID")
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output as JSON")
+	_ = cmd.MarkFlagRequired("data-graph-id")
+	_ = cmd.MarkFlagRequired("model-id")
+
+	return cmd
+}

--- a/cli/internal/cmd/datagraph/columnmetadata/set.go
+++ b/cli/internal/cmd/datagraph/columnmetadata/set.go
@@ -1,0 +1,88 @@
+package columnmetadata
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/rudderlabs/rudder-iac/cli/internal/app"
+	"github.com/rudderlabs/rudder-iac/cli/internal/cmd/telemetry"
+	"github.com/spf13/cobra"
+)
+
+func newCmdSet() *cobra.Command {
+	var (
+		dataGraphID string
+		modelID     string
+		displayName string
+		jsonOutput  bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "set <columnName>",
+		Short: "Set or update a column display name alias",
+		Args:  cobra.ExactArgs(1),
+		Example: heredoc.Doc(`
+			$ rudder-cli data-graphs column-metadata set ltv --data-graph-id dg-1 --model-id m-1 --display-name "Lifetime Value"
+		`),
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return requireDataGraphFlag()
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var err error
+			defer func() {
+				telemetry.TrackCommand("data-graphs column-metadata set", err, []telemetry.KV{
+					{K: "json", V: jsonOutput},
+				}...)
+			}()
+
+			columnName := args[0]
+			trimmedDisplayName := strings.TrimSpace(displayName)
+			if trimmedDisplayName == "" {
+				return fmt.Errorf("display name cannot be empty")
+			}
+
+			deps, err := app.NewDeps()
+			if err != nil {
+				return fmt.Errorf("initialising dependencies: %w", err)
+			}
+
+			dgClient := newDataGraphClient(deps.Client())
+			result, err := dgClient.UpsertColumnMetadata(
+				cmd.Context(),
+				dataGraphID,
+				modelID,
+				columnName,
+				trimmedDisplayName,
+			)
+			if err != nil {
+				return fmt.Errorf("setting column metadata: %w", err)
+			}
+
+			if jsonOutput {
+				enc := json.NewEncoder(cmd.OutOrStdout())
+				enc.SetIndent("", "  ")
+				return enc.Encode(result)
+			}
+
+			fmt.Fprintf(
+				cmd.OutOrStdout(),
+				"Set display name for column %q to %q\n",
+				result.ColumnName,
+				result.DisplayName,
+			)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&dataGraphID, "data-graph-id", "", "Data graph ID")
+	cmd.Flags().StringVar(&modelID, "model-id", "", "Model ID")
+	cmd.Flags().StringVar(&displayName, "display-name", "", "Display name alias for the column")
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output the updated metadata as JSON")
+	_ = cmd.MarkFlagRequired("data-graph-id")
+	_ = cmd.MarkFlagRequired("model-id")
+	_ = cmd.MarkFlagRequired("display-name")
+
+	return cmd
+}

--- a/cli/internal/cmd/datagraph/datagraph.go
+++ b/cli/internal/cmd/datagraph/datagraph.go
@@ -4,6 +4,7 @@ import (
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/spf13/cobra"
 
+	columnmetadataCmd "github.com/rudderlabs/rudder-iac/cli/internal/cmd/datagraph/columnmetadata"
 	validateCmd "github.com/rudderlabs/rudder-iac/cli/internal/cmd/datagraph/validate"
 )
 
@@ -17,10 +18,13 @@ func NewCmdDataGraph() *cobra.Command {
 			$ rudder-cli data-graphs validate --all
 			$ rudder-cli data-graphs validate --modified
 			$ rudder-cli data-graphs validate model my-model-id
+			$ rudder-cli data-graphs column-metadata list --data-graph-id dg-1 --model-id m-1
+			$ rudder-cli data-graphs column-metadata set ltv --data-graph-id dg-1 --model-id m-1 --display-name "Lifetime Value"
 		`),
 	}
 
 	cmd.AddCommand(validateCmd.NewCmdValidate())
+	cmd.AddCommand(columnmetadataCmd.NewCmdColumnMetadata())
 
 	return cmd
 }

--- a/cli/internal/providers/datagraph/testutils/mocks.go
+++ b/cli/internal/providers/datagraph/testutils/mocks.go
@@ -203,6 +203,18 @@ func (m *MockDataGraphClient) ValidateRelationship(ctx context.Context, req *dgC
 	return &dgClient.ValidationReport{}, nil
 }
 
+func (m *MockDataGraphClient) ListColumnMetadata(ctx context.Context, dataGraphID, modelID string) (*dgClient.ColumnMetadataListResponse, error) {
+	return &dgClient.ColumnMetadataListResponse{}, nil
+}
+
+func (m *MockDataGraphClient) UpsertColumnMetadata(ctx context.Context, dataGraphID, modelID, columnName, displayName string) (*dgClient.ColumnMetadata, error) {
+	return &dgClient.ColumnMetadata{}, nil
+}
+
+func (m *MockDataGraphClient) DeleteColumnMetadata(ctx context.Context, dataGraphID, modelID, columnName string) error {
+	return nil
+}
+
 // MockURNResolver implements handler.URNResolver for testing
 type MockURNResolver struct {
 	urnByID map[string]map[string]string // map[resourceType]map[remoteID]urn


### PR DESCRIPTION
Scanned-by: gitleaks 8.30.1

## 🔗 Ticket

https://linear.app/rudderstack/issue/PRO-5711/cli-column-alias

---

## Summary

Adds imperative rudder-cli data-graphs column-metadata commands (list / set / clear) for managing column display name aliases on data graph models, following a new `/v2/data-graphs/.../column-metadata` proxy in rudder-api, then a Go client and CLI on top of the existing` /v2/data-graphs` pattern (no apigateway paths from the CLI, no IaC provider or apply cycle).

---

## Changes

 - rudder-api: Add `/v2/data-graphs/:dataGraphId/models/:modelId/column-metadata` proxy (`GET` list, `PATCH` upsert, `DELETE` clear) to config-backend apigateway, with structured 409/400 forwarding on `PATCH`.
 - rudder-iac client: Add ColumnMetadataStore on `/v2/data-graphs` (ListColumnMetadata, UpsertColumnMetadata, DeleteColumnMetadata) with path encoding and 204-safe delete.
 - rudder-cli: Add data-graphs column-metadata list|set|clear (experimental dataGraph gate, set trims display name); document usage in `README.md`.

---

## Testing

How was this tested?

- Unit tests

- rudder-api: `npx nx test rudder-api --testPathPattern=column-metadata` — service tests (apigateway URLs, auth, error mapping including 409 code / conflictingColumnName) and router tests (GET/PATCH/DELETE, structured 409/400 on PATCH).
- rudder-iac: `go test ./api/client/datagraph/... `— column_metadata_test.go covers list/upsert/delete paths, PathEscape for column names, and empty-ID validation. go build ./cli/cmd/rudder-cli/... verified CLI compiles.
- CLI commands: No dedicated cmd tests (aligned with retl-sources preview; client tests cover the HTTP contract).

---

## Risk / Impact

Low / Medium / High
Notes (if any):

---

## Checklist

- [ ] Ticket linked
- [ ] Tests added/updated
- [ ] No breaking changes (or documented)
