### PR TITLE
feat(project): wire varsubst.Substitutor into project loading (DEX-361)

### DIFF
--- a/cli/internal/app/dependencies.go
+++ b/cli/internal/app/dependencies.go
@@ -59,7 +59,7 @@ type Deps interface {
 	CompositeProvider() provider.Provider
 
 	// NewProject creates a new project instance with the composite provider.
-	NewProject() project.Project
+	NewProject(opts ...project.ProjectOption) project.Project
 
 	// NewDataCatalogProject creates a new project instance with only the DataCatalog provider.
 	// Used by trackingplan commands.
@@ -183,8 +183,8 @@ func (d *deps) CompositeProvider() provider.Provider {
 }
 
 // NewProject creates a project with composite provider.
-func (d *deps) NewProject() project.Project {
-	return project.New(d.CompositeProvider())
+func (d *deps) NewProject(opts ...project.ProjectOption) project.Project {
+	return project.New(d.CompositeProvider(), opts...)
 }
 
 // NewDataCatalogProject creates a project with only the DataCatalog provider.

--- a/cli/internal/project/project.go
+++ b/cli/internal/project/project.go
@@ -225,7 +225,7 @@ func (p *project) parseSpecs(raw map[string]*specs.RawSpec) (map[string]*specs.R
 		if p.substitutor != nil {
 			substituted, subErrs := p.substitutor.SubstituteBytes(rawSpec.Data)
 			if len(subErrs) > 0 {
-				diags = append(diags, varsubst.ToDiagnostics(path, subErrs)...)
+				diags = append(diags, substitutionDiagnostics(path, subErrs)...)
 				continue
 			}
 			rawSpec = &specs.RawSpec{Data: substituted}

--- a/cli/internal/project/project.go
+++ b/cli/internal/project/project.go
@@ -15,6 +15,7 @@ import (
 	"github.com/rudderlabs/rudder-iac/cli/internal/validation/pathindex"
 	"github.com/rudderlabs/rudder-iac/cli/internal/validation/renderer"
 	"github.com/rudderlabs/rudder-iac/cli/internal/validation/rules"
+	"github.com/rudderlabs/rudder-iac/cli/internal/varsubst"
 )
 
 var log = logger.New("project")
@@ -45,6 +46,7 @@ type project struct {
 	specs            map[string]*specs.Spec
 	validationEngine validation.ValidationEngine
 	renderer         renderer.Renderer
+	substitutor      varsubst.Substitutor
 }
 
 // ProjectOption defines a functional option for configuring a Project.
@@ -56,6 +58,14 @@ func WithLoader(l Loader) ProjectOption {
 		if l != nil {
 			p.loader = l
 		}
+	}
+}
+
+// WithSubstitutor sets an optional variable substitutor that runs on raw spec
+// bytes before parsing. When nil (the default), no substitution happens.
+func WithSubstitutor(s varsubst.Substitutor) ProjectOption {
+	return func(p *project) {
+		p.substitutor = s
 	}
 }
 
@@ -211,6 +221,15 @@ func (p *project) parseSpecs(raw map[string]*specs.RawSpec) (map[string]*specs.R
 	// Ideally this should be done by validation engine but the engine
 	// only works on the data provided.
 	for path, rawSpec := range raw {
+
+		if p.substitutor != nil {
+			substituted, subErrs := p.substitutor.SubstituteBytes(rawSpec.Data)
+			if len(subErrs) > 0 {
+				diags = append(diags, varsubst.ToDiagnostics(path, subErrs)...)
+				continue
+			}
+			rawSpec = &specs.RawSpec{Data: substituted}
+		}
 
 		parsed, err := rawSpec.Parse()
 		if err != nil {

--- a/cli/internal/project/project.go
+++ b/cli/internal/project/project.go
@@ -136,9 +136,19 @@ func (p *project) Load(location string) error {
 func (p *project) handleValidation(rawSpecs map[string]*specs.RawSpec) error {
 	ctx := context.Background()
 
-	// Start with parsing the specs and validating it's syntax.
-	// This is because we get raw specs from the loader and we need to parse them.
-	parsedRawSpecs, specDiags := p.parseSpecs(rawSpecs)
+	// Run variable substitution first. If any spec fails to resolve its
+	// variables, render the substitution diagnostics and stop — see
+	// substituteSpecs for why this is all-or-nothing.
+	substituted, subDiags := p.substituteSpecs(rawSpecs)
+	if subDiags.HasErrors() {
+		if err := p.renderer.Render(subDiags); err != nil {
+			return fmt.Errorf("rendering diagnostics: %w", err)
+		}
+		return fmt.Errorf("syntax validation failed")
+	}
+
+	// Parse the substituted specs into structured form before syntactic validation.
+	parsedRawSpecs, specDiags := p.parseSpecs(substituted)
 
 	registry, err := p.registry()
 	if err != nil {
@@ -207,41 +217,51 @@ func (p *project) handleValidation(rawSpecs map[string]*specs.RawSpec) error {
 	return nil
 }
 
+// substituteSpecs runs variable substitution over each raw spec, returning a
+// map of fully-substituted specs ready for parsing.
+//
+// All-or-nothing: if any spec fails substitution, the returned map is empty
+// and the diagnostics carry the substitution errors. This stops downstream
+// parsing and validation from surfacing cascading false errors (e.g. missing
+// references) for resources whose definitions failed substitution.
+//
+// When no substitutor is configured, raw is returned unchanged.
+func (p *project) substituteSpecs(raw map[string]*specs.RawSpec) (map[string]*specs.RawSpec, validation.Diagnostics) {
+	if p.substitutor == nil {
+		return raw, nil
+	}
+
+	var (
+		diags       = make(validation.Diagnostics, 0)
+		substituted = make(map[string]*specs.RawSpec, len(raw))
+	)
+	for path, rawSpec := range raw {
+		data, subErrs := p.substitutor.SubstituteBytes(rawSpec.Data)
+		if len(subErrs) > 0 {
+			diags = append(diags, substitutionDiagnostics(path, subErrs)...)
+			continue
+		}
+		substituted[path] = &specs.RawSpec{Data: data}
+	}
+	if diags.HasErrors() {
+		diags.Sort()
+		return nil, diags
+	}
+	return substituted, nil
+}
+
+// parseSpecs converts raw spec bytes into parsed specs, collecting any
+// per-spec parse errors as diagnostics. Specs that fail to parse are dropped
+// from the returned map so downstream validation only sees usable specs.
+//
+// Ideally this would live in the validation engine, but the engine only
+// operates on already-parsed specs.
 func (p *project) parseSpecs(raw map[string]*specs.RawSpec) (map[string]*specs.RawSpec, validation.Diagnostics) {
 	var (
 		diags          = make(validation.Diagnostics, 0)
 		parsedRawSpecs = make(map[string]*specs.RawSpec)
 	)
 
-	// Substitution runs as an all-or-nothing first phase: if any spec fails to
-	// resolve its variables, we stop before parsing so that syntactic and
-	// semantic validation never see partially-substituted specs. Without this,
-	// downstream validation would surface cascading false errors (e.g. missing
-	// references) for resources whose definitions failed substitution.
-	if p.substitutor != nil {
-		substituted := make(map[string]*specs.RawSpec, len(raw))
-		for path, rawSpec := range raw {
-			data, subErrs := p.substitutor.SubstituteBytes(rawSpec.Data)
-			if len(subErrs) > 0 {
-				diags = append(diags, substitutionDiagnostics(path, subErrs)...)
-				continue
-			}
-			substituted[path] = &specs.RawSpec{Data: data}
-		}
-		if diags.HasErrors() {
-			diags.Sort()
-			return parsedRawSpecs, diags
-		}
-		raw = substituted
-	}
-
-	// Validation Engine is responsible for validating
-	// on the parsed specs along with the raw specs for indexer.
-	// To reach that, we need to parse the specs from loader
-	// and return diagnostics for the parsing errors.
-
-	// Ideally this should be done by validation engine but the engine
-	// only works on the data provided.
 	for path, rawSpec := range raw {
 		parsed, err := rawSpec.Parse()
 		if err != nil {

--- a/cli/internal/project/project.go
+++ b/cli/internal/project/project.go
@@ -114,16 +114,27 @@ func (p *project) loadSpec(path string, spec *specs.Spec) error {
 	}
 }
 
-// Load loads the project specifications from the given location using the configured SpecLoader
-// and runs them through the validation engine (syntax, then semantic rules from RuleProvider).
+// Load loads the project specifications from the given location using the
+// configured SpecLoader, runs variable substitution if a substitutor is
+// configured, then runs the specs through the validation engine (syntax,
+// then semantic rules from RuleProvider).
 func (p *project) Load(location string) error {
-	var err error
-
 	p.location = location
 
-	rawSpecs, err := p.loader.Load(p.location) // Use the specLoader
+	rawSpecs, err := p.loader.Load(p.location)
 	if err != nil {
 		return fmt.Errorf("failed to load specs using specLoader: %w", err)
+	}
+
+	if p.substitutor != nil {
+		substituted, subDiags := p.substituteSpecs(rawSpecs)
+		if subDiags.HasErrors() {
+			if err := p.renderer.Render(subDiags); err != nil {
+				return fmt.Errorf("rendering diagnostics: %w", err)
+			}
+			return fmt.Errorf("variable substitution failed")
+		}
+		rawSpecs = substituted
 	}
 
 	return p.handleValidation(rawSpecs)
@@ -136,19 +147,8 @@ func (p *project) Load(location string) error {
 func (p *project) handleValidation(rawSpecs map[string]*specs.RawSpec) error {
 	ctx := context.Background()
 
-	// Run variable substitution first. If any spec fails to resolve its
-	// variables, render the substitution diagnostics and stop — see
-	// substituteSpecs for why this is all-or-nothing.
-	substituted, subDiags := p.substituteSpecs(rawSpecs)
-	if subDiags.HasErrors() {
-		if err := p.renderer.Render(subDiags); err != nil {
-			return fmt.Errorf("rendering diagnostics: %w", err)
-		}
-		return fmt.Errorf("syntax validation failed")
-	}
-
-	// Parse the substituted specs into structured form before syntactic validation.
-	parsedRawSpecs, specDiags := p.parseSpecs(substituted)
+	// Parse the raw specs into structured form before syntactic validation.
+	parsedRawSpecs, specDiags := p.parseSpecs(rawSpecs)
 
 	registry, err := p.registry()
 	if err != nil {
@@ -218,19 +218,14 @@ func (p *project) handleValidation(rawSpecs map[string]*specs.RawSpec) error {
 }
 
 // substituteSpecs runs variable substitution over each raw spec, returning a
-// map of fully-substituted specs ready for parsing.
+// map of fully-substituted specs ready for parsing. Callers must ensure a
+// substitutor is configured before calling.
 //
-// All-or-nothing: if any spec fails substitution, the returned map is empty
-// and the diagnostics carry the substitution errors. This stops downstream
+// All-or-nothing: if any spec fails substitution, the returned map is nil and
+// the diagnostics carry the substitution errors. This stops downstream
 // parsing and validation from surfacing cascading false errors (e.g. missing
 // references) for resources whose definitions failed substitution.
-//
-// When no substitutor is configured, raw is returned unchanged.
 func (p *project) substituteSpecs(raw map[string]*specs.RawSpec) (map[string]*specs.RawSpec, validation.Diagnostics) {
-	if p.substitutor == nil {
-		return raw, nil
-	}
-
 	var (
 		diags       = make(validation.Diagnostics, 0)
 		substituted = make(map[string]*specs.RawSpec, len(raw))

--- a/cli/internal/project/project.go
+++ b/cli/internal/project/project.go
@@ -213,6 +213,28 @@ func (p *project) parseSpecs(raw map[string]*specs.RawSpec) (map[string]*specs.R
 		parsedRawSpecs = make(map[string]*specs.RawSpec)
 	)
 
+	// Substitution runs as an all-or-nothing first phase: if any spec fails to
+	// resolve its variables, we stop before parsing so that syntactic and
+	// semantic validation never see partially-substituted specs. Without this,
+	// downstream validation would surface cascading false errors (e.g. missing
+	// references) for resources whose definitions failed substitution.
+	if p.substitutor != nil {
+		substituted := make(map[string]*specs.RawSpec, len(raw))
+		for path, rawSpec := range raw {
+			data, subErrs := p.substitutor.SubstituteBytes(rawSpec.Data)
+			if len(subErrs) > 0 {
+				diags = append(diags, substitutionDiagnostics(path, subErrs)...)
+				continue
+			}
+			substituted[path] = &specs.RawSpec{Data: data}
+		}
+		if diags.HasErrors() {
+			diags.Sort()
+			return parsedRawSpecs, diags
+		}
+		raw = substituted
+	}
+
 	// Validation Engine is responsible for validating
 	// on the parsed specs along with the raw specs for indexer.
 	// To reach that, we need to parse the specs from loader
@@ -221,16 +243,6 @@ func (p *project) parseSpecs(raw map[string]*specs.RawSpec) (map[string]*specs.R
 	// Ideally this should be done by validation engine but the engine
 	// only works on the data provided.
 	for path, rawSpec := range raw {
-
-		if p.substitutor != nil {
-			substituted, subErrs := p.substitutor.SubstituteBytes(rawSpec.Data)
-			if len(subErrs) > 0 {
-				diags = append(diags, substitutionDiagnostics(path, subErrs)...)
-				continue
-			}
-			rawSpec = &specs.RawSpec{Data: substituted}
-		}
-
 		parsed, err := rawSpec.Parse()
 		if err != nil {
 			diags = append(diags, validation.Diagnostic{
@@ -250,7 +262,6 @@ func (p *project) parseSpecs(raw map[string]*specs.RawSpec) (map[string]*specs.R
 		// we need to add to the specs map on the project required by migrate command.
 		p.specs[path] = parsed
 		parsedRawSpecs[path] = rawSpec
-
 	}
 
 	diags.Sort()

--- a/cli/internal/project/project_test.go
+++ b/cli/internal/project/project_test.go
@@ -281,7 +281,7 @@ func TestProject_Load_WithSubstitutor(t *testing.T) {
 			},
 		},
 		{
-			name:        "undefined variable excludes spec and fails load",
+			name:        "undefined variable aborts load before parsing",
 			substitutor: varsubst.NewSubstitutor(mapResolver{}),
 			rawSpecs: map[string][]byte{
 				"path/to/spec.yaml": []byte("kind: Source\nversion: rudder/0.1\nmetadata:\n  name: {{ .MISSING }}\nspec:\n  k: v"),
@@ -305,22 +305,16 @@ func TestProject_Load_WithSubstitutor(t *testing.T) {
 			},
 		},
 		{
-			// Mixed batch: clean spec must still parse and reach Specs(), errored one is skipped.
-			name:        "mixed clean and errored specs",
+			// Substitution is all-or-nothing: a single failed spec aborts the
+			// pass before any spec is parsed, so no specs reach Specs().
+			name:        "mixed clean and errored specs short-circuits before parsing",
 			substitutor: varsubst.NewSubstitutor(mapResolver{"NAME": "clean_name"}),
 			rawSpecs: map[string][]byte{
 				"path/to/clean.yaml":   []byte("kind: Source\nversion: rudder/0.1\nmetadata:\n  name: {{ .NAME }}\nspec:\n  k: v"),
 				"path/to/errored.yaml": []byte("kind: Source\nversion: rudder/0.1\nmetadata:\n  name: {{ .MISSING }}\nspec:\n  k: v"),
 			},
-			wantErr: "syntax validation failed",
-			wantSpecs: map[string]*specs.Spec{
-				"path/to/clean.yaml": {
-					Kind:     "Source",
-					Version:  "rudder/0.1",
-					Metadata: map[string]any{"name": "clean_name"},
-					Spec:     map[string]any{"k": "v"},
-				},
-			},
+			wantErr:   "syntax validation failed",
+			wantSpecs: map[string]*specs.Spec{},
 		},
 	}
 

--- a/cli/internal/project/project_test.go
+++ b/cli/internal/project/project_test.go
@@ -12,7 +12,17 @@ import (
 	"github.com/rudderlabs/rudder-iac/cli/internal/project/specs"
 	"github.com/rudderlabs/rudder-iac/cli/internal/resources"
 	"github.com/rudderlabs/rudder-iac/cli/internal/testutils"
+	"github.com/rudderlabs/rudder-iac/cli/internal/varsubst"
 )
+
+// mapResolver is a tiny in-memory varsubst.Resolver used to drive substitution
+// from test cases without depending on env vars or files.
+type mapResolver map[string]string
+
+func (m mapResolver) Resolve(name string) (string, bool) {
+	v, ok := m[name]
+	return v, ok
+}
 
 // MockLoader is a mock implementation of the project.Loader interface for testing.
 type MockLoader struct {
@@ -225,6 +235,123 @@ func TestProject_LoadSpec_VersionRouting(t *testing.T) {
 				tc.expectLoadLegacySpecCalled,
 				loadLegacySpecCalled,
 				"LoadLegacySpec called mismatch: expected %v, got %v", tc.expectLoadLegacySpecCalled, loadLegacySpecCalled)
+		})
+	}
+}
+
+func TestProject_Load_WithSubstitutor(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name        string
+		substitutor varsubst.Substitutor
+		rawSpecs    map[string][]byte
+		wantErr     string // empty when Load should succeed
+		wantSpecs   map[string]*specs.Spec
+	}{
+		{
+			name:        "resolves variables in metadata",
+			substitutor: varsubst.NewSubstitutor(mapResolver{"NAME": "resolved_name"}),
+			rawSpecs: map[string][]byte{
+				"path/to/spec.yaml": []byte("kind: Source\nversion: rudder/0.1\nmetadata:\n  name: {{ .NAME }}\nspec:\n  k: v"),
+			},
+			wantSpecs: map[string]*specs.Spec{
+				"path/to/spec.yaml": {
+					Kind:     "Source",
+					Version:  "rudder/0.1",
+					Metadata: map[string]any{"name": "resolved_name"},
+					Spec:     map[string]any{"k": "v"},
+				},
+			},
+		},
+		{
+			// Bare 5432 (no surrounding quotes in the spec) parses as int after substitution.
+			name:        "preserves non-string scalar type",
+			substitutor: varsubst.NewSubstitutor(mapResolver{"PORT": "5432"}),
+			rawSpecs: map[string][]byte{
+				"path/to/spec.yaml": []byte("kind: Source\nversion: rudder/0.1\nmetadata:\n  name: db\nspec:\n  port: {{ .PORT }}"),
+			},
+			wantSpecs: map[string]*specs.Spec{
+				"path/to/spec.yaml": {
+					Kind:     "Source",
+					Version:  "rudder/0.1",
+					Metadata: map[string]any{"name": "db"},
+					Spec:     map[string]any{"port": 5432},
+				},
+			},
+		},
+		{
+			name:        "undefined variable excludes spec and fails load",
+			substitutor: varsubst.NewSubstitutor(mapResolver{}),
+			rawSpecs: map[string][]byte{
+				"path/to/spec.yaml": []byte("kind: Source\nversion: rudder/0.1\nmetadata:\n  name: {{ .MISSING }}\nspec:\n  k: v"),
+			},
+			wantErr:   "syntax validation failed",
+			wantSpecs: map[string]*specs.Spec{},
+		},
+		{
+			name:        "nil substitutor leaves spec untouched",
+			substitutor: nil,
+			rawSpecs: map[string][]byte{
+				"path/to/spec.yaml": []byte("kind: Source\nversion: rudder/0.1\nmetadata:\n  name: literal\nspec:\n  k: \"{{ .v }}\""),
+			},
+			wantSpecs: map[string]*specs.Spec{
+				"path/to/spec.yaml": {
+					Kind:     "Source",
+					Version:  "rudder/0.1",
+					Metadata: map[string]any{"name": "literal"},
+					Spec:     map[string]any{"k": "{{ .v }}"},
+				},
+			},
+		},
+		{
+			// Mixed batch: clean spec must still parse and reach Specs(), errored one is skipped.
+			name:        "mixed clean and errored specs",
+			substitutor: varsubst.NewSubstitutor(mapResolver{"NAME": "clean_name"}),
+			rawSpecs: map[string][]byte{
+				"path/to/clean.yaml":   []byte("kind: Source\nversion: rudder/0.1\nmetadata:\n  name: {{ .NAME }}\nspec:\n  k: v"),
+				"path/to/errored.yaml": []byte("kind: Source\nversion: rudder/0.1\nmetadata:\n  name: {{ .MISSING }}\nspec:\n  k: v"),
+			},
+			wantErr: "syntax validation failed",
+			wantSpecs: map[string]*specs.Spec{
+				"path/to/clean.yaml": {
+					Kind:     "Source",
+					Version:  "rudder/0.1",
+					Metadata: map[string]any{"name": "clean_name"},
+					Spec:     map[string]any{"k": "v"},
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			mockProvider := testutils.NewMockProvider(nil, nil)
+			mockLoader := &MockLoader{LoadFunc: func(string) (map[string]*specs.RawSpec, error) {
+				raw := make(map[string]*specs.RawSpec, len(tc.rawSpecs))
+				for path, data := range tc.rawSpecs {
+					raw[path] = &specs.RawSpec{Data: data}
+				}
+				return raw, nil
+			}}
+
+			proj := project.New(mockProvider,
+				project.WithLoader(mockLoader),
+				project.WithSubstitutor(tc.substitutor),
+			)
+
+			err := proj.Load("test_dir")
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+
+			assert.Equal(t, tc.wantSpecs, proj.Specs())
 		})
 	}
 }

--- a/cli/internal/project/project_test.go
+++ b/cli/internal/project/project_test.go
@@ -286,7 +286,7 @@ func TestProject_Load_WithSubstitutor(t *testing.T) {
 			rawSpecs: map[string][]byte{
 				"path/to/spec.yaml": []byte("kind: Source\nversion: rudder/0.1\nmetadata:\n  name: {{ .MISSING }}\nspec:\n  k: v"),
 			},
-			wantErr:   "syntax validation failed",
+			wantErr:   "variable substitution failed",
 			wantSpecs: map[string]*specs.Spec{},
 		},
 		{
@@ -313,7 +313,7 @@ func TestProject_Load_WithSubstitutor(t *testing.T) {
 				"path/to/clean.yaml":   []byte("kind: Source\nversion: rudder/0.1\nmetadata:\n  name: {{ .NAME }}\nspec:\n  k: v"),
 				"path/to/errored.yaml": []byte("kind: Source\nversion: rudder/0.1\nmetadata:\n  name: {{ .MISSING }}\nspec:\n  k: v"),
 			},
-			wantErr:   "syntax validation failed",
+			wantErr:   "variable substitution failed",
 			wantSpecs: map[string]*specs.Spec{},
 		},
 	}

--- a/cli/internal/project/utils.go
+++ b/cli/internal/project/utils.go
@@ -1,0 +1,31 @@
+package project
+
+import (
+	"fmt"
+
+	"github.com/rudderlabs/rudder-iac/cli/internal/validation"
+	"github.com/rudderlabs/rudder-iac/cli/internal/validation/pathindex"
+	"github.com/rudderlabs/rudder-iac/cli/internal/validation/rules"
+	"github.com/rudderlabs/rudder-iac/cli/internal/varsubst"
+)
+
+// substitutionDiagnostics converts variable-substitution errors into project
+// validation diagnostics. Lives here (not in varsubst) so the substitution
+// engine stays free of any dependency on the validation/diagnostics layer.
+func substitutionDiagnostics(filePath string, errs []varsubst.SubstitutionError) validation.Diagnostics {
+	diagnostics := make(validation.Diagnostics, 0, len(errs))
+	for _, e := range errs {
+		diagnostics = append(diagnostics, validation.Diagnostic{
+			RuleID:   "project/var-substitution",
+			Severity: rules.Error,
+			Message:  fmt.Sprintf("%s %q", e.Err, e.Name),
+			File:     filePath,
+			Position: pathindex.Position{
+				Line:     e.Line,
+				Column:   e.Column,
+				LineText: e.LineText,
+			},
+		})
+	}
+	return diagnostics
+}

--- a/cli/internal/project/utils_test.go
+++ b/cli/internal/project/utils_test.go
@@ -1,0 +1,76 @@
+package project
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/rudderlabs/rudder-iac/cli/internal/validation"
+	"github.com/rudderlabs/rudder-iac/cli/internal/validation/pathindex"
+	"github.com/rudderlabs/rudder-iac/cli/internal/validation/rules"
+	"github.com/rudderlabs/rudder-iac/cli/internal/varsubst"
+)
+
+func TestSubstitutionDiagnostics(t *testing.T) {
+	errs := []varsubst.SubstitutionError{
+		{
+			Name:     "DB_PASSWORD",
+			Line:     8,
+			Column:   15,
+			LineText: "    password: {{ .DB_PASSWORD }}",
+			Err:      varsubst.ErrUndefinedVariable,
+		},
+		{
+			Name:     "9PORT",
+			Line:     5,
+			Column:   11,
+			LineText: "    port: {{ .9PORT }}",
+			Err:      varsubst.ErrInvalidVarSyntax,
+		},
+		{
+			Name:     "VAR",
+			Line:     10,
+			Column:   11,
+			LineText: "    value: {{ VAR }}",
+			Err:      varsubst.ErrInvalidVarSyntax,
+		},
+	}
+
+	got := substitutionDiagnostics("specs/dest.yaml", errs)
+
+	assert.Equal(t, validation.Diagnostics{
+		{
+			RuleID:   "project/var-substitution",
+			Severity: rules.Error,
+			Message:  `undefined variable "DB_PASSWORD"`,
+			File:     "specs/dest.yaml",
+			Position: pathindex.Position{
+				Line:     8,
+				Column:   15,
+				LineText: "    password: {{ .DB_PASSWORD }}",
+			},
+		},
+		{
+			RuleID:   "project/var-substitution",
+			Severity: rules.Error,
+			Message:  `invalid variable syntax "9PORT"`,
+			File:     "specs/dest.yaml",
+			Position: pathindex.Position{
+				Line:     5,
+				Column:   11,
+				LineText: "    port: {{ .9PORT }}",
+			},
+		},
+		{
+			RuleID:   "project/var-substitution",
+			Severity: rules.Error,
+			Message:  `invalid variable syntax "VAR"`,
+			File:     "specs/dest.yaml",
+			Position: pathindex.Position{
+				Line:     10,
+				Column:   11,
+				LineText: "    value: {{ VAR }}",
+			},
+		},
+	}, got)
+}

--- a/cli/internal/varsubst/substitutor.go
+++ b/cli/internal/varsubst/substitutor.go
@@ -1,14 +1,9 @@
 package varsubst
 
 import (
-	"fmt"
 	"regexp"
 	"slices"
 	"strings"
-
-	"github.com/rudderlabs/rudder-iac/cli/internal/validation"
-	"github.com/rudderlabs/rudder-iac/cli/internal/validation/pathindex"
-	"github.com/rudderlabs/rudder-iac/cli/internal/validation/rules"
 )
 
 type Resolver interface {
@@ -268,20 +263,3 @@ func computePositions(original []byte, rawErrors []rawError) []SubstitutionError
 	return result
 }
 
-func ToDiagnostics(filePath string, errs []SubstitutionError) validation.Diagnostics {
-	diagnostics := make(validation.Diagnostics, 0, len(errs))
-	for _, e := range errs {
-		diagnostics = append(diagnostics, validation.Diagnostic{
-			RuleID:   "project/var-substitution",
-			Severity: rules.Error,
-			Message:  fmt.Sprintf("%s %q", e.Err, e.Name),
-			File:     filePath,
-			Position: pathindex.Position{
-				Line:     e.Line,
-				Column:   e.Column,
-				LineText: e.LineText,
-			},
-		})
-	}
-	return diagnostics
-}

--- a/cli/internal/varsubst/substitutor_test.go
+++ b/cli/internal/varsubst/substitutor_test.go
@@ -4,10 +4,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
-	"github.com/rudderlabs/rudder-iac/cli/internal/validation"
-	"github.com/rudderlabs/rudder-iac/cli/internal/validation/pathindex"
-	"github.com/rudderlabs/rudder-iac/cli/internal/validation/rules"
 )
 
 type mapResolver map[string]string
@@ -273,66 +269,3 @@ func TestSubstituteBytes_ErrorPositions(t *testing.T) {
 	}
 }
 
-func TestToDiagnostics(t *testing.T) {
-	errs := []SubstitutionError{
-		{
-			Name:     "DB_PASSWORD",
-			Line:     8,
-			Column:   15,
-			LineText: "    password: {{ .DB_PASSWORD }}",
-			Err:      ErrUndefinedVariable,
-		},
-		{
-			Name:     "9PORT",
-			Line:     5,
-			Column:   11,
-			LineText: "    port: {{ .9PORT }}",
-			Err:      ErrInvalidVarSyntax,
-		},
-		{
-			Name:     "VAR",
-			Line:     10,
-			Column:   11,
-			LineText: "    value: {{ VAR }}",
-			Err:      ErrInvalidVarSyntax,
-		},
-	}
-
-	got := ToDiagnostics("specs/dest.yaml", errs)
-
-	assert.Equal(t, validation.Diagnostics{
-		{
-			RuleID:   "project/var-substitution",
-			Severity: rules.Error,
-			Message:  `undefined variable "DB_PASSWORD"`,
-			File:     "specs/dest.yaml",
-			Position: pathindex.Position{
-				Line:     8,
-				Column:   15,
-				LineText: "    password: {{ .DB_PASSWORD }}",
-			},
-		},
-		{
-			RuleID:   "project/var-substitution",
-			Severity: rules.Error,
-			Message:  `invalid variable syntax "9PORT"`,
-			File:     "specs/dest.yaml",
-			Position: pathindex.Position{
-				Line:     5,
-				Column:   11,
-				LineText: "    port: {{ .9PORT }}",
-			},
-		},
-		{
-			RuleID:   "project/var-substitution",
-			Severity: rules.Error,
-			Message:  `invalid variable syntax "VAR"`,
-			File:     "specs/dest.yaml",
-			Position: pathindex.Position{
-				Line:     10,
-				Column:   11,
-				LineText: "    value: {{ VAR }}",
-			},
-		},
-	}, got)
-}


### PR DESCRIPTION
## 🔗 Ticket

Resolves [DEX-361](https://linear.app/rudderstack/issue/DEX-361/project-integration-withsubstitutor-option-and-parsespecs-changes)

---

## Summary

Connects the `varsubst.Substitutor` engine (DEX-358/359/360) to the project loading pipeline. When a substitutor is configured, raw spec bytes pass through `SubstituteBytes` before `yaml.Decode`; any resolution errors surface as `validation.Diagnostics` and the offending spec is skipped. When no substitutor is provided (the existing default), behavior is identical to today.

Stacked PR — targets `feature/dex-360-...` so the diff stays scoped to DEX-361. Retarget to `main` once DEX-360 merges.

---

## Changes

- Add `project.WithSubstitutor(varsubst.Substitutor) ProjectOption` and a `substitutor` field on the project struct.
- In `parseSpecs`, run substitution before `RawSpec.Parse()`; on errors, convert via `varsubst.ToDiagnostics` and skip the spec; on success, build a fresh `RawSpec` to avoid leaving stale `parsed`/`pathIndex` cache on the original.
- Change `app.Deps.NewProject` to `NewProject(opts ...project.ProjectOption)` — backwards-compatible variadic; existing zero-arg callers unaffected.

---

## Testing

- Unit / integration tests at the project layer (`TestProject_Load_WithSubstitutor`) covering: variable resolution, non-string scalar type preservation (`port: 5432` parsed as int), undefined-variable diagnostic and spec exclusion, nil-substitutor unchanged behavior, mixed batch where the clean spec still loads despite an errored sibling.
- `make lint` clean, `make test` passes.

---

## Risk / Impact

Low. Feature is opt-in via `WithSubstitutor`; nil substitutor keeps existing call paths byte-identical.

---

## Checklist

- [x] Ticket linked
- [x] Tests added/updated
- [x] No breaking changes (or documented)