### PR TITLE
feat(cli): wire --var-file flag and experimental gate for variable substitution (DEX-362)

### DIFF
--- a/cli/internal/app/options.go
+++ b/cli/internal/app/options.go
@@ -1,0 +1,49 @@
+package app
+
+import (
+	"fmt"
+
+	"github.com/rudderlabs/rudder-iac/cli/internal/config"
+	"github.com/rudderlabs/rudder-iac/cli/internal/project"
+	"github.com/rudderlabs/rudder-iac/cli/internal/varsubst"
+	"github.com/rudderlabs/rudder-iac/cli/internal/varsubst/resolver"
+)
+
+// NewProjectOptions assembles the project options that should be applied to
+// every project created via Deps.NewProject. Each capability is gated by its
+// own experimental flag in cfg; when a flag is off, the related option is
+// omitted entirely. Additional capabilities should be wired in here so all
+// command call sites pick them up uniformly.
+func NewProjectOptions(cfg config.Config, varFiles []string) ([]project.ProjectOption, error) {
+	var opts []project.ProjectOption
+
+	if cfg.ExperimentalFlags.EnableVarSubstitution {
+		sub, err := buildSubstitutor(varFiles)
+		if err != nil {
+			return nil, err
+		}
+		opts = append(opts, project.WithSubstitutor(sub))
+	}
+
+	return opts, nil
+}
+
+// buildSubstitutor wires the standard resolver chain: env resolver first
+// (highest priority), then a FileResolver per varFile in the order provided.
+func buildSubstitutor(varFiles []string) (varsubst.Substitutor, error) {
+	envR, err := resolver.NewEnvResolver()
+	if err != nil {
+		return nil, fmt.Errorf("initialising env resolver: %w", err)
+	}
+
+	resolvers := []varsubst.Resolver{envR}
+	for _, path := range varFiles {
+		r, err := resolver.NewFileResolver(path)
+		if err != nil {
+			return nil, fmt.Errorf("initialising file resolver: %w", err)
+		}
+		resolvers = append(resolvers, r)
+	}
+
+	return varsubst.NewSubstitutor(resolvers...), nil
+}

--- a/cli/internal/app/options_test.go
+++ b/cli/internal/app/options_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/rudderlabs/rudder-iac/cli/internal/config"
-	"github.com/rudderlabs/rudder-iac/cli/internal/varsubst"
+	"github.com/rudderlabs/rudder-iac/cli/internal/varsubst/resolver"
 )
 
 func setExperimental(t *testing.T, enabled bool) {
@@ -65,7 +65,7 @@ func TestNewProjectOptions(t *testing.T) {
 		opts, err := NewProjectOptions(config.GetConfig(), []string{path})
 		require.Error(t, err)
 		assert.Nil(t, opts)
-		assert.ErrorIs(t, err, varsubst.ErrVarFileNotFound)
+		assert.ErrorIs(t, err, resolver.ErrVarFileNotFound)
 	})
 
 	t.Run("invalid var file surfaces ErrVarFileParseFailed", func(t *testing.T) {
@@ -75,7 +75,7 @@ func TestNewProjectOptions(t *testing.T) {
 		opts, err := NewProjectOptions(config.GetConfig(), []string{path})
 		require.Error(t, err)
 		assert.Nil(t, opts)
-		assert.ErrorIs(t, err, varsubst.ErrVarFileParseFailed)
+		assert.ErrorIs(t, err, resolver.ErrVarFileParseFailed)
 	})
 }
 

--- a/cli/internal/app/options_test.go
+++ b/cli/internal/app/options_test.go
@@ -1,0 +1,131 @@
+package app
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/rudderlabs/rudder-iac/cli/internal/config"
+	"github.com/rudderlabs/rudder-iac/cli/internal/varsubst"
+)
+
+func setExperimental(t *testing.T, enabled bool) {
+	t.Helper()
+	prevExp := viper.Get("experimental")
+	prevFlag := viper.Get("flags.enableVarSubstitution")
+	viper.Set("experimental", enabled)
+	viper.Set("flags.enableVarSubstitution", enabled)
+	t.Cleanup(func() {
+		viper.Set("experimental", prevExp)
+		viper.Set("flags.enableVarSubstitution", prevFlag)
+	})
+}
+
+func writeVarFile(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "vars.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(content), 0644))
+	return path
+}
+
+func TestNewProjectOptions(t *testing.T) {
+	t.Run("flag disabled returns no options", func(t *testing.T) {
+		setExperimental(t, false)
+
+		opts, err := NewProjectOptions(config.GetConfig(), []string{"/does/not/matter"})
+		require.NoError(t, err)
+		assert.Nil(t, opts)
+	})
+
+	t.Run("flag enabled with no var files wires substitutor", func(t *testing.T) {
+		setExperimental(t, true)
+
+		opts, err := NewProjectOptions(config.GetConfig(), nil)
+		require.NoError(t, err)
+		assert.Len(t, opts, 1)
+	})
+
+	t.Run("flag enabled with var file wires substitutor", func(t *testing.T) {
+		setExperimental(t, true)
+		path := writeVarFile(t, "FOO: bar")
+
+		opts, err := NewProjectOptions(config.GetConfig(), []string{path})
+		require.NoError(t, err)
+		assert.Len(t, opts, 1)
+	})
+
+	t.Run("missing var file surfaces ErrVarFileNotFound", func(t *testing.T) {
+		setExperimental(t, true)
+		path := filepath.Join(t.TempDir(), "missing.yaml")
+
+		opts, err := NewProjectOptions(config.GetConfig(), []string{path})
+		require.Error(t, err)
+		assert.Nil(t, opts)
+		assert.ErrorIs(t, err, varsubst.ErrVarFileNotFound)
+	})
+
+	t.Run("invalid var file surfaces ErrVarFileParseFailed", func(t *testing.T) {
+		setExperimental(t, true)
+		path := writeVarFile(t, "{{ not yaml")
+
+		opts, err := NewProjectOptions(config.GetConfig(), []string{path})
+		require.Error(t, err)
+		assert.Nil(t, opts)
+		assert.ErrorIs(t, err, varsubst.ErrVarFileParseFailed)
+	})
+}
+
+func TestBuildSubstitutor_ResolverChain(t *testing.T) {
+	t.Run("env resolver is always wired (no var files)", func(t *testing.T) {
+		t.Setenv("RUDDER_GREETING", "hello")
+
+		sub, err := buildSubstitutor(nil)
+		require.NoError(t, err)
+
+		got, errs := sub.SubstituteBytes([]byte(`{{ .GREETING }}`))
+		require.Empty(t, errs)
+		assert.Equal(t, "hello", string(got))
+	})
+
+	t.Run("env resolver takes priority over file resolver", func(t *testing.T) {
+		t.Setenv("RUDDER_NAME", "env-value")
+		path := writeVarFile(t, "NAME: file-value")
+
+		sub, err := buildSubstitutor([]string{path})
+		require.NoError(t, err)
+
+		got, errs := sub.SubstituteBytes([]byte(`{{ .NAME }}`))
+		require.Empty(t, errs)
+		assert.Equal(t, "env-value", string(got))
+	})
+
+	t.Run("earlier var file wins over later var file", func(t *testing.T) {
+		dir := t.TempDir()
+		path1 := filepath.Join(dir, "first.yaml")
+		path2 := filepath.Join(dir, "second.yaml")
+		require.NoError(t, os.WriteFile(path1, []byte("X: first"), 0644))
+		require.NoError(t, os.WriteFile(path2, []byte("X: second"), 0644))
+
+		sub, err := buildSubstitutor([]string{path1, path2})
+		require.NoError(t, err)
+
+		got, errs := sub.SubstituteBytes([]byte(`{{ .X }}`))
+		require.Empty(t, errs)
+		assert.Equal(t, "first", string(got))
+	})
+
+	t.Run("file resolver supplies values not in env", func(t *testing.T) {
+		path := writeVarFile(t, "DB_HOST: db.example.com")
+
+		sub, err := buildSubstitutor([]string{path})
+		require.NoError(t, err)
+
+		got, errs := sub.SubstituteBytes([]byte(`{{ .DB_HOST }}`))
+		require.Empty(t, errs)
+		assert.Equal(t, "db.example.com", string(got))
+	})
+}

--- a/cli/internal/cmd/project/apply/apply.go
+++ b/cli/internal/cmd/project/apply/apply.go
@@ -30,6 +30,7 @@ func NewCmdApply() *cobra.Command {
 		location string
 		dryRun   bool
 		confirm  bool
+		varFiles []string
 	)
 
 	cmd := &cobra.Command{
@@ -51,7 +52,12 @@ func NewCmdApply() *cobra.Command {
 				return fmt.Errorf("initialising dependencies: %w", err)
 			}
 
-			p = deps.NewProject()
+			projectOpts, err := app.NewProjectOptions(config.GetConfig(), varFiles)
+			if err != nil {
+				return err
+			}
+
+			p = deps.NewProject(projectOpts...)
 
 			// Load and validate the project configuration
 			if err := p.Load(location); err != nil {
@@ -122,6 +128,7 @@ func NewCmdApply() *cobra.Command {
 	cmd.Flags().StringVarP(&location, "location", "l", ".", "Path to the directory containing the project files or a specific file")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Only show the changes without applying them")
 	cmd.Flags().BoolVar(&confirm, "confirm", true, "Confirm changes before applying them")
+	cmd.Flags().StringArrayVar(&varFiles, "var-file", nil, "Path to a YAML file with variables for substitution (repeatable; earlier files take priority)")
 
 	return cmd
 }

--- a/cli/internal/cmd/project/validate/validate.go
+++ b/cli/internal/cmd/project/validate/validate.go
@@ -6,6 +6,7 @@ import (
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/rudderlabs/rudder-iac/cli/internal/app"
 	"github.com/rudderlabs/rudder-iac/cli/internal/cmd/telemetry"
+	"github.com/rudderlabs/rudder-iac/cli/internal/config"
 	"github.com/rudderlabs/rudder-iac/cli/internal/logger"
 	"github.com/rudderlabs/rudder-iac/cli/internal/project"
 	"github.com/rudderlabs/rudder-iac/cli/internal/ui"
@@ -25,6 +26,7 @@ func NewCmdValidate() *cobra.Command {
 		p        project.Project
 		err      error
 		location string
+		varFiles []string
 	)
 
 	cmd := &cobra.Command{
@@ -44,7 +46,12 @@ func NewCmdValidate() *cobra.Command {
 				return fmt.Errorf("initialising dependencies: %w", err)
 			}
 
-			p = deps.NewProject()
+			projectOpts, err := app.NewProjectOptions(config.GetConfig(), varFiles)
+			if err != nil {
+				return err
+			}
+
+			p = deps.NewProject(projectOpts...)
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -72,5 +79,6 @@ func NewCmdValidate() *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&location, "location", "l", ".", "Path to the directory containing the project files or a specific file")
+	cmd.Flags().StringArrayVar(&varFiles, "var-file", nil, "Path to a YAML file with variables for substitution (repeatable; earlier files take priority)")
 	return cmd
 }

--- a/cli/internal/config/experimental.go
+++ b/cli/internal/config/experimental.go
@@ -22,6 +22,8 @@ type ExperimentalConfig struct {
 	DataGraph bool `mapstructure:"dataGraph"`
 	// EventRuleIncludes enables including event rules from other tracking plans
 	EventRuleIncludes bool `mapstructure:"eventRuleIncludes"`
+	// EnableVarSubstitution enables variable substitution in project specs via --var-file and RUDDER_* env vars
+	EnableVarSubstitution bool `mapstructure:"enableVarSubstitution"`
 }
 
 // getAvailableExperimentalFlags returns information about all available experimental flags


### PR DESCRIPTION
## 🔗 Ticket

Resolves [DEX-362](https://linear.app/rudderstack/issue/DEX-362/cli-wiring-var-file-flag-experimental-gate-and-prerune-setup)

---

## Summary

Adds the user-facing entry point for variable substitution: a repeatable `--var-file` flag on `apply` and `validate`, plus a new `enableVarSubstitution` experimental flag that gates the whole mechanism. When the flag is off (default), behaviour is identical to today.

---

## Changes

- `config`: add `enableVarSubstitution` experimental flag (env `RUDDERSTACK_X_ENABLE_VAR_SUBSTITUTION`)
- `app`: add `NewProjectOptions(cfg, varFiles)` that assembles `[]project.ProjectOption` — currently wires the substitutor (`EnvResolver` first, then a `FileResolver` per `--var-file` in order) when the experimental flag is on; designed so future capabilities slot in alongside it
- `apply`, `validate`: register `--var-file` (`StringArrayVar`) and pass the assembled options to `deps.NewProject`
- **Deviation from ticket**: `migrate` deliberately does **not** get `--var-file`. Migration writes the loaded project back to disk, so substituting at load time would silently strip the user's template variables from the migrated YAML — almost certainly not the intended outcome for someone migrating a templated v0.1 project. Open to revisiting if migrate gains a "preserve templates" pathway later.
- `destroy` correctly remains untouched — no specs are loaded.

---

## Testing

- Unit tests on `NewProjectOptions`: flag-off short-circuit, flag-on with/without var files, `ErrVarFileNotFound`, `ErrVarFileParseFailed`
- Unit tests on `buildSubstitutor` resolver chain: env always wired, env-over-file priority, earlier-file-over-later-file priority, file resolver supplies values not in env
- `make lint` and `make test` clean

---

## Risk / Impact

Low — feature is gated behind an experimental flag that defaults to off, so the default code path is unchanged.

---

## Checklist

- [x] Ticket linked
- [x] Tests added/updated
- [x] No breaking changes (or documented)