### PR TITLE
feat(data-graph): colum metadata description

### DIFF
--- a/api/client/datagraph/column_metadata.go
+++ b/api/client/datagraph/column_metadata.go
@@ -7,16 +7,24 @@ import (
 	"fmt"
 )
 
-// ColumnMetadataEntry is a single (name, displayName) pair sent in a batch upsert.
+// ColumnMetadataEntry is a single column-metadata write sent in a batch upsert.
+// DisplayName / Description are pointers so a nil value serializes as JSON `null`
+// (an explicit clear, per the declarative apply contract) rather than being
+// omitted — hence no `omitempty`. A non-nil value sets the field. At least one
+// of the two is non-nil; an empty string is invalid (use null to clear).
 type ColumnMetadataEntry struct {
-	Name        string `json:"name"`
-	DisplayName string `json:"displayName"`
+	Name        string  `json:"name"`
+	DisplayName *string `json:"displayName"`
+	Description *string `json:"description"`
 }
 
-// ColumnMetadataRow is a single (name, displayName) row returned by the API.
+// ColumnMetadataRow is a single column-metadata row returned by the API.
+// displayName / description are omitted by the server when unset, so they
+// unmarshal to the empty string.
 type ColumnMetadataRow struct {
 	Name        string `json:"name"`
-	DisplayName string `json:"displayName"`
+	DisplayName string `json:"displayName,omitempty"`
+	Description string `json:"description,omitempty"`
 }
 
 // ColumnMetadataListResponse is the response from both List and BatchUpsert.

--- a/api/client/datagraph/column_metadata_test.go
+++ b/api/client/datagraph/column_metadata_test.go
@@ -108,7 +108,7 @@ func TestBatchUpsertColumnMetadata(t *testing.T) {
 			if req.Header.Get("Authorization") != "Bearer test-token" {
 				return false
 			}
-			expected := `{"columns":[{"name":"email","displayName":"Email"},{"name":"user_id","displayName":"User ID"}]}`
+			expected := `{"columns":[{"name":"email","displayName":"Email","description":null},{"name":"user_id","displayName":"User ID","description":null}]}`
 			return testutils.ValidateRequest(t, req, "PATCH", "https://api.rudderstack.com/v2/data-graphs/dg-123/models/em-456/column-metadata", expected)
 		},
 		ResponseStatus: 200,
@@ -128,8 +128,8 @@ func TestBatchUpsertColumnMetadata(t *testing.T) {
 		"em-456",
 		datagraph.BatchUpsertColumnMetadataRequest{
 			Columns: []datagraph.ColumnMetadataEntry{
-				{Name: "email", DisplayName: "Email"},
-				{Name: "user_id", DisplayName: "User ID"},
+				{Name: "email", DisplayName: stringPtr("Email")},
+				{Name: "user_id", DisplayName: stringPtr("User ID")},
 			},
 		},
 	)
@@ -145,6 +145,52 @@ func TestBatchUpsertColumnMetadata(t *testing.T) {
 	httpClient.AssertNumberOfCalls()
 }
 
+// TestBatchUpsertColumnMetadata_Description covers the description field on the
+// wire: a description-only entry sends displayName:null, a both-fields entry
+// sends both, and the response decodes description on the returned rows.
+func TestBatchUpsertColumnMetadata_Description(t *testing.T) {
+	httpClient := testutils.NewMockHTTPClient(t, testutils.Call{
+		Validate: func(req *http.Request) bool {
+			expected := `{"columns":[` +
+				`{"name":"notes","displayName":null,"description":"Free-form notes"},` +
+				`{"name":"user_id","displayName":"User ID","description":"Primary identifier"}` +
+				`]}`
+			return testutils.ValidateRequest(t, req, "PATCH", "https://api.rudderstack.com/v2/data-graphs/dg-123/models/em-456/column-metadata", expected)
+		},
+		ResponseStatus: 200,
+		ResponseBody: `{
+			"columns": [
+				{"name": "notes", "description": "Free-form notes", "updatedAt": "2024-01-15T12:00:00Z"},
+				{"name": "user_id", "displayName": "User ID", "description": "Primary identifier", "updatedAt": "2024-01-15T12:00:00Z"}
+			]
+		}`,
+	})
+
+	store := newTestStore(t, httpClient)
+
+	result, err := store.BatchUpsertColumnMetadata(
+		context.Background(),
+		"dg-123",
+		"em-456",
+		datagraph.BatchUpsertColumnMetadataRequest{
+			Columns: []datagraph.ColumnMetadataEntry{
+				{Name: "notes", DisplayName: nil, Description: stringPtr("Free-form notes")},
+				{Name: "user_id", DisplayName: stringPtr("User ID"), Description: stringPtr("Primary identifier")},
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, &datagraph.ColumnMetadataListResponse{
+		Columns: []datagraph.ColumnMetadataRow{
+			{Name: "notes", Description: "Free-form notes"},
+			{Name: "user_id", DisplayName: "User ID", Description: "Primary identifier"},
+		},
+	}, result)
+
+	httpClient.AssertNumberOfCalls()
+}
+
 func TestBatchUpsertColumnMetadata_BothColumnsAndDeleteColumns(t *testing.T) {
 	httpClient := testutils.NewMockHTTPClient(t, testutils.Call{
 		Validate: func(req *http.Request) bool {
@@ -152,7 +198,7 @@ func TestBatchUpsertColumnMetadata_BothColumnsAndDeleteColumns(t *testing.T) {
 				return false
 			}
 			expected := `{
-				"columns": [{"name":"user_id","displayName":"User ID"}],
+				"columns": [{"name":"user_id","displayName":"User ID","description":null}],
 				"deleteColumns": ["email","legacy_field"]
 			}`
 			return testutils.ValidateRequest(t, req, "PATCH", "https://api.rudderstack.com/v2/data-graphs/dg-123/models/em-456/column-metadata", expected)
@@ -172,7 +218,7 @@ func TestBatchUpsertColumnMetadata_BothColumnsAndDeleteColumns(t *testing.T) {
 		"dg-123",
 		"em-456",
 		datagraph.BatchUpsertColumnMetadataRequest{
-			Columns:       []datagraph.ColumnMetadataEntry{{Name: "user_id", DisplayName: "User ID"}},
+			Columns:       []datagraph.ColumnMetadataEntry{{Name: "user_id", DisplayName: stringPtr("User ID")}},
 			DeleteColumns: []string{"email", "legacy_field"},
 		},
 	)
@@ -225,7 +271,7 @@ func TestBatchUpsertColumnMetadata_EmptyDataGraphID(t *testing.T) {
 	store := newTestStore(t, httpClient)
 
 	_, err := store.BatchUpsertColumnMetadata(context.Background(), "", "em-456", datagraph.BatchUpsertColumnMetadataRequest{
-		Columns: []datagraph.ColumnMetadataEntry{{Name: "email", DisplayName: "Email"}},
+		Columns: []datagraph.ColumnMetadataEntry{{Name: "email", DisplayName: stringPtr("Email")}},
 	})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "data graph ID cannot be empty")
@@ -236,7 +282,7 @@ func TestBatchUpsertColumnMetadata_EmptyModelID(t *testing.T) {
 	store := newTestStore(t, httpClient)
 
 	_, err := store.BatchUpsertColumnMetadata(context.Background(), "dg-123", "", datagraph.BatchUpsertColumnMetadataRequest{
-		Columns: []datagraph.ColumnMetadataEntry{{Name: "email", DisplayName: "Email"}},
+		Columns: []datagraph.ColumnMetadataEntry{{Name: "email", DisplayName: stringPtr("Email")}},
 	})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "model ID cannot be empty")
@@ -254,7 +300,7 @@ func TestBatchUpsertColumnMetadata_BadRequest(t *testing.T) {
 	store := newTestStore(t, httpClient)
 
 	_, err := store.BatchUpsertColumnMetadata(context.Background(), "dg-123", "em-456", datagraph.BatchUpsertColumnMetadataRequest{
-		Columns: []datagraph.ColumnMetadataEntry{{Name: "email", DisplayName: ""}},
+		Columns: []datagraph.ColumnMetadataEntry{{Name: "email", DisplayName: stringPtr("")}},
 	})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "upserting column metadata")
@@ -274,7 +320,7 @@ func TestBatchUpsertColumnMetadata_NotFound(t *testing.T) {
 	store := newTestStore(t, httpClient)
 
 	_, err := store.BatchUpsertColumnMetadata(context.Background(), "dg-123", "em-456", datagraph.BatchUpsertColumnMetadataRequest{
-		Columns: []datagraph.ColumnMetadataEntry{{Name: "email", DisplayName: "Email"}},
+		Columns: []datagraph.ColumnMetadataEntry{{Name: "email", DisplayName: stringPtr("Email")}},
 	})
 	require.Error(t, err)
 
@@ -297,7 +343,7 @@ func TestBatchUpsertColumnMetadata_ServerError(t *testing.T) {
 	store := newTestStore(t, httpClient)
 
 	_, err := store.BatchUpsertColumnMetadata(context.Background(), "dg-123", "em-456", datagraph.BatchUpsertColumnMetadataRequest{
-		Columns: []datagraph.ColumnMetadataEntry{{Name: "email", DisplayName: "Email"}},
+		Columns: []datagraph.ColumnMetadataEntry{{Name: "email", DisplayName: stringPtr("Email")}},
 	})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "upserting column metadata")

--- a/cli/internal/cmd/datagraph/validate/column_validation_test.go
+++ b/cli/internal/cmd/datagraph/validate/column_validation_test.go
@@ -174,7 +174,7 @@ spec:
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "syntax validation failed")
 
-	assert.Contains(t, out, "'display_name' is required")
+	assert.Contains(t, out, "at least one of 'display_name' or 'description'")
 	assert.Contains(t, out, "Found 1 error(s)")
 }
 

--- a/cli/internal/providers/datagraph/handlers/model/handler.go
+++ b/cli/internal/providers/datagraph/handlers/model/handler.go
@@ -266,6 +266,7 @@ func columnsFromRemote(rows []dgClient.ColumnMetadataRow) []map[string]any {
 		out[i] = map[string]any{
 			"name":         row.Name,
 			"display_name": row.DisplayName,
+			"description":  row.Description,
 		}
 	}
 	return out
@@ -390,10 +391,20 @@ func (h *HandlerImpl) applyColumnMetadata(
 	for _, col := range localColumns {
 		name, _ := col["name"].(string)
 		displayName, _ := col["display_name"].(string)
-		entries = append(entries, dgClient.ColumnMetadataEntry{
-			Name:        name,
-			DisplayName: displayName,
-		})
+		description, _ := col["description"].(string)
+		// Declarative mapping: a field present in yaml is set; a field absent
+		// (empty here) is cleared by sending JSON null (nil pointer). The local
+		// validator guarantees at least one is non-empty.
+		entry := dgClient.ColumnMetadataEntry{Name: name}
+		if displayName != "" {
+			dn := displayName
+			entry.DisplayName = &dn
+		}
+		if description != "" {
+			desc := description
+			entry.Description = &desc
+		}
+		entries = append(entries, entry)
 		if name != "" {
 			localNames[name] = struct{}{}
 		}

--- a/cli/internal/providers/datagraph/handlers/model/handler_test.go
+++ b/cli/internal/providers/datagraph/handlers/model/handler_test.go
@@ -18,6 +18,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func strptr(s string) *string { return &s }
+
 func TestMapRemoteToState(t *testing.T) {
 	mockClient := &testutils.MockDataGraphClient{}
 	h := &HandlerImpl{client: mockClient}
@@ -754,8 +756,8 @@ func TestCreate_BatchUpsertColumnMetadata(t *testing.T) {
 		assert.Equal(t, "em-456", gotModelID)
 		assert.Equal(t, dgClient.BatchUpsertColumnMetadataRequest{
 			Columns: []dgClient.ColumnMetadataEntry{
-				{Name: "id", DisplayName: "User ID"},
-				{Name: "email_address", DisplayName: "Email"},
+				{Name: "id", DisplayName: strptr("User ID")},
+				{Name: "email_address", DisplayName: strptr("Email")},
 			},
 		}, gotReq)
 	})
@@ -845,7 +847,7 @@ func TestUpdate_BatchUpsertColumnMetadata(t *testing.T) {
 		assert.Equal(t, "dg-remote-123", gotDgID)
 		assert.Equal(t, "em-456", gotModelID)
 		assert.Equal(t, dgClient.BatchUpsertColumnMetadataRequest{
-			Columns: []dgClient.ColumnMetadataEntry{{Name: "id", DisplayName: "Customer ID"}},
+			Columns: []dgClient.ColumnMetadataEntry{{Name: "id", DisplayName: strptr("Customer ID")}},
 		}, gotReq)
 	})
 
@@ -931,7 +933,7 @@ func TestUpdate_BatchUpsertColumnMetadata(t *testing.T) {
 
 		assert.Equal(t, 1, upsertCalls)
 		assert.Equal(t, dgClient.BatchUpsertColumnMetadataRequest{
-			Columns:       []dgClient.ColumnMetadataEntry{{Name: "id", DisplayName: "User ID"}},
+			Columns:       []dgClient.ColumnMetadataEntry{{Name: "id", DisplayName: strptr("User ID")}},
 			DeleteColumns: []string{"email"},
 		}, gotReq)
 	})
@@ -968,8 +970,8 @@ func TestUpdate_BatchUpsertColumnMetadata(t *testing.T) {
 
 		assert.Equal(t, dgClient.BatchUpsertColumnMetadataRequest{
 			Columns: []dgClient.ColumnMetadataEntry{
-				{Name: "id", DisplayName: "User ID"},
-				{Name: "phone", DisplayName: "Phone"},
+				{Name: "id", DisplayName: strptr("User ID")},
+				{Name: "phone", DisplayName: strptr("Phone")},
 			},
 			// Sorted alphabetically for deterministic wire payload.
 			DeleteColumns: []string{"email", "legacy_field"},
@@ -1078,8 +1080,8 @@ func TestMapRemoteToState_PopulatesColumns(t *testing.T) {
 		resource, _, err := h.MapRemoteToState(remote, urnResolver)
 		require.NoError(t, err)
 		assert.Equal(t, []map[string]any{
-			{"name": "email", "display_name": "Email"},
-			{"name": "id", "display_name": "User ID"},
+			{"name": "email", "display_name": "Email", "description": ""},
+			{"name": "id", "display_name": "User ID", "description": ""},
 		}, resource.Columns)
 	})
 
@@ -1298,8 +1300,8 @@ func TestRoundTrip_ColumnsIdempotent(t *testing.T) {
 	// the test would flag a (legitimate) diff on column ordering rather than the
 	// idempotency bug under test.
 	localResource.Columns = []map[string]any{
-		{"name": "email", "display_name": "Email"},
-		{"name": "id", "display_name": "User ID"},
+		{"name": "email", "display_name": "Email", "description": ""},
+		{"name": "id", "display_name": "User ID", "description": ""},
 	}
 
 	// 3. Round-trip equality at the diff layer: identical Columns => no diff.

--- a/cli/internal/providers/datagraph/model/datagraph.go
+++ b/cli/internal/providers/datagraph/model/datagraph.go
@@ -39,11 +39,14 @@ type ModelSpec struct {
 }
 
 // ColumnMetadataYAML is one entry in a model's `columns:` block. Constraints
-// match the rudder-api column-metadata contract: required, length-bounded,
-// trimmed, no control characters, and case-insensitively unique within a model.
+// match the rudder-api column-metadata contract: length-bounded, trimmed, no
+// control characters, and (for display_name) case-insensitively unique within a
+// model. Each entry must set at least one of display_name / description — that
+// cross-field rule is enforced by the spec validator, not struct tags.
 type ColumnMetadataYAML struct {
 	Name        string `json:"name" yaml:"name" mapstructure:"name" validate:"required,max=255"`
-	DisplayName string `json:"display_name" yaml:"display_name" mapstructure:"display_name" validate:"required,max=255"`
+	DisplayName string `json:"display_name,omitempty" yaml:"display_name,omitempty" mapstructure:"display_name" validate:"omitempty,max=255"`
+	Description string `json:"description,omitempty" yaml:"description,omitempty" mapstructure:"description" validate:"omitempty,max=255"`
 }
 
 // RelationshipSpec represents configuration for relationships from YAML

--- a/cli/internal/providers/datagraph/provider.go
+++ b/cli/internal/providers/datagraph/provider.go
@@ -257,6 +257,7 @@ func columnsFromSpec(specColumns []dgModel.ColumnMetadataYAML) []map[string]any 
 		out[i] = map[string]any{
 			"name":         c.Name,
 			"display_name": c.DisplayName,
+			"description":  c.Description,
 		}
 	}
 	return out
@@ -552,6 +553,7 @@ func columnsForExport(rows []dgClient.ColumnMetadataRow) []dgModel.ColumnMetadat
 		out[i] = dgModel.ColumnMetadataYAML{
 			Name:        row.Name,
 			DisplayName: row.DisplayName,
+			Description: row.Description,
 		}
 	}
 	return out

--- a/cli/internal/providers/datagraph/provider_test.go
+++ b/cli/internal/providers/datagraph/provider_test.go
@@ -427,8 +427,8 @@ func TestLoadSpec_ColumnsOrderIdempotent(t *testing.T) {
 	// the shape directly here keeps the test self-contained and decoupled
 	// from the unexported handler client field.
 	remoteShapeColumns := []map[string]any{
-		{"name": "email", "display_name": "Email"},
-		{"name": "user_id", "display_name": "User ID"},
+		{"name": "email", "display_name": "Email", "description": ""},
+		{"name": "user_id", "display_name": "User ID", "description": ""},
 	}
 	remoteShape := *localModel
 	remoteShape.Columns = remoteShapeColumns

--- a/cli/internal/providers/datagraph/rules/datagraph_columns_valid_test.go
+++ b/cli/internal/providers/datagraph/rules/datagraph_columns_valid_test.go
@@ -80,6 +80,64 @@ func TestDataGraphSpecSyntaxValid_ColumnsValid(t *testing.T) {
 			},
 		},
 		{
+			name: "column with description only (no display_name)",
+			spec: dgModel.DataGraphSpec{
+				ID:        "my-dg",
+				AccountID: "wh-123",
+				Models: []dgModel.ModelSpec{
+					{
+						ID:          "user",
+						DisplayName: "User",
+						Type:        "entity",
+						Table:       "db.schema.users",
+						PrimaryID:   "id",
+						Columns: []dgModel.ColumnMetadataYAML{
+							{Name: "notes", Description: "Free-form notes"},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "column with both display_name and description",
+			spec: dgModel.DataGraphSpec{
+				ID:        "my-dg",
+				AccountID: "wh-123",
+				Models: []dgModel.ModelSpec{
+					{
+						ID:          "user",
+						DisplayName: "User",
+						Type:        "entity",
+						Table:       "db.schema.users",
+						PrimaryID:   "id",
+						Columns: []dgModel.ColumnMetadataYAML{
+							{Name: "id", DisplayName: "User ID", Description: "Primary identifier"},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "two description-only columns do not collide (no description uniqueness)",
+			spec: dgModel.DataGraphSpec{
+				ID:        "my-dg",
+				AccountID: "wh-123",
+				Models: []dgModel.ModelSpec{
+					{
+						ID:          "user",
+						DisplayName: "User",
+						Type:        "entity",
+						Table:       "db.schema.users",
+						PrimaryID:   "id",
+						Columns: []dgModel.ColumnMetadataYAML{
+							{Name: "notes", Description: "Same note"},
+							{Name: "memo", Description: "Same note"},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "model without columns is valid",
 			spec: dgModel.DataGraphSpec{
 				ID:        "my-dg",
@@ -197,7 +255,7 @@ func TestDataGraphSpecSyntaxValid_ColumnsInvalid(t *testing.T) {
 			expectedMsgSubstrings: []string{"'name' is required"},
 		},
 		{
-			name: "column missing display_name",
+			name: "column with neither display_name nor description",
 			spec: dgModel.DataGraphSpec{
 				ID:        "my-dg",
 				AccountID: "wh-123",
@@ -205,26 +263,20 @@ func TestDataGraphSpecSyntaxValid_ColumnsInvalid(t *testing.T) {
 					baseModel(dgModel.ColumnMetadataYAML{Name: "id"}),
 				},
 			},
-			expectedRefs:          []string{"/models/0/columns/0/display_name"},
-			expectedMsgSubstrings: []string{"'display_name' is required"},
+			expectedRefs:          []string{"/models/0/columns/0"},
+			expectedMsgSubstrings: []string{"at least one of 'display_name' or 'description'"},
 		},
 		{
-			name: "column missing both name and display_name",
+			name: "column missing name (with description set)",
 			spec: dgModel.DataGraphSpec{
 				ID:        "my-dg",
 				AccountID: "wh-123",
 				Models: []dgModel.ModelSpec{
-					baseModel(dgModel.ColumnMetadataYAML{}),
+					baseModel(dgModel.ColumnMetadataYAML{Description: "some note"}),
 				},
 			},
-			expectedRefs: []string{
-				"/models/0/columns/0/name",
-				"/models/0/columns/0/display_name",
-			},
-			expectedMsgSubstrings: []string{
-				"'name' is required",
-				"'display_name' is required",
-			},
+			expectedRefs:          []string{"/models/0/columns/0/name"},
+			expectedMsgSubstrings: []string{"'name' is required"},
 		},
 		{
 			name: "column name leading whitespace",
@@ -293,6 +345,36 @@ func TestDataGraphSpecSyntaxValid_ColumnsInvalid(t *testing.T) {
 				},
 			},
 			expectedRefs:          []string{"/models/0/columns/0/display_name"},
+			expectedMsgSubstrings: []string{"control characters"},
+		},
+		{
+			name: "column description with leading whitespace is rejected",
+			spec: dgModel.DataGraphSpec{
+				ID:        "my-dg",
+				AccountID: "wh-123",
+				Models: []dgModel.ModelSpec{
+					baseModel(dgModel.ColumnMetadataYAML{
+						Name:        "id",
+						Description: " padded note",
+					}),
+				},
+			},
+			expectedRefs:          []string{"/models/0/columns/0/description"},
+			expectedMsgSubstrings: []string{"leading or trailing whitespace"},
+		},
+		{
+			name: "column description with newline is rejected",
+			spec: dgModel.DataGraphSpec{
+				ID:        "my-dg",
+				AccountID: "wh-123",
+				Models: []dgModel.ModelSpec{
+					baseModel(dgModel.ColumnMetadataYAML{
+						Name:        "id",
+						Description: "line\nbreak",
+					}),
+				},
+			},
+			expectedRefs:          []string{"/models/0/columns/0/description"},
 			expectedMsgSubstrings: []string{"control characters"},
 		},
 		{

--- a/cli/internal/providers/datagraph/rules/datagraph_spec_valid.go
+++ b/cli/internal/providers/datagraph/rules/datagraph_spec_valid.go
@@ -99,9 +99,10 @@ var validateDataGraphSpec = func(_ string, _ string, _ map[string]any, spec dgMo
 
 // validateModelColumns enforces the per-column constraints that can't be
 // expressed via struct tags: trimmed values, no control characters in
-// display_name, and in-model uniqueness of `name` and case-insensitive
-// uniqueness of `display_name`. Required/max=255 are handled upstream by
-// struct-tag validation.
+// display_name / description, the "at least one of display_name or description"
+// rule, in-model uniqueness of `name`, and case-insensitive uniqueness of
+// `display_name` (description has no uniqueness rule). max=255 is handled
+// upstream by struct-tag validation.
 func validateModelColumns(modelIdx int, columns []dgModel.ColumnMetadataYAML) []rules.ValidationResult {
 	if len(columns) == 0 {
 		return nil
@@ -125,6 +126,13 @@ func validateModelColumns(modelIdx int, columns []dgModel.ColumnMetadataYAML) []
 			})
 		}
 
+		if col.DisplayName == "" && col.Description == "" {
+			results = append(results, rules.ValidationResult{
+				Reference: base,
+				Message:   "each column must set at least one of 'display_name' or 'description'",
+			})
+		}
+
 		if col.DisplayName != "" {
 			if hasLeadingOrTrailingWhitespace(col.DisplayName) {
 				results = append(results, rules.ValidationResult{
@@ -136,6 +144,21 @@ func validateModelColumns(modelIdx int, columns []dgModel.ColumnMetadataYAML) []
 				results = append(results, rules.ValidationResult{
 					Reference: base + "/display_name",
 					Message:   "'display_name' must not contain control characters (tab, newline, carriage return)",
+				})
+			}
+		}
+
+		if col.Description != "" {
+			if hasLeadingOrTrailingWhitespace(col.Description) {
+				results = append(results, rules.ValidationResult{
+					Reference: base + "/description",
+					Message:   "'description' must not have leading or trailing whitespace",
+				})
+			}
+			if hasControlCharacters(col.Description) {
+				results = append(results, rules.ValidationResult{
+					Reference: base + "/description",
+					Message:   "'description' must not contain control characters (tab, newline, carriage return)",
 				})
 			}
 		}


### PR DESCRIPTION
Scanned-by: gitleaks 8.30.1

## 🔗 Ticket

<!-- Required for traceability -->

Resolves [DEX-XXX](link-to-ticket)

---

## Summary

The specs: https://github.com/rudderlabs/rudder-specs/pull/66

Follow-up to [#598](https://github.com/rudderlabs/rudder-iac/pull/598): extends Data Graph column metadata in IaC with an optional per-column `description` in YAML, aligned with the config-backend API.

- YAML spec: columns[].description (optional); each entry must set at least one of `display_name` or `description`; same trim/control-char rules as alias; no CI-uniqueness on descriptions.
- API client: `ColumnMetadataEntry` / `ColumnMetadataRow` carry description; batch `PATCH` sends `displayName:null` for description-only rows.
- Provider/handler: maps YAML → API on apply; state includes description on column metadata.

Test plan

-  `datagraph_columns_valid` and provider/handler tests pass
-  API client tests: description-only wire payload, both fields, response decode
-  Validate: description-only column, alias+description, neither field, whitespace/newline on description
-  rudder-cli apply with a spec using`columns[].description` only

Depends on: #598 (column metadata / aliases) and the matching config-backend PR.

---

## Changes

- Key change 1
- Key change 2
- Key change 3

---

## Testing

How was this tested?

- Unit tests / Integration tests / Manual testing

---

## Risk / Impact

Low / Medium / High
Notes (if any):

---

## Checklist

- [ ] Ticket linked
- [ ] Tests added/updated
- [ ] No breaking changes (or documented)
