### PR TITLE
feat: add Substitutor core engine for variable substitution

### DIFF
--- a/cli/internal/varsubst/substitutor.go
+++ b/cli/internal/varsubst/substitutor.go
@@ -1,0 +1,243 @@
+package varsubst
+
+import (
+	"fmt"
+	"regexp"
+	"slices"
+
+	"github.com/rudderlabs/rudder-iac/cli/internal/validation"
+	"github.com/rudderlabs/rudder-iac/cli/internal/validation/pathindex"
+	"github.com/rudderlabs/rudder-iac/cli/internal/validation/rules"
+)
+
+type Resolver interface {
+	Resolve(name string) (value string, found bool)
+}
+
+// Matches any {{ content }} token. Group 1 captures the token (anything that
+// isn't whitespace, pipe, or closing brace). Group 2 (optional) captures the
+// default value after pipe — cannot contain "}" and surrounding whitespace is
+// stripped by the enclosing \s* groups. Validation of the token (dot prefix,
+// variable name pattern) happens in code after matching.
+var varRegex = regexp.MustCompile(`\{\{\s*([^}\s|]+)(?:\s*\|\s*([^}]*?))?\s*\}\}`)
+
+var validVarName = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
+type Substitutor interface {
+	SubstituteBytes(data []byte) ([]byte, []SubstitutionError)
+}
+
+type substitutor struct {
+	resolvers []Resolver
+}
+
+func NewSubstitutor(resolvers ...Resolver) Substitutor {
+	return &substitutor{resolvers: resolvers}
+}
+
+// rawError stores the name of the variable, the byte offset, and the error kind.
+// This is used to compute the line/column positions of the error.
+type rawError struct {
+	name   string
+	offset int
+	err    error
+}
+
+// SubstituteBytes finds all {{ .VAR }} tokens and resolves them through the
+// resolver chain. Matches are processed last-to-first so that replacing a token
+// with a different-length value does not invalidate earlier byte offsets.
+// A copy of the original bytes is kept so that error positions can be computed
+// against unmodified content after all replacements are done.
+func (s *substitutor) SubstituteBytes(data []byte) ([]byte, []SubstitutionError) {
+	matches := varRegex.FindAllSubmatchIndex(data, -1)
+	if len(matches) == 0 {
+		return data, nil
+	}
+
+	original := make([]byte, len(data))
+	copy(original, data)
+
+	var rawErrors []rawError
+
+	for i := len(matches) - 1; i >= 0; i-- {
+		match := matches[i]
+		matchStart, matchEnd := match[0], match[1]
+
+		if isInComment(data, matchStart) {
+			continue
+		}
+
+		token := string(data[match[2]:match[3]])
+
+		varName, err := parseVarName(token)
+		if err != nil {
+			rawErrors = append(rawErrors, rawError{name: varName, offset: matchStart, err: err})
+			continue
+		}
+
+		var (
+			defaultVal string
+			hasDefault = match[4] != -1
+		)
+		if hasDefault {
+			defaultVal = string(data[match[4]:match[5]])
+		}
+
+		var (
+			resolved string
+			found    bool
+		)
+		for _, r := range s.resolvers {
+			resolved, found = r.Resolve(varName)
+			if found {
+				break
+			}
+		}
+
+		if !found {
+			if hasDefault {
+				resolved = defaultVal
+			} else {
+				rawErrors = append(rawErrors, rawError{name: varName, offset: matchStart, err: ErrUndefinedVariable})
+				continue
+			}
+		}
+
+		if resolved == "" {
+			resolved = `""`
+		}
+
+		data = replaceRange(data, matchStart, matchEnd, []byte(resolved))
+	}
+
+	errs := computePositions(original, rawErrors)
+	return data, errs
+}
+
+func parseVarName(token string) (string, error) {
+	if token[0] != '.' {
+		return token, ErrInvalidVarSyntax
+	}
+
+	name := token[1:]
+	if !validVarName.MatchString(name) {
+		return name, ErrInvalidVarSyntax
+	}
+
+	return name, nil
+}
+
+func replaceRange(data []byte, start, end int, replacement []byte) []byte {
+	result := make([]byte, 0, start+len(replacement)+len(data)-end)
+	result = append(result, data[:start]...)
+	result = append(result, replacement...)
+	result = append(result, data[end:]...)
+	return result
+}
+
+// isInComment finds the start of the line containing matchStart, then scans
+// forward tracking single/double quote state. Returns true if an unquoted #
+// appears before matchStart, indicating the token is inside a YAML comment.
+func isInComment(data []byte, matchStart int) bool {
+	lineStart := matchStart
+	// go backward to find the start of the line
+	for lineStart > 0 && data[lineStart-1] != '\n' {
+		lineStart--
+	}
+
+	var (
+		inSingleQuote bool
+		inDoubleQuote bool
+	)
+
+	for i := lineStart; i < matchStart; i++ {
+		switch data[i] {
+		case '\'':
+			if !inDoubleQuote {
+				inSingleQuote = !inSingleQuote
+			}
+		case '"':
+			if !inSingleQuote {
+				inDoubleQuote = !inDoubleQuote
+			}
+		case '#':
+			if !inSingleQuote && !inDoubleQuote {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// computePositions converts raw byte offsets into line/col positions in a single
+// scan of the original (pre-substitution) bytes. Errors are reversed into ascending
+// offset order because they were collected during the right-to-left substitution
+// pass. Then positions are emitted as the scan reaches each error's offset.
+func computePositions(original []byte, rawErrors []rawError) []SubstitutionError {
+	if len(rawErrors) == 0 {
+		return nil
+	}
+
+	// reverse into ascending offset order so we can scan the bytes left-to-right
+	slices.Reverse(rawErrors)
+
+	var (
+		result    = make([]SubstitutionError, 0, len(rawErrors))
+		line      = 1
+		lineStart int
+		errorIdx  int
+	)
+
+	// walk through original bytes once, tracking line/col as we go.
+	// when the current byte offset matches the next error's offset,
+	// scan forward to find the end of the line and emit the error.
+	for i := range original {
+		if i == rawErrors[errorIdx].offset {
+			lineEnd := i
+			for lineEnd < len(original) && original[lineEnd] != '\n' {
+				lineEnd++
+			}
+
+			// Line and column numbers are 1-indexed (matching how editors and error messages display positions), but byte offsets are 0-indexed. 
+			// The +1 converts from zero-based offset to one-based column.
+			result = append(result, SubstitutionError{
+				Name:     rawErrors[errorIdx].name,
+				Line:     line,				
+				Column:   i - lineStart + 1,
+				LineText: string(original[lineStart:lineEnd]),
+				Err:      rawErrors[errorIdx].err,
+			})
+
+			errorIdx++
+			if errorIdx >= len(rawErrors) {
+				break
+			}
+		}
+
+		if original[i] == '\n' {
+			line++
+			lineStart = i + 1
+		}
+	}
+
+	return result
+}
+
+func ToDiagnostics(filePath string, errs []SubstitutionError) validation.Diagnostics {
+	diagnostics := make(validation.Diagnostics, 0, len(errs))
+	for _, e := range errs {
+		diagnostics = append(diagnostics, validation.Diagnostic{
+			RuleID:   "project/var-substitution",
+			Severity: rules.Error,
+			Message:  fmt.Sprintf("%s %q", e.Err, e.Name),
+			File:     filePath,
+			Position: pathindex.Position{
+				Line:     e.Line,
+				Column:   e.Column,
+				LineText: e.LineText,
+			},
+		})
+	}
+	return diagnostics
+}

--- a/cli/internal/varsubst/substitutor.go
+++ b/cli/internal/varsubst/substitutor.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"regexp"
 	"slices"
+	"strings"
 
 	"github.com/rudderlabs/rudder-iac/cli/internal/validation"
 	"github.com/rudderlabs/rudder-iac/cli/internal/validation/pathindex"
@@ -16,13 +17,27 @@ type Resolver interface {
 
 // Matches any {{ content }} token. Group 1 captures the token (anything that
 // isn't whitespace, pipe, or closing brace). Group 2 (optional) captures the
-// default value after pipe — cannot contain "}" and surrounding whitespace is
-// stripped by the enclosing \s* groups. Validation of the token (dot prefix,
-// variable name pattern) happens in code after matching.
-var varRegex = regexp.MustCompile(`\{\{\s*([^}\s|]+)(?:\s*\|\s*([^}]*?))?\s*\}\}`)
+// default value after pipe — a single `}` is allowed (so defaults can contain
+// regex like `[a-z]{3}`), but `}}` always terminates the token. Surrounding
+// whitespace is stripped by the enclosing \s* groups. Validation of the token
+// (dot prefix, variable name pattern) happens in code after matching.
+var varRegex = regexp.MustCompile(`\{\{\s*([^}\s|]+)(?:\s*\|\s*((?:[^}]|}[^}])*?))?\s*\}\}`)
 
 var validVarName = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
 
+// Substitutor performs `{{ .VAR }}` substitution against a chain of resolvers.
+//
+// Known limitations:
+//
+//   - Substitution always runs inside YAML quoted strings. There is currently
+//     no escape mechanism to write a literal `{{ }}` token (e.g. in
+//     description text), so any `{{ .X }}`-shaped substring in a quoted value
+//     is treated as a variable reference.
+//   - Resolved values are injected verbatim. Values containing newlines, YAML
+//     special characters, or content that parses as a different YAML type
+//     (`true`, `123`, `null`, sequences) can change the document's semantics.
+//     Callers that need to force a string should quote at the call site:
+//     `flag: "{{ .FLAG }}"`.
 type Substitutor interface {
 	SubstituteBytes(data []byte) ([]byte, []SubstitutionError)
 }
@@ -80,7 +95,10 @@ func (s *substitutor) SubstituteBytes(data []byte) ([]byte, []SubstitutionError)
 			hasDefault = match[4] != -1
 		)
 		if hasDefault {
-			defaultVal = string(data[match[4]:match[5]])
+			// Trim trailing whitespace: when the default contains a single `}`
+			// (e.g. `[a-z]{3}`), regex backtracking can absorb the trailing
+			// space before `}}` into the capture group.
+			defaultVal = strings.TrimRight(string(data[match[4]:match[5]]), " \t")
 		}
 
 		var (
@@ -103,7 +121,7 @@ func (s *substitutor) SubstituteBytes(data []byte) ([]byte, []SubstitutionError)
 			}
 		}
 
-		if resolved == "" {
+		if resolved == "" && !isAdjacentToQuote(data, matchStart, matchEnd) {
 			resolved = `""`
 		}
 
@@ -138,6 +156,8 @@ func replaceRange(data []byte, start, end int, replacement []byte) []byte {
 // isInComment finds the start of the line containing matchStart, then scans
 // forward tracking single/double quote state. Returns true if an unquoted #
 // appears before matchStart, indicating the token is inside a YAML comment.
+// Inside a double-quoted string, a backslash escapes the next character so
+// that `\"` is treated as part of the string rather than closing it.
 func isInComment(data []byte, matchStart int) bool {
 	lineStart := matchStart
 	// go backward to find the start of the line
@@ -152,6 +172,12 @@ func isInComment(data []byte, matchStart int) bool {
 
 	for i := lineStart; i < matchStart; i++ {
 		switch data[i] {
+		case '\\':
+			// In YAML double-quoted strings, `\X` is an escape sequence; skip
+			// the next character so an escaped quote is not treated as a close.
+			if inDoubleQuote && i+1 < matchStart {
+				i++
+			}
 		case '\'':
 			if !inDoubleQuote {
 				inSingleQuote = !inSingleQuote
@@ -167,6 +193,24 @@ func isInComment(data []byte, matchStart int) bool {
 		}
 	}
 
+	return false
+}
+
+// isAdjacentToQuote reports whether the byte immediately before matchStart or
+// immediately after matchEnd is a YAML quote character. Used to suppress the
+// auto-quoting of empty resolved values when the token is already wrapped in
+// quotes (e.g. `"{{ .VAR }}"`), which would otherwise produce invalid YAML.
+func isAdjacentToQuote(data []byte, matchStart, matchEnd int) bool {
+	if matchStart > 0 {
+		if c := data[matchStart-1]; c == '"' || c == '\'' {
+			return true
+		}
+	}
+	if matchEnd < len(data) {
+		if c := data[matchEnd]; c == '"' || c == '\'' {
+			return true
+		}
+	}
 	return false
 }
 

--- a/cli/internal/varsubst/substitutor_test.go
+++ b/cli/internal/varsubst/substitutor_test.go
@@ -86,6 +86,24 @@ func TestSubstituteBytes(t *testing.T) {
 			wantData:  `host: ""`,
 		},
 		{
+			name:      "empty resolved value not auto-quoted inside double quotes",
+			resolvers: []Resolver{mapResolver{"HOST": ""}},
+			input:     `host: "{{ .HOST }}"`,
+			wantData:  `host: ""`,
+		},
+		{
+			name:      "empty resolved value not auto-quoted inside single quotes",
+			resolvers: []Resolver{mapResolver{"HOST": ""}},
+			input:     `host: '{{ .HOST }}'`,
+			wantData:  `host: ''`,
+		},
+		{
+			name:      "default value containing closing brace",
+			resolvers: []Resolver{mapResolver{}},
+			input:     "pattern: {{ .RE | [a-z]{3} }}",
+			wantData:  "pattern: [a-z]{3}",
+		},
+		{
 			name:      "whitespace variants",
 			resolvers: []Resolver{mapResolver{"VAR": "value"}},
 			input:     "a: {{.VAR}}\nb: {{ .VAR }}\nc: {{  .VAR  }}",
@@ -199,6 +217,12 @@ func TestIsInComment(t *testing.T) {
 			line:       "'#hash-in-single-quotes' {{ .VAR }}",
 			matchStart: 25,
 			want:       false,
+		},
+		{
+			name:       "escaped quote inside double quotes does not reopen string",
+			line:       `key: "val\"ue" # {{ .VAR }}`,
+			matchStart: 17,
+			want:       true,
 		},
 	}
 

--- a/cli/internal/varsubst/substitutor_test.go
+++ b/cli/internal/varsubst/substitutor_test.go
@@ -1,0 +1,314 @@
+package varsubst
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/rudderlabs/rudder-iac/cli/internal/validation"
+	"github.com/rudderlabs/rudder-iac/cli/internal/validation/pathindex"
+	"github.com/rudderlabs/rudder-iac/cli/internal/validation/rules"
+)
+
+type mapResolver map[string]string
+
+func (m mapResolver) Resolve(name string) (string, bool) {
+	v, ok := m[name]
+	return v, ok
+}
+
+func TestSubstituteBytes(t *testing.T) {
+	tests := []struct {
+		name      string
+		resolvers []Resolver
+		input     string
+		wantData  string
+		wantErrs  []SubstitutionError
+	}{
+		{
+			name:      "single variable substitution",
+			resolvers: []Resolver{mapResolver{"HOST": "localhost"}},
+			input:     "host: {{ .HOST }}",
+			wantData:  "host: localhost",
+		},
+		{
+			name:      "multiple variables in one file",
+			resolvers: []Resolver{mapResolver{"HOST": "localhost", "PORT": "5432"}},
+			input:     "host: {{ .HOST }}\nport: {{ .PORT }}",
+			wantData:  "host: localhost\nport: 5432",
+		},
+		{
+			name:      "variable with default used when unresolved",
+			resolvers: []Resolver{mapResolver{}},
+			input:     "host: {{ .HOST | localhost }}",
+			wantData:  "host: localhost",
+		},
+		{
+			name:      "variable with default resolver takes precedence",
+			resolvers: []Resolver{mapResolver{"HOST": "prod.example.com"}},
+			input:     "host: {{ .HOST | localhost }}",
+			wantData:  "host: prod.example.com",
+		},
+		{
+			name:      "multiple tokens on one line",
+			resolvers: []Resolver{mapResolver{"HOST": "localhost", "PORT": "5432", "DB": "mydb"}},
+			input:     "url: https://{{ .HOST }}:{{ .PORT }}/{{ .DB }}",
+			wantData:  "url: https://localhost:5432/mydb",
+		},
+		{
+			name:      "token in YAML comment skipped",
+			resolvers: []Resolver{mapResolver{"VAR": "value"}},
+			input:     "# comment {{ .VAR }}",
+			wantData:  "# comment {{ .VAR }}",
+		},
+		{
+			name:      "token after inline comment skipped",
+			resolvers: []Resolver{mapResolver{"VAR": "value"}},
+			input:     "value # {{ .VAR }}",
+			wantData:  "value # {{ .VAR }}",
+		},
+		{
+			name:      "hash inside double quotes is not a comment",
+			resolvers: []Resolver{mapResolver{"VAR": "value"}},
+			input:     `"#not-comment" {{ .VAR }}`,
+			wantData:  `"#not-comment" value`,
+		},
+		{
+			name:      "hash inside single quotes is not a comment",
+			resolvers: []Resolver{mapResolver{"VAR": "value"}},
+			input:     `'#hash-in-single-quotes' {{ .VAR }}`,
+			wantData:  `'#hash-in-single-quotes' value`,
+		},
+		{
+			name:      "empty resolved value auto-quoted",
+			resolvers: []Resolver{mapResolver{"HOST": ""}},
+			input:     "host: {{ .HOST }}",
+			wantData:  `host: ""`,
+		},
+		{
+			name:      "whitespace variants",
+			resolvers: []Resolver{mapResolver{"VAR": "value"}},
+			input:     "a: {{.VAR}}\nb: {{ .VAR }}\nc: {{  .VAR  }}",
+			wantData:  "a: value\nb: value\nc: value",
+		},
+		{
+			name:      "no variables passthrough unchanged",
+			resolvers: []Resolver{mapResolver{"VAR": "value"}},
+			input:     "host: localhost\nport: 5432",
+			wantData:  "host: localhost\nport: 5432",
+		},
+		{
+			name:      "all undefined collect all errors no partial substitution",
+			resolvers: []Resolver{mapResolver{}},
+			input:     "host: {{ .HOST }}\nport: {{ .PORT }}",
+			wantData:  "host: {{ .HOST }}\nport: {{ .PORT }}",
+			wantErrs: []SubstitutionError{
+				{Name: "HOST", Line: 1, Column: 7, LineText: "host: {{ .HOST }}", Err: ErrUndefinedVariable},
+				{Name: "PORT", Line: 2, Column: 7, LineText: "port: {{ .PORT }}", Err: ErrUndefinedVariable},
+			},
+		},
+		{
+			name:      "mixed resolved and undefined",
+			resolvers: []Resolver{mapResolver{"HOST": "localhost"}},
+			input:     "host: {{ .HOST }}\nport: {{ .PORT }}",
+			wantData:  "host: localhost\nport: {{ .PORT }}",
+			wantErrs: []SubstitutionError{
+				{Name: "PORT", Line: 2, Column: 7, LineText: "port: {{ .PORT }}", Err: ErrUndefinedVariable},
+			},
+		},
+		{
+			name: "resolver priority order first resolver wins",
+			resolvers: []Resolver{
+				mapResolver{"HOST": "from-env"},
+				mapResolver{"HOST": "from-file"},
+			},
+			input:    "host: {{ .HOST }}",
+			wantData: "host: from-env",
+		},
+		{
+			name:      "invalid variable name reports error",
+			resolvers: []Resolver{mapResolver{}},
+			input:     "host: {{ .123BAD }}",
+			wantData:  "host: {{ .123BAD }}",
+			wantErrs: []SubstitutionError{
+				{Name: "123BAD", Line: 1, Column: 7, LineText: "host: {{ .123BAD }}", Err: ErrInvalidVarSyntax},
+			},
+		},
+		{
+			name:      "invalid variable name mixed with valid",
+			resolvers: []Resolver{mapResolver{"HOST": "localhost"}},
+			input:     "host: {{ .HOST }}\nport: {{ .9PORT }}",
+			wantData:  "host: localhost\nport: {{ .9PORT }}",
+			wantErrs: []SubstitutionError{
+				{Name: "9PORT", Line: 2, Column: 7, LineText: "port: {{ .9PORT }}", Err: ErrInvalidVarSyntax},
+			},
+		},
+		{
+			name:      "missing dot prefix reports error",
+			resolvers: []Resolver{mapResolver{"VAR": "value"}},
+			input:     "key: {{ VAR }}",
+			wantData:  "key: {{ VAR }}",
+			wantErrs: []SubstitutionError{
+				{Name: "VAR", Line: 1, Column: 6, LineText: "key: {{ VAR }}", Err: ErrInvalidVarSyntax},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sub := NewSubstitutor(tt.resolvers...)
+			got, errs := sub.SubstituteBytes([]byte(tt.input))
+
+			assert.Equal(t, tt.wantData, string(got))
+			if tt.wantErrs != nil {
+				assert.Equal(t, tt.wantErrs, errs)
+			} else {
+				assert.Empty(t, errs)
+			}
+		})
+	}
+}
+
+func TestIsInComment(t *testing.T) {
+	tests := []struct {
+		name       string
+		line       string
+		matchStart int
+		want       bool
+	}{
+		{
+			name:       "hash comment",
+			line:       "# comment {{ .VAR }}",
+			matchStart: 10,
+			want:       true,
+		},
+		{
+			name:       "hash in double quotes not a comment",
+			line:       `"#not-comment" {{ .VAR }}`,
+			matchStart: 15,
+			want:       false,
+		},
+		{
+			name:       "inline comment",
+			line:       "value # {{ .VAR }}",
+			matchStart: 8,
+			want:       true,
+		},
+		{
+			name:       "hash in single quotes not a comment",
+			line:       "'#hash-in-single-quotes' {{ .VAR }}",
+			matchStart: 25,
+			want:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isInComment([]byte(tt.line), tt.matchStart))
+		})
+	}
+}
+
+func TestSubstituteBytes_ErrorPositions(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		wantErrs []SubstitutionError
+	}{
+		{
+			name:  "error on first line",
+			input: "host: {{ .HOST }}",
+			wantErrs: []SubstitutionError{
+				{Name: "HOST", Line: 1, Column: 7, LineText: "host: {{ .HOST }}", Err: ErrUndefinedVariable},
+			},
+		},
+		{
+			name:  "error on last line",
+			input: "first: value\nsecond: {{ .VAR }}",
+			wantErrs: []SubstitutionError{
+				{Name: "VAR", Line: 2, Column: 9, LineText: "second: {{ .VAR }}", Err: ErrUndefinedVariable},
+			},
+		},
+		{
+			name:  "multiple errors each has correct position",
+			input: "a: {{ .X }}\nb: {{ .Y }}\nc: {{ .Z }}",
+			wantErrs: []SubstitutionError{
+				{Name: "X", Line: 1, Column: 4, LineText: "a: {{ .X }}", Err: ErrUndefinedVariable},
+				{Name: "Y", Line: 2, Column: 4, LineText: "b: {{ .Y }}", Err: ErrUndefinedVariable},
+				{Name: "Z", Line: 3, Column: 4, LineText: "c: {{ .Z }}", Err: ErrUndefinedVariable},
+			},
+		},
+	}
+
+	sub := NewSubstitutor()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, errs := sub.SubstituteBytes([]byte(tt.input))
+			assert.Equal(t, tt.wantErrs, errs)
+		})
+	}
+}
+
+func TestToDiagnostics(t *testing.T) {
+	errs := []SubstitutionError{
+		{
+			Name:     "DB_PASSWORD",
+			Line:     8,
+			Column:   15,
+			LineText: "    password: {{ .DB_PASSWORD }}",
+			Err:      ErrUndefinedVariable,
+		},
+		{
+			Name:     "9PORT",
+			Line:     5,
+			Column:   11,
+			LineText: "    port: {{ .9PORT }}",
+			Err:      ErrInvalidVarSyntax,
+		},
+		{
+			Name:     "VAR",
+			Line:     10,
+			Column:   11,
+			LineText: "    value: {{ VAR }}",
+			Err:      ErrInvalidVarSyntax,
+		},
+	}
+
+	got := ToDiagnostics("specs/dest.yaml", errs)
+
+	assert.Equal(t, validation.Diagnostics{
+		{
+			RuleID:   "project/var-substitution",
+			Severity: rules.Error,
+			Message:  `undefined variable "DB_PASSWORD"`,
+			File:     "specs/dest.yaml",
+			Position: pathindex.Position{
+				Line:     8,
+				Column:   15,
+				LineText: "    password: {{ .DB_PASSWORD }}",
+			},
+		},
+		{
+			RuleID:   "project/var-substitution",
+			Severity: rules.Error,
+			Message:  `invalid variable syntax "9PORT"`,
+			File:     "specs/dest.yaml",
+			Position: pathindex.Position{
+				Line:     5,
+				Column:   11,
+				LineText: "    port: {{ .9PORT }}",
+			},
+		},
+		{
+			RuleID:   "project/var-substitution",
+			Severity: rules.Error,
+			Message:  `invalid variable syntax "VAR"`,
+			File:     "specs/dest.yaml",
+			Position: pathindex.Position{
+				Line:     10,
+				Column:   11,
+				LineText: "    value: {{ VAR }}",
+			},
+		},
+	}, got)
+}


### PR DESCRIPTION
## 🔗 Ticket

Resolves [DEX-360](https://linear.app/rudderstack/issue/DEX-360/varsubst-package-substitutor-core-engine)

---

## Summary

Implements the Substitutor — the core byte-scanning engine that finds `{{ .VAR }}` tokens in raw YAML bytes, resolves them through an ordered chain of resolvers, and returns substituted bytes. Includes comment detection, empty value handling, variable name validation, position computation, and diagnostic conversion.

---

## Changes

- Add `Substitutor` interface and `NewSubstitutor` constructor accepting variadic `Resolver` arguments
- Implement `SubstituteBytes` with reverse-iteration to preserve byte offsets during replacement
- Add `isInComment` for quote-aware YAML comment detection
- Add `parseVarName` to validate dot prefix and `[A-Za-z_][A-Za-z0-9_]*` name pattern
- Add single-pass `computePositions` to convert byte offsets to line/col from original bytes
- Add `ToDiagnostics` to bridge `[]SubstitutionError` into `validation.Diagnostics`
- Broad `varRegex` matches any `{{ content }}` token; validation happens in code

---

## Testing

- 34 unit tests covering substitution, comment detection, error positions, and diagnostics
- Covers: single/multiple vars, defaults, resolver priority, comment skipping, empty value quoting, whitespace variants, undefined vars, invalid names, missing dot prefix, mixed errors

---

## Risk / Impact

Low — new additive code, no changes to existing functionality.

---

## Checklist

- [x] Ticket linked
- [x] Tests added/updated
- [x] No breaking changes (or documented)