### PR TITLE
fix(cli): later --var-file overrides earlier (DEX-384)

### DIFF
--- a/cli/internal/app/options.go
+++ b/cli/internal/app/options.go
@@ -29,7 +29,10 @@ func NewProjectOptions(cfg config.Config, varFiles []string) ([]project.ProjectO
 }
 
 // buildSubstitutor wires the standard resolver chain: env resolver first
-// (highest priority), then a FileResolver per varFile in the order provided.
+// (highest priority), then a FileResolver per varFile in reverse order so
+// that a later --var-file overrides values from an earlier one. This matches
+// the layering convention used by helm, kubectl, docker-compose, terraform,
+// etc.: `--var-file base.yaml --var-file overrides.yaml` → overrides wins.
 func buildSubstitutor(varFiles []string) (varsubst.Substitutor, error) {
 	envR, err := resolver.NewEnvResolver()
 	if err != nil {
@@ -37,8 +40,8 @@ func buildSubstitutor(varFiles []string) (varsubst.Substitutor, error) {
 	}
 
 	resolvers := []varsubst.Resolver{envR}
-	for _, path := range varFiles {
-		r, err := resolver.NewFileResolver(path)
+	for i := len(varFiles) - 1; i >= 0; i-- {
+		r, err := resolver.NewFileResolver(varFiles[i])
 		if err != nil {
 			return nil, fmt.Errorf("initialising file resolver: %w", err)
 		}

--- a/cli/internal/app/options_test.go
+++ b/cli/internal/app/options_test.go
@@ -103,7 +103,7 @@ func TestBuildSubstitutor_ResolverChain(t *testing.T) {
 		assert.Equal(t, "env-value", string(got))
 	})
 
-	t.Run("earlier var file wins over later var file", func(t *testing.T) {
+	t.Run("later var file wins over earlier var file", func(t *testing.T) {
 		dir := t.TempDir()
 		path1 := filepath.Join(dir, "first.yaml")
 		path2 := filepath.Join(dir, "second.yaml")
@@ -115,7 +115,7 @@ func TestBuildSubstitutor_ResolverChain(t *testing.T) {
 
 		got, errs := sub.SubstituteBytes([]byte(`{{ .X }}`))
 		require.Empty(t, errs)
-		assert.Equal(t, "first", string(got))
+		assert.Equal(t, "second", string(got))
 	})
 
 	t.Run("file resolver supplies values not in env", func(t *testing.T) {


### PR DESCRIPTION
## 🔗 Ticket

Resolves [DEX-384](https://linear.app/rudderstack/issue/DEX-384/varsubst-later-var-file-should-override-earlier)

---

## Summary

Surfaced by @abhimanyubabbar in review on #594: the resolver chain is first-match-wins, and `buildSubstitutor` appends file resolvers in CLI order, so `--var-file base.yaml --var-file overrides.yaml` keeps `base.yaml` and silently shadows `overrides.yaml` — the opposite of what every comparable tool does.

This PR reverses the iteration so that later `--var-file` flags win, matching `helm --values`, `kubectl -f`, `docker-compose -f`, `terraform -var-file`, and `ansible-playbook --extra-vars`. Env resolver stays at the top of the chain (highest priority unchanged).

---

## Changes

- `buildSubstitutor` iterates `varFiles` in reverse when appending file resolvers
- Doc comment updated to spell out the layering convention and call out the comparable tools
- Test renamed and assertion flipped: "later var file wins over earlier var file"

---

## Testing

- `go test ./cli/internal/app/...` — passes
- `make lint` — clean
- `TestBuildSubstitutor_ResolverChain` still covers env-priority and earlier-vs-later precedence; assertion updated to reflect the new (correct) behaviour

---

## Risk / Impact

Low — behaviour change for users who passed multiple `--var-file` flags with overlapping keys. The feature is still gated behind the `enableVarSubstitution` experimental flag and shipped in the same release as the wiring (DEX-362, just merged), so no released user is affected. The new behaviour is the one users will expect; the old behaviour was the surprise.

---

## Checklist

- [x] Ticket linked
- [x] Tests added/updated
- [x] No breaking changes (or documented)