### PR TITLE
chore: add AGENTS.md with Cloud-specific dev environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,24 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Overview
+
+This is a Go CLI tool (`rudder-cli`) for RudderStack Infrastructure-as-Code management. It is a standalone binary that talks to the RudderStack Public API — there are no local databases, message queues, or Docker Compose stacks required for development.
+
+### Quick reference
+
+Standard commands are documented in `CLAUDE.md` and `Makefile`:
+- `make build` — build CLI binary to `bin/rudder-cli`
+- `make lint` — run golangci-lint (gosec)
+- `make test` — unit tests (excludes `cli/tests/`)
+- `make test-e2e` — end-to-end tests (requires `RUDDERSTACK_ACCESS_TOKEN`)
+- `make test-all` — unit + E2E tests
+
+### Gotchas
+
+- **`go.mod` replace directive**: The file contains `replace github.com/rudderlabs/rudder-data-catalog-provider/sdk => ../rudder-data-catalog-provider/sdk` pointing to a sibling repo that does not exist in the workspace. This is safe to ignore — no Go source files import this module, so builds and tests are unaffected.
+- **One unit test requires API credentials**: `cli/pkg/exp/project/project_test.go` (`TestProjectLoad`) fails without `RUDDERSTACK_ACCESS_TOKEN` set. This is an integration-like test that lives outside `cli/tests/`. All other unit tests pass without credentials.
+- **E2E tests need real API access**: Tests in `cli/tests/` require `RUDDERSTACK_ACCESS_TOKEN` and optionally `RUDDERSTACK_API_URL`. They interact with a real RudderStack workspace.
+- **Most CLI commands require auth**: Commands like `validate`, `apply`, `import` need an access token. Use `RUDDERSTACK_ACCESS_TOKEN` env var or `rudder-cli auth login`. The `typer options` command works without auth and is useful for quick smoke-testing the binary.
+- **Go version**: The project requires Go 1.24.0 (specified in `go.mod`). The golangci-lint tool auto-downloads a newer Go toolchain (1.25.x) for itself, which is expected behavior.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 🔗 Ticket

N/A — Development environment setup

---

## Summary

Adds `AGENTS.md` with Cursor Cloud-specific instructions for future cloud agents working on this repository. This file documents non-obvious gotchas and quick-reference commands to help agents set up and work with the codebase without re-discovering known issues each session.

---

## Changes

- Added `AGENTS.md` with a `## Cursor Cloud specific instructions` section covering:
  - Quick reference to standard `make` commands (documented in `CLAUDE.md` / `Makefile`)
  - Gotcha: dormant `replace` directive in `go.mod` for `rudder-data-catalog-provider/sdk`
  - Gotcha: `TestProjectLoad` in `cli/pkg/exp/project` requires `RUDDERSTACK_ACCESS_TOKEN`
  - Gotcha: E2E tests require real API credentials
  - Note on Go version and golangci-lint auto-downloading newer Go toolchain

---

## Testing

- ✅ `make build` — CLI binary builds successfully
- ✅ `make lint` — 0 issues
- ✅ `make test` — all unit tests pass except 1 that requires API credentials (`TestProjectLoad`)
- ✅ `bin/rudder-cli --help` — CLI runs and shows available commands
- ✅ `bin/rudder-cli typer options --platform kotlin` — demonstrates functional output without auth

CLI demo output:
[cli_demo_output.log](https://cursor.com/agents/bc-a6c2f702-4bb4-433a-9ccc-feb237cd94db/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcli_demo_output.log)

---

## Risk / Impact

Low — only adds a new documentation file (`AGENTS.md`), no code changes.

---

## Checklist

- [x] No breaking changes
- [x] Documentation added

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a6c2f702-4bb4-433a-9ccc-feb237cd94db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a6c2f702-4bb4-433a-9ccc-feb237cd94db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

