### PR TITLE
feat: add varsubst package foundation

### DIFF
--- a/cli/internal/varsubst/errors.go
+++ b/cli/internal/varsubst/errors.go
@@ -1,0 +1,32 @@
+package varsubst
+
+import (
+	"errors"
+	"fmt"
+)
+
+var (
+	ErrUndefinedVariable  = errors.New("undefined variable")
+	ErrInvalidVarSyntax   = errors.New("invalid variable syntax")
+	ErrVarFileNotFound    = errors.New("variable file not found")
+	ErrVarFileParseFailed = errors.New("variable file parse failed")
+)
+
+type SubstitutionError struct {
+	Name     string
+	Line     int
+	Column   int
+	LineText string
+	Err      error
+}
+
+func (e *SubstitutionError) Error() string {
+	if e.Name != "" {
+		return fmt.Sprintf("line %d, column %d: %s: %s", e.Line, e.Column, e.Err, e.Name)
+	}
+	return fmt.Sprintf("line %d, column %d: %s", e.Line, e.Column, e.Err)
+}
+
+func (e *SubstitutionError) Unwrap() error {
+	return e.Err
+}

--- a/cli/internal/varsubst/errors_test.go
+++ b/cli/internal/varsubst/errors_test.go
@@ -1,0 +1,55 @@
+package varsubst
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSubstitutionError_Error(t *testing.T) {
+	tests := []struct {
+		name    string
+		err     *SubstitutionError
+		wantMsg string
+	}{
+		{
+			name: "with variable name",
+			err: &SubstitutionError{
+				Name:     "DB_PASSWORD",
+				Line:     5,
+				Column:   12,
+				LineText: "  password: {{ .DB_PASSWORD }}",
+				Err:      ErrUndefinedVariable,
+			},
+			wantMsg: "line 5, column 12: undefined variable: DB_PASSWORD",
+		},
+		{
+			name: "without variable name",
+			err: &SubstitutionError{
+				Line:     3,
+				Column:   8,
+				LineText: "  host: {{ .123BAD }}",
+				Err:      ErrInvalidVarSyntax,
+			},
+			wantMsg: "line 3, column 8: invalid variable syntax",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.wantMsg, tt.err.Error())
+		})
+	}
+}
+
+func TestSubstitutionError_Unwrap(t *testing.T) {
+	err := &SubstitutionError{
+		Name: "HOST",
+		Line: 1,
+		Err:  ErrUndefinedVariable,
+	}
+
+	assert.True(t, errors.Is(err, ErrUndefinedVariable))
+	assert.False(t, errors.Is(err, ErrInvalidVarSyntax))
+}

--- a/cli/internal/varsubst/resolver/env_resolver.go
+++ b/cli/internal/varsubst/resolver/env_resolver.go
@@ -23,6 +23,9 @@ func newEnvResolverFromEnviron(environ []string) Resolver {
 			continue
 		}
 		if strings.HasPrefix(key, defaultEnvPrefix) {
+			// Last-write-wins: if the same RUDDER_-prefixed key appears more than
+			// once in environ, the later occurrence silently overrides the earlier
+			// one. This mirrors the OS behaviour on lookup.
 			vars[strings.TrimPrefix(key, defaultEnvPrefix)] = value
 		}
 	}

--- a/cli/internal/varsubst/resolver/env_resolver.go
+++ b/cli/internal/varsubst/resolver/env_resolver.go
@@ -1,0 +1,36 @@
+package resolver
+
+import (
+	"os"
+	"strings"
+)
+
+const defaultEnvPrefix = "RUDDER_"
+
+type envResolver struct {
+	vars map[string]string
+}
+
+func NewEnvResolver() Resolver {
+	return newEnvResolverFromEnviron(os.Environ())
+}
+
+func newEnvResolverFromEnviron(environ []string) Resolver {
+	vars := make(map[string]string)
+	for _, env := range environ {
+		key, value, ok := strings.Cut(env, "=")
+		if !ok {
+			continue
+		}
+		if strings.HasPrefix(key, defaultEnvPrefix) {
+			vars[strings.TrimPrefix(key, defaultEnvPrefix)] = value
+		}
+	}
+
+	return &envResolver{vars: vars}
+}
+
+func (r *envResolver) Resolve(name string) (string, bool) {
+	value, found := r.vars[name]
+	return value, found
+}

--- a/cli/internal/varsubst/resolver/env_resolver_test.go
+++ b/cli/internal/varsubst/resolver/env_resolver_test.go
@@ -89,13 +89,39 @@ func TestNewEnvResolverFromEnviron(t *testing.T) {
 	}
 }
 
-func TestNewEnvResolver_LoadsRudderPrefixedVariables(t *testing.T) {
-	t.Setenv("RUDDER_ABC", "hello")
-	t.Setenv("ABC", "ignored")
+func TestNewEnvResolver(t *testing.T) {
+	t.Setenv("RUDDER_DB_HOST", "db.example.com")
+	t.Setenv("RUDDER_DB_PORT", "5432")
+	t.Setenv("RUDDER_EMPTY", "")
+	t.Setenv("DB_HOST", "ignored")
 
 	r := NewEnvResolver()
-	value, found := r.Resolve("ABC")
 
-	assert.Equal(t, "hello", value)
-	assert.True(t, found)
+	t.Run("strips prefix and loads value", func(t *testing.T) {
+		value, found := r.Resolve("DB_HOST")
+		assert.Equal(t, "db.example.com", value)
+		assert.True(t, found)
+	})
+
+	t.Run("loads multiple prefixed vars", func(t *testing.T) {
+		value, found := r.Resolve("DB_PORT")
+		assert.Equal(t, "5432", value)
+		assert.True(t, found)
+	})
+
+	t.Run("ignores unprefixed vars", func(t *testing.T) {
+		_, found := r.Resolve("ignored")
+		assert.False(t, found)
+	})
+
+	t.Run("missing key returns not found", func(t *testing.T) {
+		_, found := r.Resolve("MISSING")
+		assert.False(t, found)
+	})
+
+	t.Run("empty value is preserved", func(t *testing.T) {
+		value, found := r.Resolve("EMPTY")
+		assert.Equal(t, "", value)
+		assert.True(t, found)
+	})
 }

--- a/cli/internal/varsubst/resolver/env_resolver_test.go
+++ b/cli/internal/varsubst/resolver/env_resolver_test.go
@@ -1,0 +1,101 @@
+package resolver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewEnvResolverFromEnviron(t *testing.T) {
+	tests := []struct {
+		name      string
+		environ   []string
+		lookup    string
+		wantValue string
+		wantFound bool
+	}{
+		{
+			name: "strips prefix from matching env vars",
+			environ: []string{
+				"RUDDER_DB_HOST=db.example.com",
+				"RUDDER_DB_PORT=5432",
+			},
+			lookup:    "DB_PORT",
+			wantValue: "5432",
+			wantFound: true,
+		},
+		{
+			name: "ignores env vars without matching prefix",
+			environ: []string{
+				"RUDDER_DB_HOST=db.example.com",
+				"HOME=/home/user",
+				"PATH=/usr/bin",
+			},
+			lookup:    "HOME",
+			wantValue: "",
+			wantFound: false,
+		},
+		{
+			name: "case sensitive prefix matching",
+			environ: []string{
+				"RUDDER_DB_HOST=upper",
+				"rudder_db_host=lower",
+			},
+			lookup:    "db_host",
+			wantValue: "",
+			wantFound: false,
+		},
+		{
+			name: "empty value is preserved",
+			environ: []string{
+				"RUDDER_HOST=",
+			},
+			lookup:    "HOST",
+			wantValue: "",
+			wantFound: true,
+		},
+		{
+			name:      "no matching env vars yields empty map",
+			environ:   []string{"OTHER_VAR=value"},
+			lookup:    "OTHER_VAR",
+			wantValue: "",
+			wantFound: false,
+		},
+		{
+			name: "value containing equals sign",
+			environ: []string{
+				"RUDDER_CONN=host=db;port=5432",
+			},
+			lookup:    "CONN",
+			wantValue: "host=db;port=5432",
+			wantFound: true,
+		},
+		{
+			name:      "entry without equals sign is skipped",
+			environ:   []string{"RUDDER_BROKEN"},
+			lookup:    "BROKEN",
+			wantValue: "",
+			wantFound: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := newEnvResolverFromEnviron(tt.environ)
+			value, found := r.Resolve(tt.lookup)
+			assert.Equal(t, tt.wantValue, value)
+			assert.Equal(t, tt.wantFound, found)
+		})
+	}
+}
+
+func TestNewEnvResolver_LoadsRudderPrefixedVariables(t *testing.T) {
+	t.Setenv("RUDDER_ABC", "hello")
+	t.Setenv("ABC", "ignored")
+
+	r := NewEnvResolver()
+	value, found := r.Resolve("ABC")
+
+	assert.Equal(t, "hello", value)
+	assert.True(t, found)
+}

--- a/cli/internal/varsubst/resolver/resolver.go
+++ b/cli/internal/varsubst/resolver/resolver.go
@@ -1,0 +1,8 @@
+package resolver
+
+// Resolver resolves a variable name to its string value.
+// The two-return-value pattern lets callers distinguish "resolved to empty string"
+// from "not found".
+type Resolver interface {
+	Resolve(name string) (value string, found bool)
+}


### PR DESCRIPTION
## 🔗 Ticket

Resolves DEX-358

---

## Summary

Create the varsubst package foundation: the Resolver interface that all variable sources implement, the shared error/sentinel types, and the first concrete resolver — EnvResolver — which resolves variables from environment variables with a configurable prefix.

---

## Changes

### Description

This ticket establishes the core abstractions for the variable substitution system and delivers the highest-priority resolver (environment variables).

### Resolver Interface

Define a `Resolver` interface that resolves a variable name to its string value:

```go
type Resolver interface {
    Resolve(name string) (value string, found bool)
}
```

The two-return-value pattern (`value` + `found bool`) lets callers distinguish between `resolved to empty string` and `not found` — important because an empty env var is a valid, intentional value.

### Error Types

Define the sentinel errors and the structured `SubstitutionError` type that will be used across the package:

```go
type SubstitutionError struct {
    Name     string   // variable name, e.g. "DB_PASSWORD"
    Line     int      // 1-indexed line number
    Column   int      // 1-indexed column number
    LineText string   // full text of the line for display
    Err      error    // underlying error (one of the sentinels)
}
```

Sentinel errors:

- `ErrUndefinedVariable` — `{{ .VAR }}` with no default, not found in any resolver
- `ErrInvalidVarSyntax` — malformed token: `{{ .123BAD }}`, unclosed `{{ .FOO`
- `ErrVarFileNotFound` — `--var-file` path does not exist
- `ErrVarFileParseFailed` — var file has invalid YAML or nested structures

### EnvResolver

Implements `Resolver`. At construction time, eagerly loads all environment variables matching a given prefix (default: `RUDDER_`), strips the prefix, and stores them in an in-memory map. `Resolve` is a simple map lookup.

Example: `RUDDER_DB_HOST=db.example.com` → stored as `DB_HOST` → `{{ .DB_HOST }}` resolves to `"db.example.com"`

```go
type EnvResolver struct {
    vars   map[string]string
    prefix string
}

func NewEnvResolver(prefix string) *EnvResolver
func (r *EnvResolver) Resolve(name string) (string, bool)
```

### Acceptance Criteria

- `varsubst` package exists with `resolver.go`, `errors.go`, `env_resolver.go`
- `Resolver` interface is defined
- All sentinel errors and `SubstitutionError` struct are defined
- `EnvResolver` loads env vars with prefix stripping
- Unit tests pass with full coverage of `EnvResolver`

---

## Testing

Table-driven unit tests for `EnvResolver` covering:

- Prefix stripping works correctly
- Case sensitivity (`RUDDER_db_host` vs `RUDDER_DB_HOST`)
- Empty value env var (`RUDDER_HOST=""` → resolves to `""`, `found=true`)
- Missing variable (`returns "", found=false`)
- Env vars without the matching prefix are ignored
- Multiple env vars loaded correctly

---

## Risk / Impact

Low

Notes (if any):

- This PR only adds the varsubst package foundation and corresponding unit tests.

---

## Checklist

- [x] Ticket linked
- [x] Tests added/updated
- [x] No breaking changes (or documented)
