### PR TITLE
feat: add FileResolver for varsubst package

### DIFF
--- a/cli/internal/varsubst/errors.go
+++ b/cli/internal/varsubst/errors.go
@@ -6,10 +6,8 @@ import (
 )
 
 var (
-	ErrUndefinedVariable  = errors.New("undefined variable")
-	ErrInvalidVarSyntax   = errors.New("invalid variable syntax")
-	ErrVarFileNotFound    = errors.New("variable file not found")
-	ErrVarFileParseFailed = errors.New("variable file parse failed")
+	ErrUndefinedVariable = errors.New("undefined variable")
+	ErrInvalidVarSyntax  = errors.New("invalid variable syntax")
 )
 
 type SubstitutionError struct {

--- a/cli/internal/varsubst/resolver/env_resolver.go
+++ b/cli/internal/varsubst/resolver/env_resolver.go
@@ -11,11 +11,11 @@ type envResolver struct {
 	vars map[string]string
 }
 
-func NewEnvResolver() Resolver {
+func NewEnvResolver() (Resolver, error) {
 	return newEnvResolverFromEnviron(os.Environ())
 }
 
-func newEnvResolverFromEnviron(environ []string) Resolver {
+func newEnvResolverFromEnviron(environ []string) (Resolver, error) {
 	vars := make(map[string]string)
 	for _, env := range environ {
 		key, value, ok := strings.Cut(env, "=")
@@ -30,7 +30,7 @@ func newEnvResolverFromEnviron(environ []string) Resolver {
 		}
 	}
 
-	return &envResolver{vars: vars}
+	return &envResolver{vars: vars}, nil
 }
 
 func (r *envResolver) Resolve(name string) (string, bool) {

--- a/cli/internal/varsubst/resolver/env_resolver_test.go
+++ b/cli/internal/varsubst/resolver/env_resolver_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewEnvResolverFromEnviron(t *testing.T) {
@@ -81,7 +82,8 @@ func TestNewEnvResolverFromEnviron(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			r := newEnvResolverFromEnviron(tt.environ)
+			r, err := newEnvResolverFromEnviron(tt.environ)
+			require.NoError(t, err)
 			value, found := r.Resolve(tt.lookup)
 			assert.Equal(t, tt.wantValue, value)
 			assert.Equal(t, tt.wantFound, found)
@@ -95,7 +97,8 @@ func TestNewEnvResolver(t *testing.T) {
 	t.Setenv("RUDDER_EMPTY", "")
 	t.Setenv("DB_HOST", "ignored")
 
-	r := NewEnvResolver()
+	r, err := NewEnvResolver()
+	require.NoError(t, err)
 
 	t.Run("strips prefix and loads value", func(t *testing.T) {
 		value, found := r.Resolve("DB_HOST")

--- a/cli/internal/varsubst/resolver/errors.go
+++ b/cli/internal/varsubst/resolver/errors.go
@@ -3,12 +3,11 @@ package resolver
 import "errors"
 
 var (
-	// ErrNotFound is returned when a backing source for a resolver is missing
-	// (e.g. the variable file does not exist on disk).
-	ErrNotFound = errors.New("not found")
+	// ErrVarFileNotFound is returned when the variable file does not exist on disk.
+	ErrVarFileNotFound = errors.New("variable file not found")
 
-	// ErrIllegalArgument is returned when a resolver receives input it cannot
-	// process — for example, a variable file that fails to parse or whose
-	// contents do not match the expected scalar shape.
-	ErrIllegalArgument = errors.New("illegal argument")
+	// ErrVarFileParseFailed is returned when the variable file cannot be parsed
+	// as a flat YAML map of scalar values (e.g. invalid YAML, nested map/array,
+	// or a nil value).
+	ErrVarFileParseFailed = errors.New("variable file parse failed")
 )

--- a/cli/internal/varsubst/resolver/errors.go
+++ b/cli/internal/varsubst/resolver/errors.go
@@ -1,0 +1,14 @@
+package resolver
+
+import "errors"
+
+var (
+	// ErrNotFound is returned when a backing source for a resolver is missing
+	// (e.g. the variable file does not exist on disk).
+	ErrNotFound = errors.New("not found")
+
+	// ErrIllegalArgument is returned when a resolver receives input it cannot
+	// process — for example, a variable file that fails to parse or whose
+	// contents do not match the expected scalar shape.
+	ErrIllegalArgument = errors.New("illegal argument")
+)

--- a/cli/internal/varsubst/resolver/file_resolver.go
+++ b/cli/internal/varsubst/resolver/file_resolver.go
@@ -1,0 +1,53 @@
+package resolver
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/rudderlabs/rudder-iac/cli/internal/varsubst"
+	"gopkg.in/yaml.v3"
+)
+
+type fileResolver struct {
+	vars map[string]string
+}
+
+func NewFileResolver(path string) (Resolver, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("%w: %s", varsubst.ErrVarFileNotFound, path)
+		}
+		return nil, fmt.Errorf("reading variable file %s: %w", path, err)
+	}
+
+	var raw map[string]any
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		return nil, fmt.Errorf("%w: %s", varsubst.ErrVarFileParseFailed, path)
+	}
+
+	vars := make(map[string]string, len(raw))
+	for key, val := range raw {
+		switch v := val.(type) {
+		case string:
+			vars[key] = v
+		case int:
+			vars[key] = fmt.Sprint(v)
+		case float64:
+			vars[key] = fmt.Sprint(v)
+		case bool:
+			vars[key] = fmt.Sprint(v)
+		case nil:
+			vars[key] = ""
+		default:
+			return nil, fmt.Errorf("%w: key %q has non-scalar value in %s", varsubst.ErrVarFileParseFailed, key, path)
+		}
+	}
+
+	return &fileResolver{vars: vars}, nil
+}
+
+func (r *fileResolver) Resolve(name string) (string, bool) {
+	value, found := r.vars[name]
+	return value, found
+}

--- a/cli/internal/varsubst/resolver/file_resolver.go
+++ b/cli/internal/varsubst/resolver/file_resolver.go
@@ -14,10 +14,10 @@ type fileResolver struct {
 // NewFileResolver loads variables from a flat YAML file whose top-level keys
 // map to scalar values (string, int, float, bool).
 //
-// Nil values are rejected. A YAML key with no value (`KEY:`) or an explicit
-// null (`KEY: null`) returns ErrVarFileParseFailed because the intent is
-// ambiguous. To represent an empty string, use explicit quotes: `KEY: ""` or
-// `KEY: ''`.
+// Null/empty values are rejected. A YAML key with no value (`KEY:`) or an
+// explicit null (`KEY: null`) returns ErrVarFileParseFailed — setting null
+// values is not supported. To represent an empty value, use empty quotes:
+// `KEY: ""`.
 func NewFileResolver(path string) (Resolver, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -44,7 +44,7 @@ func NewFileResolver(path string) (Resolver, error) {
 		case bool:
 			vars[key] = fmt.Sprint(v)
 		case nil:
-			return nil, fmt.Errorf("%w: key %q has nil value in %s (use \"\" or '' for empty strings)", ErrVarFileParseFailed, key, path)
+			return nil, fmt.Errorf("%w: key %q has a null or empty value in %s. Setting null values is not supported; to set an empty value use empty quotes \"\"", ErrVarFileParseFailed, key, path)
 		default:
 			return nil, fmt.Errorf("%w: key %q has non-scalar value in %s", ErrVarFileParseFailed, key, path)
 		}

--- a/cli/internal/varsubst/resolver/file_resolver.go
+++ b/cli/internal/varsubst/resolver/file_resolver.go
@@ -15,21 +15,21 @@ type fileResolver struct {
 // map to scalar values (string, int, float, bool).
 //
 // Nil values are rejected. A YAML key with no value (`KEY:`) or an explicit
-// null (`KEY: null`) returns ErrIllegalArgument because the intent is
+// null (`KEY: null`) returns ErrVarFileParseFailed because the intent is
 // ambiguous. To represent an empty string, use explicit quotes: `KEY: ""` or
 // `KEY: ''`.
 func NewFileResolver(path string) (Resolver, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, fmt.Errorf("%w: variable file %s", ErrNotFound, path)
+			return nil, fmt.Errorf("%w: variable file %s", ErrVarFileNotFound, path)
 		}
 		return nil, fmt.Errorf("reading variable file %s: %w", path, err)
 	}
 
 	var raw map[string]any
 	if err := yaml.Unmarshal(data, &raw); err != nil {
-		return nil, fmt.Errorf("%w: parsing variable file %s", ErrIllegalArgument, path)
+		return nil, fmt.Errorf("%w: parsing variable file %s", ErrVarFileParseFailed, path)
 	}
 
 	vars := make(map[string]string, len(raw))
@@ -44,9 +44,9 @@ func NewFileResolver(path string) (Resolver, error) {
 		case bool:
 			vars[key] = fmt.Sprint(v)
 		case nil:
-			return nil, fmt.Errorf("%w: key %q has nil value in %s (use \"\" or '' for empty strings)", ErrIllegalArgument, key, path)
+			return nil, fmt.Errorf("%w: key %q has nil value in %s (use \"\" or '' for empty strings)", ErrVarFileParseFailed, key, path)
 		default:
-			return nil, fmt.Errorf("%w: key %q has non-scalar value in %s", ErrIllegalArgument, key, path)
+			return nil, fmt.Errorf("%w: key %q has non-scalar value in %s", ErrVarFileParseFailed, key, path)
 		}
 	}
 

--- a/cli/internal/varsubst/resolver/file_resolver.go
+++ b/cli/internal/varsubst/resolver/file_resolver.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/rudderlabs/rudder-iac/cli/internal/varsubst"
 	"gopkg.in/yaml.v3"
 )
 
@@ -12,18 +11,25 @@ type fileResolver struct {
 	vars map[string]string
 }
 
+// NewFileResolver loads variables from a flat YAML file whose top-level keys
+// map to scalar values (string, int, float, bool).
+//
+// Nil values are rejected. A YAML key with no value (`KEY:`) or an explicit
+// null (`KEY: null`) returns ErrIllegalArgument because the intent is
+// ambiguous. To represent an empty string, use explicit quotes: `KEY: ""` or
+// `KEY: ''`.
 func NewFileResolver(path string) (Resolver, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, fmt.Errorf("%w: %s", varsubst.ErrVarFileNotFound, path)
+			return nil, fmt.Errorf("%w: variable file %s", ErrNotFound, path)
 		}
 		return nil, fmt.Errorf("reading variable file %s: %w", path, err)
 	}
 
 	var raw map[string]any
 	if err := yaml.Unmarshal(data, &raw); err != nil {
-		return nil, fmt.Errorf("%w: %s", varsubst.ErrVarFileParseFailed, path)
+		return nil, fmt.Errorf("%w: parsing variable file %s", ErrIllegalArgument, path)
 	}
 
 	vars := make(map[string]string, len(raw))
@@ -38,9 +44,9 @@ func NewFileResolver(path string) (Resolver, error) {
 		case bool:
 			vars[key] = fmt.Sprint(v)
 		case nil:
-			vars[key] = ""
+			return nil, fmt.Errorf("%w: key %q has nil value in %s (use \"\" or '' for empty strings)", ErrIllegalArgument, key, path)
 		default:
-			return nil, fmt.Errorf("%w: key %q has non-scalar value in %s", varsubst.ErrVarFileParseFailed, key, path)
+			return nil, fmt.Errorf("%w: key %q has non-scalar value in %s", ErrIllegalArgument, key, path)
 		}
 	}
 

--- a/cli/internal/varsubst/resolver/file_resolver_test.go
+++ b/cli/internal/varsubst/resolver/file_resolver_test.go
@@ -5,7 +5,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/rudderlabs/rudder-iac/cli/internal/varsubst"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -25,24 +24,34 @@ func TestNewFileResolver(t *testing.T) {
 		wantErr error
 	}{
 		{
-			name:    "missing file returns ErrVarFileNotFound",
+			name:    "missing file returns ErrNotFound",
 			noFile:  true,
-			wantErr: varsubst.ErrVarFileNotFound,
+			wantErr: ErrNotFound,
 		},
 		{
-			name:    "invalid YAML returns ErrVarFileParseFailed",
+			name:    "invalid YAML returns ErrIllegalArgument",
 			content: "{{not valid yaml",
-			wantErr: varsubst.ErrVarFileParseFailed,
+			wantErr: ErrIllegalArgument,
 		},
 		{
 			name:    "nested map rejected",
 			content: "DB:\n  HOST: localhost\n  PORT: 5432",
-			wantErr: varsubst.ErrVarFileParseFailed,
+			wantErr: ErrIllegalArgument,
 		},
 		{
 			name:    "nested array rejected",
 			content: "HOSTS:\n  - a\n  - b",
-			wantErr: varsubst.ErrVarFileParseFailed,
+			wantErr: ErrIllegalArgument,
+		},
+		{
+			name:    "nil value (bare key) rejected",
+			content: "EMPTY_KEY:",
+			wantErr: ErrIllegalArgument,
+		},
+		{
+			name:    "explicit null value rejected",
+			content: "EMPTY_KEY: null",
+			wantErr: ErrIllegalArgument,
 		},
 		{
 			name:    "valid flat file succeeds",
@@ -51,6 +60,10 @@ func TestNewFileResolver(t *testing.T) {
 		{
 			name:    "empty file succeeds",
 			content: "",
+		},
+		{
+			name:    "explicit empty string succeeds",
+			content: `EMPTY: ""`,
 		},
 	}
 
@@ -110,8 +123,8 @@ func TestFileResolver_Resolve(t *testing.T) {
 			wantFound: true,
 		},
 		{
-			name:      "null value converted to empty string",
-			content:   "EMPTY_KEY:",
+			name:      "explicit empty string value preserved",
+			content:   `EMPTY_KEY: ""`,
 			lookup:    "EMPTY_KEY",
 			wantValue: "",
 			wantFound: true,

--- a/cli/internal/varsubst/resolver/file_resolver_test.go
+++ b/cli/internal/varsubst/resolver/file_resolver_test.go
@@ -1,0 +1,160 @@
+package resolver
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/rudderlabs/rudder-iac/cli/internal/varsubst"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func writeVarFile(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "vars.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(content), 0644))
+	return path
+}
+
+func TestNewFileResolver(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		noFile  bool
+		wantErr error
+	}{
+		{
+			name:    "missing file returns ErrVarFileNotFound",
+			noFile:  true,
+			wantErr: varsubst.ErrVarFileNotFound,
+		},
+		{
+			name:    "invalid YAML returns ErrVarFileParseFailed",
+			content: "{{not valid yaml",
+			wantErr: varsubst.ErrVarFileParseFailed,
+		},
+		{
+			name:    "nested map rejected",
+			content: "DB:\n  HOST: localhost\n  PORT: 5432",
+			wantErr: varsubst.ErrVarFileParseFailed,
+		},
+		{
+			name:    "nested array rejected",
+			content: "HOSTS:\n  - a\n  - b",
+			wantErr: varsubst.ErrVarFileParseFailed,
+		},
+		{
+			name:    "valid flat file succeeds",
+			content: "DB_HOST: localhost\nDB_PORT: 5432",
+		},
+		{
+			name:    "empty file succeeds",
+			content: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var path string
+			if tt.noFile {
+				path = filepath.Join(t.TempDir(), "nonexistent.yaml")
+			} else {
+				path = writeVarFile(t, tt.content)
+			}
+
+			_, err := NewFileResolver(path)
+			if tt.wantErr != nil {
+				assert.ErrorIs(t, err, tt.wantErr)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestFileResolver_Resolve(t *testing.T) {
+	tests := []struct {
+		name      string
+		content   string
+		lookup    string
+		wantValue string
+		wantFound bool
+	}{
+		{
+			name:      "string value found",
+			content:   "DB_HOST: db.staging.example.com",
+			lookup:    "DB_HOST",
+			wantValue: "db.staging.example.com",
+			wantFound: true,
+		},
+		{
+			name:      "integer converted to string",
+			content:   "DB_PORT: 5432",
+			lookup:    "DB_PORT",
+			wantValue: "5432",
+			wantFound: true,
+		},
+		{
+			name:      "boolean converted to string",
+			content:   "ENABLED: true",
+			lookup:    "ENABLED",
+			wantValue: "true",
+			wantFound: true,
+		},
+		{
+			name:      "float converted to string",
+			content:   "RATE: 3.14",
+			lookup:    "RATE",
+			wantValue: "3.14",
+			wantFound: true,
+		},
+		{
+			name:      "null value converted to empty string",
+			content:   "EMPTY_KEY:",
+			lookup:    "EMPTY_KEY",
+			wantValue: "",
+			wantFound: true,
+		},
+		{
+			name:      "variable not in file returns not found",
+			content:   "DB_HOST: localhost",
+			lookup:    "MISSING",
+			wantValue: "",
+			wantFound: false,
+		},
+		{
+			name:      "empty file resolves nothing",
+			content:   "",
+			lookup:    "ANY",
+			wantValue: "",
+			wantFound: false,
+		},
+		{
+			name:      "comments and empty lines handled",
+			content:   "# database config\n\nDB_HOST: localhost\n# port below\nDB_PORT: 5432",
+			lookup:    "DB_HOST",
+			wantValue: "localhost",
+			wantFound: true,
+		},
+		{
+			name:      "multiple variables in same file",
+			content:   "DB_HOST: localhost\nDB_PORT: 5432\nDB_NAME: analytics",
+			lookup:    "DB_NAME",
+			wantValue: "analytics",
+			wantFound: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := writeVarFile(t, tt.content)
+			r, err := NewFileResolver(path)
+			require.NoError(t, err)
+
+			value, found := r.Resolve(tt.lookup)
+			assert.Equal(t, tt.wantValue, value)
+			assert.Equal(t, tt.wantFound, found)
+		})
+	}
+}

--- a/cli/internal/varsubst/resolver/file_resolver_test.go
+++ b/cli/internal/varsubst/resolver/file_resolver_test.go
@@ -24,34 +24,34 @@ func TestNewFileResolver(t *testing.T) {
 		wantErr error
 	}{
 		{
-			name:    "missing file returns ErrNotFound",
+			name:    "missing file returns ErrVarFileNotFound",
 			noFile:  true,
-			wantErr: ErrNotFound,
+			wantErr: ErrVarFileNotFound,
 		},
 		{
-			name:    "invalid YAML returns ErrIllegalArgument",
+			name:    "invalid YAML returns ErrVarFileParseFailed",
 			content: "{{not valid yaml",
-			wantErr: ErrIllegalArgument,
+			wantErr: ErrVarFileParseFailed,
 		},
 		{
 			name:    "nested map rejected",
 			content: "DB:\n  HOST: localhost\n  PORT: 5432",
-			wantErr: ErrIllegalArgument,
+			wantErr: ErrVarFileParseFailed,
 		},
 		{
 			name:    "nested array rejected",
 			content: "HOSTS:\n  - a\n  - b",
-			wantErr: ErrIllegalArgument,
+			wantErr: ErrVarFileParseFailed,
 		},
 		{
 			name:    "nil value (bare key) rejected",
 			content: "EMPTY_KEY:",
-			wantErr: ErrIllegalArgument,
+			wantErr: ErrVarFileParseFailed,
 		},
 		{
 			name:    "explicit null value rejected",
 			content: "EMPTY_KEY: null",
-			wantErr: ErrIllegalArgument,
+			wantErr: ErrVarFileParseFailed,
 		},
 		{
 			name:    "valid flat file succeeds",


### PR DESCRIPTION
## 🔗 Ticket

Resolves [DEX-359](https://linear.app/rudderstack/issue/DEX-359/varsubst-package-fileresolver)

---

## Summary

Implements the FileResolver, which reads a single flat key-value YAML variable file and resolves variables from its contents. Each `--var-file` CLI argument (wired in a later ticket) will create a separate FileResolver instance added to the Substitutor's resolver chain.

---

## Changes

- Add `FileResolver` in the `resolver` package — reads flat YAML, parses into `map[string]string`, resolves via map lookup
- Non-string YAML scalars (int, bool, float, null) converted to string representations
- Nested structures (maps/arrays) rejected with `ErrVarFileParseFailed`
- Update `NewEnvResolver` signature to `(Resolver, error)` for consistency across all resolver constructors

---

## Testing

- 15 table-driven unit tests covering: missing file, invalid YAML, nested structures, type conversions, comments/empty lines, empty file, found/not-found lookups
- All existing EnvResolver tests updated and passing

---

## Risk / Impact

Low — new package with no callers yet; EnvResolver signature change is internal to the varsubst package which has no external consumers.

---

## Checklist

- [x] Ticket linked
- [x] Tests added/updated
- [x] No breaking changes (or documented)