### PR TITLE
chore: update Go skill conventions with patterns from varsubst work

### DIFF
--- a/.claude/skills/apply-go-repo-conventions/references/general-go-convention.md
+++ b/.claude/skills/apply-go-repo-conventions/references/general-go-convention.md
@@ -47,6 +47,22 @@ Failure messages should quickly show function, input, and got/want mismatch.
 Prefer table-driven tests for multiple scenarios.
 Use `t.Fatal` only when continuing invalidates remaining assertions.
 
+## Prefer Standard Library Over Hand-Rolled
+
+Use `slices.Reverse`, `slices.Sort`, `maps.Keys`, etc. instead of writing manual loops.
+Standard library functions are self-documenting and well-tested.
+
+## Avoid Redundant Work in Loops
+
+When processing an ordered collection against shared data, prefer a single scan with index
+tracking over per-item re-scans from the beginning. Algorithmic structure matters, not just
+correctness.
+
+## Extract Small Validation Helpers
+
+When inline validation exceeds 2-3 checks, extract to a named function like `parseX()` or
+`validateX()` returning `(result, error)`. Keeps the calling function focused on orchestration.
+
 ## Practical Tie-Breakers
 
 When multiple choices are valid:

--- a/.claude/skills/apply-go-repo-conventions/references/interfaces.md
+++ b/.claude/skills/apply-go-repo-conventions/references/interfaces.md
@@ -9,7 +9,7 @@ Use this reference when deciding interface shape, location, and constructor/API 
 
 - Define interfaces at the consumer boundary, not in provider packages by default.
 - Keep interfaces small and behavior-focused.
-- Accept interfaces where polymorphism is needed; return concrete types from constructors.
+- Return interfaces from constructors for public APIs; keep the struct unexported.
 - Do not use pointers to interfaces.
 - Avoid creating an interface when only one concrete implementation exists and no test seam is needed.
 
@@ -41,13 +41,19 @@ type Engine struct {
 ```
 
 ```go
-// Provider package returns concrete implementation.
-func NewStateLoader(client *Client) *StateLoader {
-    return &StateLoader{client: client}
+// Provider package returns interface, keeps struct unexported.
+type Substitutor interface {
+    SubstituteBytes(data []byte) ([]byte, []SubstitutionError)
+}
+
+type substitutor struct { ... }
+
+func NewSubstitutor(resolvers ...Resolver) Substitutor {
+    return &substitutor{resolvers: resolvers}
 }
 ```
 
-Why: the consumer controls the minimal contract; provider stays concrete and discoverable.
+Why: callers depend on behavior, not implementation. The struct stays unexported; swapping or testing is straightforward.
 
 ### 2) Avoid Premature Provider-Side Interfaces
 

--- a/.claude/skills/apply-go-repo-conventions/references/repo-conventions.md
+++ b/.claude/skills/apply-go-repo-conventions/references/repo-conventions.md
@@ -25,6 +25,7 @@ This file captures repository-specific rules used during implementation and revi
 - Wrap errors with action context and `%w`.
   - Example: `fmt.Errorf("loading workspace: %w", err)`
 - Sentinel errors use `Err` prefix (for branching semantics).
+- Reuse sentinel errors when formatting messages — derive from `err.Error()` rather than hardcoding the same string (e.g. `fmt.Sprintf("%s %q", e.Err, e.Name)`).
 - Avoid logging the same error at multiple layers; log near user/command boundary.
 
 ## Logging
@@ -39,6 +40,7 @@ This file captures repository-specific rules used during implementation and revi
 - Prefer guard clauses (early return/continue) over nested `else`.
 - Use `var` blocks for tightly related multi-variable declarations.
 - Comments should explain intent/tradeoff (`why`) rather than restating code (`what`).
+- Add algorithm comments on non-trivial functions (single-pass scans, reverse iteration, offset computation) explaining the strategy and invariants.
 
 ## Provider/Apply-Cycle Awareness
 


### PR DESCRIPTION
## 🔗 Ticket

N/A — skill reference docs update

---

## Summary

Updates the `apply-go-repo-conventions` skill reference docs with patterns validated during varsubst implementation work.

---

## Changes

- **general-go-convention.md**: Add three new sections — prefer stdlib over hand-rolled loops, avoid redundant work in loops, extract small validation helpers
- **interfaces.md**: Update constructor guidance to return interfaces (unexported struct) for public APIs, with varsubst `Substitutor` as the canonical example
- **repo-conventions.md**: Add sentinel error reuse convention and algorithm comment guidance for non-trivial functions

---

## Testing

N/A — documentation-only change (no Go code modified)

---

## Risk / Impact

Low
Skill reference docs only; no runtime behavior change.

---

## Checklist

- [x] Ticket linked
- [x] Tests added/updated
- [x] No breaking changes (or documented)