### PR TITLE
fix(revert): enforce tracking plan rule id uniqueness in semantic validation

### DIFF
--- a/.agents/knowledge/conventions.md
+++ b/.agents/knowledge/conventions.md
@@ -16,8 +16,3 @@
 - Test placement uses co-located unit tests (`*_test.go`) for package behavior plus dedicated cross-package E2E under `cli/tests`, where `TestMain` builds the binary once and scenarios are snapshot-driven. Ref: `cli/tests/main_test.go` (`TestMain`), `cli/tests/README.md` (scenario and snapshot layout), `cli/tests/helpers/file_manager.go` (`StateFileManager`).
 - Snapshot file naming in E2E follows URN-derived filenames and splits expected artifacts by concern (`expected/state` vs `expected/upstream`), enabling deterministic diffing of local-state and API-state regressions separately. Ref: `cli/tests/README.md` ("URN-based filename convention", snapshot sections).
 - Error-display convention at process boundary distinguishes normal errors from machine-output flows via `SilentError`, so JSON-producing commands can fail with non-zero exits without extra stderr noise. Ref: `cli/internal/cmd/root.go` (`Execute`), `cli/internal/cmd/cmderrors/errors.go` (`SilentError`).
-
-## DEX-357 — Tracking Plan Rule-ID Validation Ownership
-- Tracking plan duplicate rule-ID checks are owned by semantic validators for both v0 and v1 specs; syntax validators should not enforce this uniqueness rule.
-- This split prevents duplicate diagnostics during validate/apply flows while keeping uniqueness scoped to each tracking plan spec.
-- Expected diagnostic contract to preserve: path `/rules/<index>/id` with message `duplicate rule id in tracking plan rules`.

--- a/cli/internal/providers/datacatalog/rules/trackingplan/trackingplan_semantic_v1_valid.go
+++ b/cli/internal/providers/datacatalog/rules/trackingplan/trackingplan_semantic_v1_valid.go
@@ -15,28 +15,8 @@ var validateTrackingPlanSemanticV1 = func(_ string, _ string, _ map[string]any, 
 	results = append(results, validateTrackingPlanVariantsV1(spec, graph)...)
 	results = append(results, validatePropertyNestingV1(spec, graph)...)
 	results = append(results, validateTrackingPlanNameUniquenessV1(spec, graph)...)
-	results = append(results, validateDuplicateRuleIDsV1(spec)...)
 	results = append(results, validateDuplicateEventsV1(spec)...)
 	results = append(results, validateDuplicatePropertiesV1(spec)...)
-
-	return results
-}
-
-func validateDuplicateRuleIDsV1(spec localcatalog.TrackingPlanV1) []rules.ValidationResult {
-	counts := make(map[string]int)
-	for _, rule := range spec.Rules {
-		counts[rule.LocalID]++
-	}
-
-	var results []rules.ValidationResult
-	for i, rule := range spec.Rules {
-		if counts[rule.LocalID] > 1 {
-			results = append(results, rules.ValidationResult{
-				Reference: fmt.Sprintf("/rules/%d/id", i),
-				Message:   "duplicate rule id in tracking plan rules",
-			})
-		}
-	}
 
 	return results
 }

--- a/cli/internal/providers/datacatalog/rules/trackingplan/trackingplan_semantic_valid.go
+++ b/cli/internal/providers/datacatalog/rules/trackingplan/trackingplan_semantic_valid.go
@@ -20,28 +20,8 @@ var validateTrackingPlanSemantic = func(_ string, _ string, _ map[string]any, sp
 	results = append(results, validateTrackingPlanVariants(spec, graph)...)
 	results = append(results, validatePropertyNestingV0(spec, graph)...)
 	results = append(results, validateTrackingPlanNameUniquenessV0(spec, graph)...)
-	results = append(results, validateDuplicateRuleIDsV0(spec)...)
 	results = append(results, validateDuplicateEventsV0(spec)...)
 	results = append(results, validateDuplicatePropertiesV0(spec)...)
-
-	return results
-}
-
-func validateDuplicateRuleIDsV0(spec localcatalog.TrackingPlan) []rules.ValidationResult {
-	counts := make(map[string]int)
-	for _, rule := range spec.Rules {
-		counts[rule.LocalID]++
-	}
-
-	var results []rules.ValidationResult
-	for i, rule := range spec.Rules {
-		if counts[rule.LocalID] > 1 {
-			results = append(results, rules.ValidationResult{
-				Reference: fmt.Sprintf("/rules/%d/id", i),
-				Message:   "duplicate rule id in tracking plan rules",
-			})
-		}
-	}
 
 	return results
 }

--- a/cli/internal/providers/datacatalog/rules/trackingplan/trackingplan_semantic_validation_test.go
+++ b/cli/internal/providers/datacatalog/rules/trackingplan/trackingplan_semantic_validation_test.go
@@ -725,62 +725,6 @@ func TestTrackingPlanSemanticValid_Uniqueness(t *testing.T) {
 	})
 }
 
-func TestTrackingPlanSemanticValid_DuplicateRuleIDsV0(t *testing.T) {
-	t.Parallel()
-
-	t.Run("duplicate rule ids are reported within tracking plan", func(t *testing.T) {
-		t.Parallel()
-
-		graph := resources.NewGraph()
-		graph.AddResource(resources.NewResource("signup_1", "event", resources.ResourceData{}, nil))
-		graph.AddResource(resources.NewResource("signup_2", "event", resources.ResourceData{}, nil))
-		graph.AddResource(resources.NewResource("signup_3", "event", resources.ResourceData{}, nil))
-
-		spec := localcatalog.TrackingPlan{
-			LocalID: "tp1",
-			Name:    "Plan 1",
-			Rules: []*localcatalog.TPRule{
-				{Type: "event_rule", LocalID: "dup", Event: &localcatalog.TPRuleEvent{Ref: "#event:signup_1"}},
-				{Type: "event_rule", LocalID: "unique", Event: &localcatalog.TPRuleEvent{Ref: "#event:signup_2"}},
-				{Type: "event_rule", LocalID: "dup", Event: &localcatalog.TPRuleEvent{Ref: "#event:signup_3"}},
-			},
-		}
-
-		results := validateTrackingPlanSemantic(localcatalog.KindTrackingPlans, specs.SpecVersionV0_1, nil, spec, graph)
-		assert.ElementsMatch(t, []rules.ValidationResult{
-			{Reference: "/rules/0/id", Message: "duplicate rule id in tracking plan rules"},
-			{Reference: "/rules/2/id", Message: "duplicate rule id in tracking plan rules"},
-		}, results)
-	})
-
-	t.Run("same rule id in different tracking plans does not cross-contaminate", func(t *testing.T) {
-		t.Parallel()
-
-		graph := resources.NewGraph()
-		graph.AddResource(resources.NewResource("signup", "event", resources.ResourceData{}, nil))
-
-		specA := localcatalog.TrackingPlan{
-			LocalID: "tp1",
-			Name:    "Plan 1",
-			Rules: []*localcatalog.TPRule{
-				{Type: "event_rule", LocalID: "shared", Event: &localcatalog.TPRuleEvent{Ref: "#event:signup"}},
-			},
-		}
-		specB := localcatalog.TrackingPlan{
-			LocalID: "tp2",
-			Name:    "Plan 2",
-			Rules: []*localcatalog.TPRule{
-				{Type: "event_rule", LocalID: "shared", Event: &localcatalog.TPRuleEvent{Ref: "#event:signup"}},
-			},
-		}
-
-		resultsA := validateTrackingPlanSemantic(localcatalog.KindTrackingPlans, specs.SpecVersionV0_1, nil, specA, graph)
-		resultsB := validateTrackingPlanSemantic(localcatalog.KindTrackingPlans, specs.SpecVersionV0_1, nil, specB, graph)
-		assert.Empty(t, resultsA)
-		assert.Empty(t, resultsB)
-	})
-}
-
 func TestTrackingPlanSemanticValid_V1ReferenceResolution(t *testing.T) {
 	t.Parallel()
 
@@ -966,62 +910,6 @@ func TestTrackingPlanSemanticValid_V1Uniqueness(t *testing.T) {
 	require.Len(t, results, 1)
 	assert.Equal(t, "/display_name", results[0].Reference)
 	assert.Contains(t, results[0].Message, "duplicate display_name 'Onboarding Plan' within kind 'tracking-plan'")
-}
-
-func TestTrackingPlanSemanticValid_DuplicateRuleIDsV1(t *testing.T) {
-	t.Parallel()
-
-	t.Run("duplicate rule ids are reported within tracking plan", func(t *testing.T) {
-		t.Parallel()
-
-		graph := resources.NewGraph()
-		graph.AddResource(resources.NewResource("signup_1", "event", resources.ResourceData{}, nil))
-		graph.AddResource(resources.NewResource("signup_2", "event", resources.ResourceData{}, nil))
-		graph.AddResource(resources.NewResource("signup_3", "event", resources.ResourceData{}, nil))
-
-		spec := localcatalog.TrackingPlanV1{
-			LocalID: "tp_v1",
-			Name:    "Plan",
-			Rules: []*localcatalog.TPRuleV1{
-				{Type: "event_rule", LocalID: "dup", Event: "#event:signup_1"},
-				{Type: "event_rule", LocalID: "unique", Event: "#event:signup_2"},
-				{Type: "event_rule", LocalID: "dup", Event: "#event:signup_3"},
-			},
-		}
-
-		results := validateTrackingPlanSemanticV1(localcatalog.KindTrackingPlansV1, specs.SpecVersionV1, nil, spec, graph)
-		assert.ElementsMatch(t, []rules.ValidationResult{
-			{Reference: "/rules/0/id", Message: "duplicate rule id in tracking plan rules"},
-			{Reference: "/rules/2/id", Message: "duplicate rule id in tracking plan rules"},
-		}, results)
-	})
-
-	t.Run("same rule id in different tracking plans does not cross-contaminate", func(t *testing.T) {
-		t.Parallel()
-
-		graph := resources.NewGraph()
-		graph.AddResource(resources.NewResource("signup", "event", resources.ResourceData{}, nil))
-
-		specA := localcatalog.TrackingPlanV1{
-			LocalID: "tp_v1_a",
-			Name:    "Plan A",
-			Rules: []*localcatalog.TPRuleV1{
-				{Type: "event_rule", LocalID: "shared", Event: "#event:signup"},
-			},
-		}
-		specB := localcatalog.TrackingPlanV1{
-			LocalID: "tp_v1_b",
-			Name:    "Plan B",
-			Rules: []*localcatalog.TPRuleV1{
-				{Type: "event_rule", LocalID: "shared", Event: "#event:signup"},
-			},
-		}
-
-		resultsA := validateTrackingPlanSemanticV1(localcatalog.KindTrackingPlansV1, specs.SpecVersionV1, nil, specA, graph)
-		resultsB := validateTrackingPlanSemanticV1(localcatalog.KindTrackingPlansV1, specs.SpecVersionV1, nil, specB, graph)
-		assert.Empty(t, resultsA)
-		assert.Empty(t, resultsB)
-	})
 }
 
 func TestTrackingPlanSemanticValid_V1VariantDiscriminator(t *testing.T) {

--- a/cli/internal/providers/datacatalog/rules/trackingplan/trackingplan_spec_valid.go
+++ b/cli/internal/providers/datacatalog/rules/trackingplan/trackingplan_spec_valid.go
@@ -116,6 +116,11 @@ var validateTrackingPlanSpecV1 = func(
 func validateRules(tpRules []*localcatalog.TPRule) []rules.ValidationResult {
 	var results []rules.ValidationResult
 
+	results = append(
+		results,
+		validateDuplicateRuleIDs(tpRules, func(r *localcatalog.TPRule) string { return r.LocalID })...,
+	)
+
 	for i, rule := range tpRules {
 		for j, prop := range rule.Properties {
 			if len(prop.Properties) == 0 {
@@ -137,6 +142,11 @@ func validateRules(tpRules []*localcatalog.TPRule) []rules.ValidationResult {
 func validateRulesV1(tpRules []*localcatalog.TPRuleV1) []rules.ValidationResult {
 	var results []rules.ValidationResult
 
+	results = append(
+		results,
+		validateDuplicateRuleIDs(tpRules, func(r *localcatalog.TPRuleV1) string { return r.LocalID })...,
+	)
+
 	for i, rule := range tpRules {
 		for j, prop := range rule.Properties {
 			ref := fmt.Sprintf("/rules/%d/properties/%d", i, j)
@@ -150,6 +160,28 @@ func validateRulesV1(tpRules []*localcatalog.TPRuleV1) []rules.ValidationResult 
 		}
 	}
 
+	return results
+}
+
+func validateDuplicateRuleIDs[T any](tpRules []T, idOf func(T) string) []rules.ValidationResult {
+	counts := make(map[string]int)
+	for _, rule := range tpRules {
+		id := idOf(rule)
+		if id == "" {
+			continue
+		}
+		counts[id]++
+	}
+
+	var results []rules.ValidationResult
+	for i, rule := range tpRules {
+		if counts[idOf(rule)] > 1 {
+			results = append(results, rules.ValidationResult{
+				Reference: fmt.Sprintf("/rules/%d/id", i),
+				Message:   "duplicate rule id in tracking plan rules",
+			})
+		}
+	}
 	return results
 }
 

--- a/cli/internal/providers/datacatalog/rules/trackingplan/trackingplan_spec_valid_test.go
+++ b/cli/internal/providers/datacatalog/rules/trackingplan/trackingplan_spec_valid_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/rudderlabs/rudder-iac/cli/internal/providers/datacatalog/localcatalog"
 	"github.com/rudderlabs/rudder-iac/cli/internal/validation/rules"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	// Trigger pattern registration (legacy_event_ref, legacy_property_ref, display_name, etc.) from parent rules package
 	_ "github.com/rudderlabs/rudder-iac/cli/internal/providers/datacatalog/rules"
@@ -1378,15 +1379,15 @@ func TestTrackingPlanSpecSyntaxValidRule_DuplicateRuleIDsV0(t *testing.T) {
 
 	event := &localcatalog.TPRuleEvent{Ref: "#/events/user-events/signup"}
 
-	t.Run("duplicate ids are not checked in syntax validation", func(t *testing.T) {
+	t.Run("no duplicates", func(t *testing.T) {
 		t.Parallel()
 
 		spec := localcatalog.TrackingPlan{
 			LocalID: "test_tp",
 			Name:    "Test TP",
 			Rules: []*localcatalog.TPRule{
-				{Type: "event_rule", LocalID: "dup_rule", Event: event},
-				{Type: "event_rule", LocalID: "dup_rule", Event: event},
+				{Type: "event_rule", LocalID: "rule1", Event: event},
+				{Type: "event_rule", LocalID: "rule2", Event: event},
 			},
 		}
 
@@ -1394,7 +1395,28 @@ func TestTrackingPlanSpecSyntaxValidRule_DuplicateRuleIDsV0(t *testing.T) {
 		assert.Empty(t, results)
 	})
 
-	t.Run("three occurrences are not flagged in syntax validation", func(t *testing.T) {
+	t.Run("two rules share an id — both reported", func(t *testing.T) {
+		t.Parallel()
+
+		spec := localcatalog.TrackingPlan{
+			LocalID: "test_tp",
+			Name:    "Test TP",
+			Rules: []*localcatalog.TPRule{
+				{Type: "event_rule", LocalID: "dup_rule", Event: event},
+				{Type: "event_rule", LocalID: "unique_rule", Event: event},
+				{Type: "event_rule", LocalID: "dup_rule", Event: event},
+			},
+		}
+
+		results := validateTrackingPlanSpec(localcatalog.KindTrackingPlans, specs.SpecVersionV0_1, map[string]any{}, spec)
+		require.Len(t, results, 2)
+		assert.Equal(t, []rules.ValidationResult{
+			{Reference: "/rules/0/id", Message: "duplicate rule id in tracking plan rules"},
+			{Reference: "/rules/2/id", Message: "duplicate rule id in tracking plan rules"},
+		}, results)
+	})
+
+	t.Run("three occurrences — all three reported with count 3", func(t *testing.T) {
 		t.Parallel()
 
 		spec := localcatalog.TrackingPlan{
@@ -1408,7 +1430,14 @@ func TestTrackingPlanSpecSyntaxValidRule_DuplicateRuleIDsV0(t *testing.T) {
 		}
 
 		results := validateTrackingPlanSpec(localcatalog.KindTrackingPlans, specs.SpecVersionV0_1, map[string]any{}, spec)
-		assert.Empty(t, results)
+		require.Len(t, results, 3)
+		for _, r := range results {
+			assert.Equal(t, "duplicate rule id in tracking plan rules", r.Message)
+		}
+		assert.ElementsMatch(t,
+			[]string{"/rules/0/id", "/rules/1/id", "/rules/2/id"},
+			extractRefs(results),
+		)
 	})
 
 	t.Run("rule ids are case-sensitive", func(t *testing.T) {
@@ -1447,6 +1476,8 @@ func TestTrackingPlanSpecSyntaxValidRule_DuplicateRuleIDsV0(t *testing.T) {
 		assert.ElementsMatch(t, []rules.ValidationResult{
 			{Reference: "/rules/0/id", Message: "'id' is required"},
 			{Reference: "/rules/2/id", Message: "'id' is required"},
+			{Reference: "/rules/1/id", Message: "duplicate rule id in tracking plan rules"},
+			{Reference: "/rules/4/id", Message: "duplicate rule id in tracking plan rules"},
 		}, results)
 	})
 }
@@ -1454,15 +1485,15 @@ func TestTrackingPlanSpecSyntaxValidRule_DuplicateRuleIDsV0(t *testing.T) {
 func TestTrackingPlanSpecSyntaxValidRule_DuplicateRuleIDsV1(t *testing.T) {
 	t.Parallel()
 
-	t.Run("duplicate ids are not checked in syntax validation", func(t *testing.T) {
+	t.Run("no duplicates", func(t *testing.T) {
 		t.Parallel()
 
 		spec := localcatalog.TrackingPlanV1{
 			LocalID: "tp_v1",
 			Name:    "Test Plan",
 			Rules: []*localcatalog.TPRuleV1{
-				{Type: "event_rule", LocalID: "dup_rule", Event: "#event:signup"},
-				{Type: "event_rule", LocalID: "dup_rule", Event: "#event:signup"},
+				{Type: "event_rule", LocalID: "rule1", Event: "#event:signup"},
+				{Type: "event_rule", LocalID: "rule2", Event: "#event:signup"},
 			},
 		}
 
@@ -1470,7 +1501,27 @@ func TestTrackingPlanSpecSyntaxValidRule_DuplicateRuleIDsV1(t *testing.T) {
 		assert.Empty(t, results)
 	})
 
-	t.Run("three occurrences are not flagged in syntax validation", func(t *testing.T) {
+	t.Run("two rules share an id — both reported", func(t *testing.T) {
+		t.Parallel()
+
+		spec := localcatalog.TrackingPlanV1{
+			LocalID: "tp_v1",
+			Name:    "Test Plan",
+			Rules: []*localcatalog.TPRuleV1{
+				{Type: "event_rule", LocalID: "dup_rule", Event: "#event:signup"},
+				{Type: "event_rule", LocalID: "dup_rule", Event: "#event:signup"},
+			},
+		}
+
+		results := validateTrackingPlanSpecV1(localcatalog.KindTrackingPlansV1, specs.SpecVersionV1, map[string]any{}, spec)
+		require.Len(t, results, 2)
+		assert.Equal(t, []rules.ValidationResult{
+			{Reference: "/rules/0/id", Message: "duplicate rule id in tracking plan rules"},
+			{Reference: "/rules/1/id", Message: "duplicate rule id in tracking plan rules"},
+		}, results)
+	})
+
+	t.Run("three occurrences — all three reported with count 3", func(t *testing.T) {
 		t.Parallel()
 
 		spec := localcatalog.TrackingPlanV1{
@@ -1484,7 +1535,10 @@ func TestTrackingPlanSpecSyntaxValidRule_DuplicateRuleIDsV1(t *testing.T) {
 		}
 
 		results := validateTrackingPlanSpecV1(localcatalog.KindTrackingPlansV1, specs.SpecVersionV1, map[string]any{}, spec)
-		assert.Empty(t, results)
+		require.Len(t, results, 3)
+		for _, r := range results {
+			assert.Equal(t, "duplicate rule id in tracking plan rules", r.Message)
+		}
 	})
 
 	t.Run("rule ids are case-sensitive", func(t *testing.T) {
@@ -1523,6 +1577,8 @@ func TestTrackingPlanSpecSyntaxValidRule_DuplicateRuleIDsV1(t *testing.T) {
 		assert.ElementsMatch(t, []rules.ValidationResult{
 			{Reference: "/rules/0/id", Message: "'id' is required"},
 			{Reference: "/rules/2/id", Message: "'id' is required"},
+			{Reference: "/rules/1/id", Message: "duplicate rule id in tracking plan rules"},
+			{Reference: "/rules/4/id", Message: "duplicate rule id in tracking plan rules"},
 		}, results)
 	})
 }


### PR DESCRIPTION
Reverts rudderlabs/rudder-iac#580

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Validation-layer relocation only; same user-facing rule and paths, with tests updated to match.
> 
> **Overview**
> Reverts PR #580 by moving **duplicate tracking plan rule `id` uniqueness** back out of semantic validation and into **spec syntax** validation for both v0 and v1.
> 
> Duplicate checks are consolidated in `validateDuplicateRuleIDs` in `trackingplan_spec_valid.go`, invoked from `validateRules` / `validateRulesV1`. The per-version helpers and call sites are removed from `trackingplan_semantic_valid.go` and `trackingplan_semantic_v1_valid.go`. Diagnostics stay at `/rules/<index>/id` with message `duplicate rule id in tracking plan rules`.
> 
> Tests follow the layer split: semantic duplicate-rule-ID cases are dropped; syntax tests now expect duplicates to be reported (including empty-id vs duplicate-id behavior). The DEX-357 conventions note that assigned this rule to semantic-only validation is removed from `.agents/knowledge/conventions.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64a90177d33e998819582adf5301adecd7906699. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->