### PR TITLE
feat: phase 4 — author rule-doc fragments + provider wiring (DEX-272)

### DIFF
--- a/.github/workflows/gen-rule-docs.yml
+++ b/.github/workflows/gen-rule-docs.yml
@@ -1,0 +1,43 @@
+name: generate rule docs
+on:
+  push:
+    branches:
+      - main
+      - "release/*"
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  gen-rule-docs:
+    name: "generate validation rule catalog"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        with:
+          egress-policy: audit
+
+      - name: checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: setup go
+        uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+        with:
+          go-version-file: 'go.mod'
+
+      # Doubles as the drift/completeness gate: gen-rule-docs validates the
+      # joined catalog and exits non-zero if any rule lacks an authored doc
+      # fragment (or a fragment references an unknown rule), failing the build.
+      - name: generate rule catalog
+        run: make gen-rule-docs
+
+      - name: upload rule catalog
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: rules.yaml
+          path: docs/generated/rules.yaml
+          if-no-files-found: error

--- a/cli/cmd/gen-rule-docs/main.go
+++ b/cli/cmd/gen-rule-docs/main.go
@@ -19,8 +19,6 @@ import (
 
 	"github.com/rudderlabs/rudder-iac/cli/internal/app"
 	"github.com/rudderlabs/rudder-iac/cli/internal/config"
-	"github.com/rudderlabs/rudder-iac/cli/internal/project"
-	projectdocs "github.com/rudderlabs/rudder-iac/cli/internal/project/docs"
 	"github.com/rudderlabs/rudder-iac/cli/internal/validation/docs"
 )
 
@@ -41,36 +39,13 @@ func run() error {
 	app.Initialise(version)
 	config.InitConfig(config.DefaultConfigFile())
 
-	// Shared with the regular app path, so the documented rule set is identical
-	// to what project validation observes.
-	cp, err := app.NewCompositeProvider()
+	// All composition lives in app.GenerateRuleCatalog so the documented rule
+	// set is built from the same providers and registry project validation
+	// uses; this command only chooses the timestamp and writes the result.
+	doc, verrs, err := app.GenerateRuleCatalog(time.Now().UTC().Format(time.RFC3339))
 	if err != nil {
-		return fmt.Errorf("building composite provider: %w", err)
+		return err
 	}
-
-	reg, err := project.BuildRegistry(cp)
-	if err != nil {
-		return fmt.Errorf("building rule registry: %w", err)
-	}
-
-	entries := cp.RuleDocEntries()
-
-	// Project-level (gatekeeper) rules are registered outside any provider, so
-	// their authored fragments are embedded here and appended to the
-	// provider-contributed entries.
-	projectEntries, err := docs.LoadRuleDocEntries(projectdocs.FragmentsFS, ".")
-	if err != nil {
-		return fmt.Errorf("loading project rule docs: %w", err)
-	}
-	entries = append(entries, projectEntries...)
-
-	doc, verrs := docs.Generate(
-		reg.AllSyntacticRules(),
-		reg.AllSemanticRules(),
-		entries,
-		app.GetVersion(),
-		time.Now().UTC().Format(time.RFC3339),
-	)
 	if len(verrs) > 0 {
 		for _, verr := range verrs {
 			fmt.Fprintln(os.Stderr, verr)

--- a/cli/cmd/gen-rule-docs/main.go
+++ b/cli/cmd/gen-rule-docs/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/rudderlabs/rudder-iac/cli/internal/app"
 	"github.com/rudderlabs/rudder-iac/cli/internal/config"
 	"github.com/rudderlabs/rudder-iac/cli/internal/project"
+	projectdocs "github.com/rudderlabs/rudder-iac/cli/internal/project/docs"
 	"github.com/rudderlabs/rudder-iac/cli/internal/validation/docs"
 )
 
@@ -52,10 +53,21 @@ func run() error {
 		return fmt.Errorf("building rule registry: %w", err)
 	}
 
+	entries := cp.RuleDocEntries()
+
+	// Project-level (gatekeeper) rules are registered outside any provider, so
+	// their authored fragments are embedded here and appended to the
+	// provider-contributed entries.
+	projectEntries, err := docs.LoadRuleDocEntries(projectdocs.FragmentsFS, ".")
+	if err != nil {
+		return fmt.Errorf("loading project rule docs: %w", err)
+	}
+	entries = append(entries, projectEntries...)
+
 	doc, verrs := docs.Generate(
 		reg.AllSyntacticRules(),
 		reg.AllSemanticRules(),
-		cp.RuleDocEntries(),
+		entries,
 		app.GetVersion(),
 		time.Now().UTC().Format(time.RFC3339),
 	)

--- a/cli/internal/app/dependencies.go
+++ b/cli/internal/app/dependencies.go
@@ -17,9 +17,11 @@ import (
 	"github.com/rudderlabs/rudder-iac/cli/internal/providers/retl"
 	"github.com/rudderlabs/rudder-iac/cli/internal/providers/transformations"
 	"github.com/rudderlabs/rudder-iac/cli/internal/providers/workspace"
+	"github.com/rudderlabs/rudder-iac/cli/internal/ruledoc"
 	"github.com/rudderlabs/rudder-iac/cli/internal/syncer"
 	"github.com/rudderlabs/rudder-iac/cli/internal/syncer/reporters"
 	"github.com/rudderlabs/rudder-iac/cli/internal/ui"
+	"github.com/rudderlabs/rudder-iac/cli/internal/validation/docs"
 	"github.com/rudderlabs/rudder-iac/cli/internal/validation/rules"
 )
 
@@ -106,13 +108,43 @@ func NewDeps() (Deps, error) {
 	}, nil
 }
 
-// NewCompositeProvider builds the composite provider without requiring an access
-// token. Rule-doc generation enumerates rules and reads authored fragments but
-// makes no network calls, so it deliberately skips the auth check NewDeps
-// enforces. It shares composeProviders with NewDeps so the documented rule set
-// stays identical to the one project validation observes — they can't drift.
-func NewCompositeProvider() (provider.Provider, error) {
-	c, err := setupClient(v)
+// GenerateRuleCatalog composes the same providers project validation uses and
+// hands them to ruledoc.Build, which joins the live rules with the authored
+// *.docs.yaml fragments and returns the validated catalog.
+//
+// Composition is the only part that needs the app's machinery, so it lives
+// here in the composition root; the provider-in, catalog-out assembly lives in
+// package ruledoc where it can be tested without credentials. Generation makes
+// no network calls, so it skips the access-token check NewDeps enforces.
+//
+// verrs carries catalog validation failures (e.g. a registered rule with no
+// authored fragment); a non-nil error means the catalog could not be assembled
+// at all. generatedAt is injected so callers own the timestamp.
+func GenerateRuleCatalog(generatedAt string) (docs.DocumentedRules, []error, error) {
+	cp, err := newCompositeProvider()
+	if err != nil {
+		return docs.DocumentedRules{}, nil, fmt.Errorf("building composite provider: %w", err)
+	}
+
+	return ruledoc.Build(cp, GetVersion(), generatedAt)
+}
+
+// newCompositeProvider builds the composite provider without requiring
+// credentials. It is used only by GenerateRuleCatalog: rule-doc generation
+// enumerates rules and reads authored fragments but makes no network calls, so
+// it skips the auth check NewDeps enforces and feeds client.New a placeholder
+// token (an empty token is rejected outright, which would otherwise break
+// generation in CI where no credentials are configured). It shares
+// composeProviders with NewDeps so the documented rule set stays identical to
+// the one project validation observes — they can't drift.
+func newCompositeProvider() (provider.Provider, error) {
+	cfg := config.GetConfig()
+
+	c, err := client.New(
+		"rule-doc-generation", // unused: generation makes no API calls
+		client.WithBaseURL(cfg.APIURL),
+		client.WithUserAgent("rudder-cli/"+v),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("setup client: %w", err)
 	}
@@ -126,7 +158,7 @@ func NewCompositeProvider() (provider.Provider, error) {
 }
 
 // composeProviders builds the provider set and aggregates it into a composite
-// provider. Shared by NewDeps and NewCompositeProvider so every consumer
+// provider. Shared by NewDeps and newCompositeProvider so every consumer
 // observes the same providers (and therefore the same registered rules).
 func composeProviders(c *client.Client) (provider.Provider, *Providers, error) {
 	p, err := setupProviders(c)

--- a/cli/internal/app/ruledoc_test.go
+++ b/cli/internal/app/ruledoc_test.go
@@ -1,0 +1,30 @@
+package app
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/rudderlabs/rudder-iac/cli/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGenerateRuleCatalog_CompleteAndDriftFree exercises the real provider
+// composition and rule registry, then asserts the joined catalog passes
+// validation with zero errors.
+//
+// This is the same drift/completeness gate the CI gen-rule-docs step enforces,
+// expressed as a unit test: if a registered rule loses its authored
+// *.docs.yaml fragment — or a fragment references a rule that no longer exists
+// — verrs is non-empty and this fails locally, with no CI round-trip needed.
+func TestGenerateRuleCatalog_CompleteAndDriftFree(t *testing.T) {
+	Initialise("test")
+	// Hermetic config: defaults only, written under a temp dir so the suite
+	// never touches the developer's ~/.rudder config.
+	config.InitConfig(filepath.Join(t.TempDir(), "config.json"))
+
+	doc, verrs, err := GenerateRuleCatalog("2026-01-01T00:00:00Z")
+	require.NoError(t, err)
+	assert.Empty(t, verrs, "every registered rule must have an authored fragment and vice versa")
+	assert.NotEmpty(t, doc.Rules, "catalog should document at least one rule")
+}

--- a/cli/internal/project/docs/duplicate-urn.docs.yaml
+++ b/cli/internal/project/docs/duplicate-urn.docs.yaml
@@ -1,0 +1,68 @@
+rule_id: "project/duplicate-urn"
+match_behavior:
+  # Project-level (gatekeeper) rule. It runs across the whole project as a
+  # ProjectRule, so it is documented with a single wildcard applies_to entry.
+  # The {kind: "*", version: "*"} pattern is what AppliesTo() reports, keeping
+  # the generated catalog deterministic regardless of active providers.
+  - applies_to:
+      - kind: "*"
+        version: "*"
+    valid:
+      - example_id: "duplicate-urn-distinct-urns"
+        title: "Distinct URNs across files"
+        description: >
+          Two specs that each declare a different resource. The URNs do not
+          collide, so the project is valid.
+        files:
+          a.yaml: |
+            version: rudder/v1
+            kind: events
+            metadata:
+              name: events-a
+            spec:
+              events:
+                - id: order_completed
+                  name: Order Completed
+          b.yaml: |
+            version: rudder/v1
+            kind: events
+            metadata:
+              name: events-b
+            spec:
+              events:
+                - id: cart_viewed
+                  name: Cart Viewed
+    invalid:
+      - example_id: "duplicate-urn-across-files"
+        title: "Same URN declared in two files"
+        description: >
+          Both files declare an event with id "order_completed", which resolves
+          to the same URN. The rule flags every occurrence.
+        files:
+          a.yaml: |
+            version: rudder/v1
+            kind: events
+            metadata:
+              name: events-a
+            spec:
+              events:
+                - id: order_completed
+                  name: Order Completed
+          b.yaml: |
+            version: rudder/v1
+            kind: events
+            metadata:
+              name: events-b
+            spec:
+              events:
+                - id: order_completed
+                  name: Order Completed (duplicate)
+        expected_diagnostics:
+          - file: "a.yaml"
+            reference: "/spec/events/0/id"
+            severity: "error"
+            message_contains: "duplicate URN 'event:order_completed'"
+          - file: "b.yaml"
+            reference: "/spec/events/0/id"
+            severity: "error"
+            message_contains: "duplicate URN 'event:order_completed'"

--- a/cli/internal/project/docs/embed.go
+++ b/cli/internal/project/docs/embed.go
@@ -1,0 +1,6 @@
+package docs
+
+import "embed"
+
+//go:embed *.docs.yaml
+var FragmentsFS embed.FS

--- a/cli/internal/project/docs/metadata-syntax-valid.docs.yaml
+++ b/cli/internal/project/docs/metadata-syntax-valid.docs.yaml
@@ -1,0 +1,85 @@
+rule_id: "project/metadata-syntax-valid"
+match_behavior:
+  # This is a project-level (gatekeeper) rule that runs against every spec
+  # regardless of kind or version, so it is documented with a single wildcard
+  # applies_to entry. The {kind: "*", version: "*"} pattern is what the rule
+  # reports from AppliesTo(), which keeps the generated catalog deterministic
+  # (independent of which providers or experimental kinds are active).
+  - applies_to:
+      - kind: "*"
+        version: "*"
+    valid:
+      - example_id: "metadata-name-only"
+        title: "Metadata with only the required name"
+        description: "The minimal valid metadata block: a name and nothing else."
+        files:
+          spec.yaml: |
+            version: rudder/v1
+            kind: events
+            metadata:
+              name: my-events
+            spec:
+              events: []
+      - example_id: "metadata-with-import"
+        title: "Metadata with a well-formed import block"
+        description: >
+          An import block where every workspace has a workspace_id and every
+          resource references a URN that exists in the spec body.
+        files:
+          spec.yaml: |
+            version: rudder/v1
+            kind: events
+            metadata:
+              name: my-events
+              import:
+                workspaces:
+                  - workspace_id: ws-123
+                    resources:
+                      - urn: "event:order_completed"
+                        remote_id: ev-remote-456
+            spec:
+              events:
+                - id: order_completed
+                  name: Order Completed
+    invalid:
+      - example_id: "metadata-missing-name"
+        title: "Metadata missing the required name field"
+        description: "Every spec's metadata must declare a name."
+        files:
+          spec.yaml: |
+            version: rudder/v1
+            kind: events
+            metadata:
+              import:
+                workspaces:
+                  - workspace_id: ws-123
+            spec:
+              events: []
+        expected_diagnostics:
+          - file: "spec.yaml"
+            reference: "/metadata/name"
+            severity: "error"
+            message_contains: "'name' is required"
+      - example_id: "metadata-import-missing-workspace-id"
+        title: "Import workspace missing the required workspace_id"
+        description: "Each workspace entry in an import block must declare a workspace_id."
+        files:
+          spec.yaml: |
+            version: rudder/v1
+            kind: events
+            metadata:
+              name: my-events
+              import:
+                workspaces:
+                  - resources:
+                      - urn: "event:order_completed"
+                        remote_id: ev-remote-456
+            spec:
+              events:
+                - id: order_completed
+                  name: Order Completed
+        expected_diagnostics:
+          - file: "spec.yaml"
+            reference: "/metadata/import/workspaces/0/workspace_id"
+            severity: "error"
+            message_contains: "'workspace_id' is required"

--- a/cli/internal/project/docs/resource-kind-version-valid.docs.yaml
+++ b/cli/internal/project/docs/resource-kind-version-valid.docs.yaml
@@ -1,0 +1,48 @@
+rule_id: "project/resource-kind-version-valid"
+match_behavior:
+  # Project-level (gatekeeper) rule that runs against every spec regardless of
+  # kind or version, so it is documented with a single wildcard applies_to
+  # entry. The {kind: "*", version: "*"} pattern is what the rule reports from
+  # AppliesTo(), keeping the generated catalog deterministic regardless of which
+  # providers or experimental kinds are active.
+  - applies_to:
+      - kind: "*"
+        version: "*"
+    valid:
+      - example_id: "kind-version-supported-pair"
+        title: "Kind declared with a supported version"
+        description: >
+          The events kind is supported at version rudder/v1, so this spec is
+          accepted. The rule only flags a kind/version combination when the kind
+          is recognised but the specific version is not registered for it.
+        files:
+          spec.yaml: |
+            version: rudder/v1
+            kind: events
+            metadata:
+              name: my-events
+            spec:
+              events:
+                - id: order_completed
+                  name: Order Completed
+    invalid:
+      - example_id: "kind-version-unsupported-version"
+        title: "Known kind declared with an unsupported version"
+        description: >
+          The events kind is recognised, but it is not registered for version
+          rudder/v0.1. The rule reports the unsupported kind/version pairing.
+        files:
+          spec.yaml: |
+            version: rudder/v0.1
+            kind: events
+            metadata:
+              name: my-events
+            spec:
+              events:
+                - id: order_completed
+                  name: Order Completed
+        expected_diagnostics:
+          - file: "spec.yaml"
+            reference: "/kind"
+            severity: "error"
+            message_contains: "is not supported with version"

--- a/cli/internal/project/docs/ruledoc_test.go
+++ b/cli/internal/project/docs/ruledoc_test.go
@@ -1,0 +1,61 @@
+package docs_test
+
+import (
+	"testing"
+
+	projectdocs "github.com/rudderlabs/rudder-iac/cli/internal/project/docs"
+	prules "github.com/rudderlabs/rudder-iac/cli/internal/project/rules"
+	"github.com/rudderlabs/rudder-iac/cli/internal/validation/docs"
+	"github.com/rudderlabs/rudder-iac/cli/internal/validation/rules"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// projectGatekeeperRules returns the project-level rules whose doc fragments
+// live in this package, paired with the phase the docs generator records.
+func projectGatekeeperRules() []rules.Rule {
+	return []rules.Rule{
+		prules.NewMetadataSyntaxValidRule(nil),
+		prules.NewDuplicateURNRule(nil),
+		prules.NewSpecSyntaxValidRule(nil),
+		prules.NewResourceKindVersionValidRule(nil),
+	}
+}
+
+// TestProjectFragmentsHaveEntries asserts every embedded fragment parses and
+// carries match behavior.
+func TestProjectFragmentsHaveEntries(t *testing.T) {
+	entries, err := docs.LoadRuleDocEntries(projectdocs.FragmentsFS, ".")
+	require.NoError(t, err)
+
+	byID := make(map[string]docs.RuleDocEntry, len(entries))
+	for _, e := range entries {
+		byID[e.RuleID] = e
+	}
+
+	for _, rule := range projectGatekeeperRules() {
+		entry, ok := byID[rule.ID()]
+		require.True(t, ok, "expected a doc entry for %s", rule.ID())
+		assert.NotEmpty(t, entry.MatchBehavior, "rule %s has no match_behavior", rule.ID())
+	}
+}
+
+// TestProjectFragmentsPassGeneration runs the embedded fragments through the
+// real docs generator together with the live rules and asserts that all
+// DocumentedRules.Validate invariants pass — proving the wildcard applies_to
+// in each fragment exactly covers what the rule reports from AppliesTo().
+func TestProjectFragmentsPassGeneration(t *testing.T) {
+	entries, err := docs.LoadRuleDocEntries(projectdocs.FragmentsFS, ".")
+	require.NoError(t, err)
+
+	syntactic := projectGatekeeperRules()
+
+	doc, verrs := docs.Generate(syntactic, nil, entries, "test", "2026-06-03T00:00:00Z")
+	assert.Empty(t, verrs, "expected no validation errors, got: %v", verrs)
+
+	require.Len(t, doc.Rules, len(syntactic))
+	for _, r := range doc.Rules {
+		require.Len(t, r.AppliesTo, 1)
+		assert.Equal(t, docs.MatchPatternDoc{Kind: "*", Version: "*"}, r.AppliesTo[0])
+	}
+}

--- a/cli/internal/project/docs/spec-syntax-valid.docs.yaml
+++ b/cli/internal/project/docs/spec-syntax-valid.docs.yaml
@@ -1,0 +1,93 @@
+rule_id: "project/spec-syntax-valid"
+match_behavior:
+  # Project-level (gatekeeper) rule that runs against every spec regardless of
+  # kind or version, so it is documented with a single wildcard applies_to
+  # entry. The {kind: "*", version: "*"} pattern is what the rule reports from
+  # AppliesTo(), keeping the generated catalog deterministic regardless of which
+  # providers or experimental kinds are active.
+  - applies_to:
+      - kind: "*"
+        version: "*"
+    valid:
+      - example_id: "spec-syntax-all-top-level-fields"
+        title: "Spec with all required top-level fields"
+        description: >
+          A well-formed spec declaring version, kind, metadata and spec. These
+          are the four top-level fields every spec must carry.
+        files:
+          spec.yaml: |
+            version: rudder/v1
+            kind: properties
+            metadata:
+              name: my-properties
+            spec:
+              properties:
+                - name: MyTestProperty
+                  type: string
+    invalid:
+      - example_id: "spec-syntax-missing-kind"
+        title: "Spec missing the required kind field"
+        description: "Every spec must declare a kind."
+        files:
+          spec.yaml: |
+            version: rudder/v1
+            kind:
+            metadata:
+              name: my-properties
+            spec:
+              properties:
+                - name: MyTestProperty
+                  type: string
+        expected_diagnostics:
+          - file: "spec.yaml"
+            reference: "/kind"
+            severity: "error"
+            message_contains: "'kind' is required"
+      - example_id: "spec-syntax-missing-version"
+        title: "Spec missing the required version field"
+        description: "Every spec must declare a version."
+        files:
+          spec.yaml: |
+            version:
+            kind: properties
+            metadata:
+              name: my-properties
+            spec:
+              properties:
+                - name: MyTestProperty
+                  type: string
+        expected_diagnostics:
+          - file: "spec.yaml"
+            reference: "/version"
+            severity: "error"
+            message_contains: "'version' is required"
+      - example_id: "spec-syntax-missing-metadata"
+        title: "Spec missing the required metadata block"
+        description: "Every spec must declare a metadata block."
+        files:
+          spec.yaml: |
+            version: rudder/v1
+            kind: properties
+            spec:
+              properties:
+                - name: MyTestProperty
+                  type: string
+        expected_diagnostics:
+          - file: "spec.yaml"
+            reference: "/metadata"
+            severity: "error"
+            message_contains: "'metadata' is required"
+      - example_id: "spec-syntax-missing-spec"
+        title: "Spec missing the required spec body"
+        description: "Every spec must declare a spec body."
+        files:
+          spec.yaml: |
+            version: rudder/v1
+            kind: properties
+            metadata:
+              name: my-properties
+        expected_diagnostics:
+          - file: "spec.yaml"
+            reference: "/spec"
+            severity: "error"
+            message_contains: "'spec' is required"

--- a/cli/internal/project/project.go
+++ b/cli/internal/project/project.go
@@ -310,12 +310,15 @@ func BuildRegistry(provider ProjectProvider) (rules.Registry, error) {
 
 	syntactic := []rules.Rule{
 		// GatekeeperRules: MatchAll rules, checks structure + known kinds/versions
-		// independently. They use activePatterns as source of truth for the supported kinds and versions.
+		// independently. spec-syntax-valid and resource-kind-version-valid use
+		// activePatterns as source of truth for the supported kinds and versions.
+		// metadata-syntax-valid and duplicate-urn match all specs and do not
+		// consume activePatterns.
 		prules.NewSpecSyntaxValidRule(activePatterns),
 		prules.NewResourceKindVersionValidRule(activePatterns),
 
-		prules.NewMetadataSyntaxValidRule(provider.ParseSpec, activePatterns),
-		prules.NewDuplicateURNRule(provider.ParseSpec, activePatterns),
+		prules.NewMetadataSyntaxValidRule(provider.ParseSpec),
+		prules.NewDuplicateURNRule(provider.ParseSpec),
 	}
 	syntactic = append(syntactic, provider.SyntacticRules()...)
 

--- a/cli/internal/project/rules/duplicate_urn_rule.go
+++ b/cli/internal/project/rules/duplicate_urn_rule.go
@@ -12,11 +12,10 @@ type ParseSpecFunc func(path string, s *specs.Spec) (*specs.ParsedSpec, error)
 
 type duplicateURNRule struct {
 	parseSpec ParseSpecFunc
-	appliesTo []rules.MatchPattern
 }
 
-func NewDuplicateURNRule(parseSpec ParseSpecFunc, patterns []rules.MatchPattern) rules.Rule {
-	return &duplicateURNRule{parseSpec: parseSpec, appliesTo: patterns}
+func NewDuplicateURNRule(parseSpec ParseSpecFunc) rules.Rule {
+	return &duplicateURNRule{parseSpec: parseSpec}
 }
 
 func (r *duplicateURNRule) ID() string               { return "project/duplicate-urn" }
@@ -24,7 +23,9 @@ func (r *duplicateURNRule) Severity() rules.Severity { return rules.Error }
 func (r *duplicateURNRule) Description() string {
 	return "URNs must be unique across the project"
 }
-func (r *duplicateURNRule) AppliesTo() []rules.MatchPattern { return r.appliesTo }
+func (r *duplicateURNRule) AppliesTo() []rules.MatchPattern {
+	return []rules.MatchPattern{rules.MatchAll()}
+}
 func (r *duplicateURNRule) Examples() rules.Examples {
 	return rules.Examples{}
 }

--- a/cli/internal/project/rules/duplicate_urn_rule_test.go
+++ b/cli/internal/project/rules/duplicate_urn_rule_test.go
@@ -13,14 +13,11 @@ import (
 func TestDuplicateURNRule_Metadata(t *testing.T) {
 	t.Parallel()
 
-	patterns := []rules.MatchPattern{
-		rules.MatchKindVersion("properties", "rudder/v1"),
-	}
-	rule := NewDuplicateURNRule(nil, patterns)
+	rule := NewDuplicateURNRule(nil)
 
 	assert.Equal(t, "project/duplicate-urn", rule.ID())
 	assert.Equal(t, rules.Error, rule.Severity())
-	assert.Equal(t, patterns, rule.AppliesTo())
+	assert.Equal(t, []rules.MatchPattern{rules.MatchAll()}, rule.AppliesTo())
 	assert.Nil(t, rule.Validate(nil))
 }
 
@@ -70,7 +67,7 @@ func TestDuplicateURNRule_ValidateProject(t *testing.T) {
 	t.Run("no duplicates", func(t *testing.T) {
 		t.Parallel()
 
-		rule := NewDuplicateURNRule(parseSpec, nil)
+		rule := NewDuplicateURNRule(parseSpec)
 		pr := rule.(rules.ProjectRule)
 
 		results := pr.ValidateProject(map[string]*rules.ValidationContext{
@@ -93,7 +90,7 @@ func TestDuplicateURNRule_ValidateProject(t *testing.T) {
 	t.Run("duplicate URN across files", func(t *testing.T) {
 		t.Parallel()
 
-		rule := NewDuplicateURNRule(parseSpec, nil)
+		rule := NewDuplicateURNRule(parseSpec)
 		pr := rule.(rules.ProjectRule)
 
 		results := pr.ValidateProject(map[string]*rules.ValidationContext{
@@ -119,7 +116,7 @@ func TestDuplicateURNRule_ValidateProject(t *testing.T) {
 	t.Run("duplicate URN within same file", func(t *testing.T) {
 		t.Parallel()
 
-		rule := NewDuplicateURNRule(parseSpec, nil)
+		rule := NewDuplicateURNRule(parseSpec)
 		pr := rule.(rules.ProjectRule)
 
 		results := pr.ValidateProject(map[string]*rules.ValidationContext{
@@ -140,7 +137,7 @@ func TestDuplicateURNRule_ValidateProject(t *testing.T) {
 	t.Run("same local ID across different resource types is allowed", func(t *testing.T) {
 		t.Parallel()
 
-		rule := NewDuplicateURNRule(parseSpec, nil)
+		rule := NewDuplicateURNRule(parseSpec)
 		pr := rule.(rules.ProjectRule)
 
 		results := pr.ValidateProject(map[string]*rules.ValidationContext{
@@ -163,7 +160,7 @@ func TestDuplicateURNRule_ValidateProject(t *testing.T) {
 	t.Run("three files with same URN", func(t *testing.T) {
 		t.Parallel()
 
-		rule := NewDuplicateURNRule(parseSpec, nil)
+		rule := NewDuplicateURNRule(parseSpec)
 		pr := rule.(rules.ProjectRule)
 
 		results := pr.ValidateProject(map[string]*rules.ValidationContext{
@@ -187,7 +184,7 @@ func TestDuplicateURNRule_ValidateProject(t *testing.T) {
 	t.Run("mixed duplicates and unique", func(t *testing.T) {
 		t.Parallel()
 
-		rule := NewDuplicateURNRule(parseSpec, nil)
+		rule := NewDuplicateURNRule(parseSpec)
 		pr := rule.(rules.ProjectRule)
 
 		results := pr.ValidateProject(map[string]*rules.ValidationContext{
@@ -213,7 +210,7 @@ func TestDuplicateURNRule_ValidateProject(t *testing.T) {
 	t.Run("tracking plan duplicate URNs", func(t *testing.T) {
 		t.Parallel()
 
-		rule := NewDuplicateURNRule(parseSpec, nil)
+		rule := NewDuplicateURNRule(parseSpec)
 		pr := rule.(rules.ProjectRule)
 
 		results := pr.ValidateProject(map[string]*rules.ValidationContext{

--- a/cli/internal/project/rules/metadata_syntax_valid.go
+++ b/cli/internal/project/rules/metadata_syntax_valid.go
@@ -15,13 +15,11 @@ import (
 
 type MetadataSyntaxValidRule struct {
 	parseSpec ParseSpecFunc
-	appliesTo []rules.MatchPattern
 }
 
-func NewMetadataSyntaxValidRule(parseSpec ParseSpecFunc, patterns []rules.MatchPattern) rules.Rule {
+func NewMetadataSyntaxValidRule(parseSpec ParseSpecFunc) rules.Rule {
 	return &MetadataSyntaxValidRule{
 		parseSpec: parseSpec,
-		appliesTo: patterns,
 	}
 }
 
@@ -38,7 +36,7 @@ func (r *MetadataSyntaxValidRule) Description() string {
 }
 
 func (r *MetadataSyntaxValidRule) AppliesTo() []rules.MatchPattern {
-	return r.appliesTo
+	return []rules.MatchPattern{rules.MatchAll()}
 }
 
 func (r *MetadataSyntaxValidRule) Examples() rules.Examples {

--- a/cli/internal/project/rules/metadata_syntax_valid_test.go
+++ b/cli/internal/project/rules/metadata_syntax_valid_test.go
@@ -35,11 +35,6 @@ func noopParseSpec(path string, spec *specs.Spec) (*specs.ParsedSpec, error) {
 func TestMetadataSyntaxValidRule_Validate(t *testing.T) {
 	t.Parallel()
 
-	appliesToPatterns := []rules.MatchPattern{
-		rules.MatchKindVersion("*", specs.SpecVersionV0_1),
-		rules.MatchKindVersion("*", specs.SpecVersionV0_1Variant),
-	}
-
 	tests := []struct {
 		name           string
 		parseSpec      ParseSpecFunc
@@ -288,7 +283,7 @@ func TestMetadataSyntaxValidRule_Validate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			rule := NewMetadataSyntaxValidRule(tt.parseSpec, appliesToPatterns)
+			rule := NewMetadataSyntaxValidRule(tt.parseSpec)
 			results := rule.Validate(tt.ctx)
 
 			assert.Len(t, results, tt.expectedErrors, "unexpected number of validation errors")
@@ -311,16 +306,12 @@ func TestMetadataSyntaxValidRule_Validate(t *testing.T) {
 func TestMetadataSyntaxValidRule_Metadata(t *testing.T) {
 	t.Parallel()
 
-	patterns := []rules.MatchPattern{
-		rules.MatchKindVersion("properties", specs.SpecVersionV0_1),
-		rules.MatchKindVersion("events", specs.SpecVersionV0_1),
-	}
-	rule := NewMetadataSyntaxValidRule(noopParseSpec, patterns)
+	rule := NewMetadataSyntaxValidRule(noopParseSpec)
 
 	assert.Equal(t, "project/metadata-syntax-valid", rule.ID())
 	assert.Equal(t, rules.Error, rule.Severity())
 	assert.Equal(t, "metadata syntax must be valid", rule.Description())
-	assert.Equal(t, patterns, rule.AppliesTo())
+	assert.Equal(t, []rules.MatchPattern{rules.MatchAll()}, rule.AppliesTo())
 
 	examples := rule.Examples()
 	assert.NotEmpty(t, examples.Valid)

--- a/cli/internal/provider/handler/basehandler_test.go
+++ b/cli/internal/provider/handler/basehandler_test.go
@@ -1,25 +1,47 @@
 package handler_test
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/rudderlabs/rudder-iac/cli/internal/project"
 	"github.com/rudderlabs/rudder-iac/cli/internal/project/specs"
 	"github.com/rudderlabs/rudder-iac/cli/internal/provider/testutils/example"
 	"github.com/rudderlabs/rudder-iac/cli/internal/provider/testutils/example/backend"
+	"github.com/rudderlabs/rudder-iac/cli/internal/validation/renderer"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// loadImportMetadataSpec runs a single-spec project through the full project
+// pipeline (the same path the apply/validate commands use) and returns the
+// load error plus the captured renderer output.
+//
+// Import-metadata validation is enforced by the project-level gatekeeper rule
+// project/metadata-syntax-valid. It runs in the syntax phase and renders its
+// diagnostics; Load itself returns a generic "syntax validation failed", so
+// assertions target the rendered output rather than err.Error(). The example
+// provider declares no SupportedMatchPatterns, but the gatekeeper rule matches
+// every kind (MatchAll), so it governs import metadata here exactly as it does
+// for real providers — the handler-phase ImportIds validation is shadowed by it.
+func loadImportMetadataSpec(t *testing.T, spec string) (error, string) {
+	t.Helper()
+
+	var buf bytes.Buffer
+	provider := example.NewProvider(backend.NewBackend())
+	proj := project.New(provider,
+		project.WithLoader(&mockLoader{specs: map[string]string{"writer/tolkien.yaml": spec}}),
+		project.WithRenderer(renderer.NewTextRenderer(&buf)),
+	)
+
+	return proj.Load("dummy/path"), buf.String()
+}
 
 func TestBaseHandler_LoadSpec_ImportMetadata(t *testing.T) {
 	t.Parallel()
 
 	t.Run("accepts URN-based import metadata", func(t *testing.T) {
-		b := backend.NewBackend()
-		provider := example.NewProvider(b)
-
-		proj := project.New(provider, project.WithLoader(&mockLoader{specs: map[string]string{
-			"writer/tolkien.yaml": `version: rudder/v0.1
+		err, _ := loadImportMetadataSpec(t, `version: rudder/v0.1
 kind: writer
 metadata:
   name: common
@@ -32,19 +54,12 @@ metadata:
 spec:
   id: tolkien
   name: J.R.R. Tolkien
-`,
-		}}))
-
-		err := proj.Load("dummy/path")
+`)
 		require.NoError(t, err, "URN-based import metadata should be accepted")
 	})
 
 	t.Run("rejects local_id-only import metadata", func(t *testing.T) {
-		b := backend.NewBackend()
-		provider := example.NewProvider(b)
-
-		proj := project.New(provider, project.WithLoader(&mockLoader{specs: map[string]string{
-			"writer/tolkien.yaml": `version: rudder/v0.1
+		err, out := loadImportMetadataSpec(t, `version: rudder/v0.1
 kind: writer
 metadata:
   name: common
@@ -57,21 +72,15 @@ metadata:
 spec:
   id: tolkien
   name: J.R.R. Tolkien
-`,
-		}}))
-
-		err := proj.Load("dummy/path")
+`)
 		require.Error(t, err, "local_id-only import metadata should be rejected")
-		assert.Contains(t, err.Error(), "local_id")
-		assert.Contains(t, err.Error(), "not supported")
+		assert.Contains(t, out, "project/metadata-syntax-valid")
+		assert.Contains(t, out, "local_id")
+		assert.Contains(t, out, "not supported")
 	})
 
 	t.Run("rejects empty URN and local_id", func(t *testing.T) {
-		b := backend.NewBackend()
-		provider := example.NewProvider(b)
-
-		proj := project.New(provider, project.WithLoader(&mockLoader{specs: map[string]string{
-			"writer/tolkien.yaml": `version: rudder/v0.1
+		err, out := loadImportMetadataSpec(t, `version: rudder/v0.1
 kind: writer
 metadata:
   name: common
@@ -83,20 +92,14 @@ metadata:
 spec:
   id: tolkien
   name: J.R.R. Tolkien
-`,
-		}}))
-
-		err := proj.Load("dummy/path")
+`)
 		require.Error(t, err, "empty URN and local_id should be rejected")
-		assert.Contains(t, err.Error(), "either urn or local_id must be set")
+		assert.Contains(t, out, "project/metadata-syntax-valid")
+		assert.Contains(t, out, "is required when")
 	})
 
 	t.Run("rejects both URN and local_id set", func(t *testing.T) {
-		b := backend.NewBackend()
-		provider := example.NewProvider(b)
-
-		proj := project.New(provider, project.WithLoader(&mockLoader{specs: map[string]string{
-			"writer/tolkien.yaml": `version: rudder/v0.1
+		err, out := loadImportMetadataSpec(t, `version: rudder/v0.1
 kind: writer
 metadata:
   name: common
@@ -110,12 +113,10 @@ metadata:
 spec:
   id: tolkien
   name: J.R.R. Tolkien
-`,
-		}}))
-
-		err := proj.Load("dummy/path")
+`)
 		require.Error(t, err, "both URN and local_id set should be rejected")
-		assert.Contains(t, err.Error(), "mutually exclusive")
+		assert.Contains(t, out, "project/metadata-syntax-valid")
+		assert.Contains(t, out, "cannot be specified together")
 	})
 }
 

--- a/cli/internal/providers/datacatalog/docs/categories-semantic-valid.docs.yaml
+++ b/cli/internal/providers/datacatalog/docs/categories-semantic-valid.docs.yaml
@@ -1,0 +1,81 @@
+rule_id: "datacatalog/categories/semantic-valid"
+match_behavior:
+  # Legacy spec versions share the same category spec shape and semantic validation,
+  # so they are documented together.
+  - applies_to:
+      - kind: "categories"
+        version: "rudder/0.1"
+      - kind: "categories"
+        version: "rudder/v0.1"
+    valid:
+      - example_id: "cat-sem-legacy-valid"
+        title: "Unique category names (legacy)"
+        files:
+          spec.yaml: |
+            version: rudder/0.1
+            kind: categories
+            metadata:
+              name: my-categories
+            spec:
+              categories:
+                - id: user_actions
+                  name: User Actions
+                - id: system_events
+                  name: System Events
+    invalid:
+      - example_id: "cat-sem-legacy-duplicate"
+        title: "Duplicate category name across files (legacy)"
+        description: "Two categories with the same name in the resource graph trigger this error."
+        files:
+          spec.yaml: |
+            version: rudder/0.1
+            kind: categories
+            metadata:
+              name: my-categories
+            spec:
+              categories:
+                - id: user_actions_2
+                  name: User Actions
+        expected_diagnostics:
+          - file: "spec.yaml"
+            reference: "/categories/0/name"
+            severity: "error"
+            message_contains: "duplicate name 'User Actions' within kind 'categories'"
+  # Current spec version (rudder/v1).
+  - applies_to:
+      - kind: "categories"
+        version: "rudder/v1"
+    valid:
+      - example_id: "cat-sem-v1-valid"
+        title: "Unique category names (v1)"
+        files:
+          spec.yaml: |
+            version: rudder/v1
+            kind: categories
+            metadata:
+              name: my-categories
+            spec:
+              categories:
+                - id: user_actions
+                  name: User Actions
+                - id: system_events
+                  name: System Events
+    invalid:
+      - example_id: "cat-sem-v1-duplicate"
+        title: "Duplicate category name across files (v1)"
+        description: "Two categories with the same name in the resource graph trigger this error."
+        files:
+          spec.yaml: |
+            version: rudder/v1
+            kind: categories
+            metadata:
+              name: my-categories
+            spec:
+              categories:
+                - id: user_actions_2
+                  name: User Actions
+        expected_diagnostics:
+          - file: "spec.yaml"
+            reference: "/categories/0/name"
+            severity: "error"
+            message_contains: "duplicate name 'User Actions' within kind 'categories'"

--- a/cli/internal/providers/datacatalog/docs/categories-spec-syntax-valid.docs.yaml
+++ b/cli/internal/providers/datacatalog/docs/categories-spec-syntax-valid.docs.yaml
@@ -1,0 +1,77 @@
+rule_id: "datacatalog/categories/spec-syntax-valid"
+match_behavior:
+  # Legacy spec versions (rudder/0.1 and rudder/v0.1) share the same
+  # category spec shape and validation, so they are documented together.
+  - applies_to:
+      - kind: "categories"
+        version: "rudder/0.1"
+      - kind: "categories"
+        version: "rudder/v0.1"
+    valid:
+      - example_id: "categories-legacy-valid"
+        title: "Valid legacy categories spec"
+        files:
+          spec.yaml: |
+            version: rudder/0.1
+            kind: categories
+            metadata:
+              name: legacy-categories
+            spec:
+              categories:
+                - id: user_actions
+                  name: User Actions
+                - id: system_events
+                  name: System Events
+    invalid:
+      - example_id: "categories-legacy-missing-name"
+        title: "Legacy category missing the required name field"
+        files:
+          spec.yaml: |
+            version: rudder/0.1
+            kind: categories
+            metadata:
+              name: legacy-categories
+            spec:
+              categories:
+                - id: user_actions
+        expected_diagnostics:
+          - file: "spec.yaml"
+            reference: "/spec/categories/0/name"
+            severity: "error"
+            message_contains: "'name' is required"
+  # Current spec version (rudder/v1).
+  - applies_to:
+      - kind: "categories"
+        version: "rudder/v1"
+    valid:
+      - example_id: "categories-v1-valid"
+        title: "Valid v1 categories spec"
+        files:
+          spec.yaml: |
+            version: rudder/v1
+            kind: categories
+            metadata:
+              name: categories
+            spec:
+              categories:
+                - id: user_actions
+                  name: User Actions
+                - id: system_events
+                  name: System Events
+    invalid:
+      - example_id: "categories-v1-missing-name"
+        title: "v1 category missing the required name field"
+        files:
+          spec.yaml: |
+            version: rudder/v1
+            kind: categories
+            metadata:
+              name: categories
+            spec:
+              categories:
+                - id: user_actions
+        expected_diagnostics:
+          - file: "spec.yaml"
+            reference: "/spec/categories/0/name"
+            severity: "error"
+            message_contains: "'name' is required"

--- a/cli/internal/providers/datacatalog/docs/custom-types-config-valid.docs.yaml
+++ b/cli/internal/providers/datacatalog/docs/custom-types-config-valid.docs.yaml
@@ -1,0 +1,103 @@
+rule_id: "datacatalog/custom-types/config-valid"
+match_behavior:
+  # Legacy spec versions share the same config validation path.
+  - applies_to:
+      - kind: "custom-types"
+        version: "rudder/0.1"
+      - kind: "custom-types"
+        version: "rudder/v0.1"
+    valid:
+      - example_id: "ct-cfg-legacy-valid-string"
+        title: "Valid string config with enum (legacy)"
+        files:
+          spec.yaml: |
+            version: rudder/0.1
+            kind: custom-types
+            metadata:
+              name: my-custom-types
+            spec:
+              types:
+                - id: user_status
+                  name: UserStatus
+                  type: string
+                  config:
+                    enum: ["active", "inactive"]
+                    pattern: "^[a-z]+$"
+      - example_id: "ct-cfg-legacy-valid-integer"
+        title: "Valid integer config with range (legacy)"
+        files:
+          spec.yaml: |
+            version: rudder/0.1
+            kind: custom-types
+            metadata:
+              name: my-custom-types
+            spec:
+              types:
+                - id: age
+                  name: Age
+                  type: integer
+                  config:
+                    minimum: 0
+                    maximum: 120
+    invalid:
+      - example_id: "ct-cfg-legacy-invalid-format"
+        title: "String config with invalid format value (legacy)"
+        files:
+          spec.yaml: |
+            version: rudder/0.1
+            kind: custom-types
+            metadata:
+              name: my-custom-types
+            spec:
+              types:
+                - id: user_email
+                  name: UserEmail
+                  type: string
+                  config:
+                    format: invalid_format
+        expected_diagnostics:
+          - file: "spec.yaml"
+            reference: "/types/0/config/format"
+            severity: "error"
+            message_contains: "invalid_format"
+  # Current spec version (rudder/v1).
+  - applies_to:
+      - kind: "custom-types"
+        version: "rudder/v1"
+    valid:
+      - example_id: "ct-cfg-v1-valid-string"
+        title: "Valid v1 string config with pattern"
+        files:
+          spec.yaml: |
+            version: rudder/v1
+            kind: custom-types
+            metadata:
+              name: my-custom-types
+            spec:
+              types:
+                - id: user_status
+                  name: UserStatus
+                  type: string
+                  config:
+                    enum: ["active", "inactive"]
+    invalid:
+      - example_id: "ct-cfg-v1-invalid-format"
+        title: "v1 string config with invalid format value"
+        files:
+          spec.yaml: |
+            version: rudder/v1
+            kind: custom-types
+            metadata:
+              name: my-custom-types
+            spec:
+              types:
+                - id: user_email
+                  name: UserEmail
+                  type: string
+                  config:
+                    format: not_a_valid_format
+        expected_diagnostics:
+          - file: "spec.yaml"
+            reference: "/types/0/config/format"
+            severity: "error"
+            message_contains: "not_a_valid_format"

--- a/cli/internal/providers/datacatalog/docs/custom-types-semantic-valid.docs.yaml
+++ b/cli/internal/providers/datacatalog/docs/custom-types-semantic-valid.docs.yaml
@@ -1,0 +1,86 @@
+rule_id: "datacatalog/custom-types/semantic-valid"
+match_behavior:
+  # Legacy spec versions share the same semantic validation path.
+  - applies_to:
+      - kind: "custom-types"
+        version: "rudder/0.1"
+      - kind: "custom-types"
+        version: "rudder/v0.1"
+    valid:
+      - example_id: "ct-sem-legacy-valid"
+        title: "Unique custom type names (legacy)"
+        files:
+          spec.yaml: |
+            version: rudder/0.1
+            kind: custom-types
+            metadata:
+              name: my-custom-types
+            spec:
+              types:
+                - id: address
+                  name: Address
+                  type: object
+                - id: user_status
+                  name: UserStatus
+                  type: string
+    invalid:
+      - example_id: "ct-sem-legacy-duplicate-name"
+        title: "Duplicate custom type name across files (legacy)"
+        description: "Two custom types with the same name in the resource graph trigger this error."
+        files:
+          spec.yaml: |
+            version: rudder/0.1
+            kind: custom-types
+            metadata:
+              name: my-custom-types
+            spec:
+              types:
+                - id: address_v2
+                  name: Address
+                  type: object
+        expected_diagnostics:
+          - file: "spec.yaml"
+            reference: "/types/0/name"
+            severity: "error"
+            message_contains: "duplicate name 'Address' within kind 'custom-types'"
+  # Current spec version (rudder/v1).
+  - applies_to:
+      - kind: "custom-types"
+        version: "rudder/v1"
+    valid:
+      - example_id: "ct-sem-v1-valid"
+        title: "Unique custom type names (v1)"
+        files:
+          spec.yaml: |
+            version: rudder/v1
+            kind: custom-types
+            metadata:
+              name: my-custom-types
+            spec:
+              types:
+                - id: address
+                  name: Address
+                  type: object
+                - id: user_status
+                  name: UserStatus
+                  type: string
+    invalid:
+      - example_id: "ct-sem-v1-duplicate-name"
+        title: "Duplicate custom type name across files (v1)"
+        description: "Two custom types with the same name in the resource graph trigger this error."
+        files:
+          spec.yaml: |
+            version: rudder/v1
+            kind: custom-types
+            metadata:
+              name: my-custom-types
+            spec:
+              types:
+                - id: address_v2
+                  name: Address
+                  type: object
+        expected_diagnostics:
+          - file: "spec.yaml"
+            reference: "/types/0/name"
+            severity: "error"
+            message_contains: "duplicate name 'Address' within kind 'custom-types'"

--- a/cli/internal/providers/datacatalog/docs/custom-types-spec-syntax-valid.docs.yaml
+++ b/cli/internal/providers/datacatalog/docs/custom-types-spec-syntax-valid.docs.yaml
@@ -1,0 +1,101 @@
+rule_id: "datacatalog/custom-types/spec-syntax-valid"
+match_behavior:
+  # Legacy spec versions (rudder/0.1 and rudder/v0.1) share the same
+  # custom-type spec shape, so they are documented together.
+  - applies_to:
+      - kind: "custom-types"
+        version: "rudder/0.1"
+      - kind: "custom-types"
+        version: "rudder/v0.1"
+    valid:
+      - example_id: "ct-spec-legacy-valid"
+        title: "Valid legacy custom-types spec"
+        files:
+          spec.yaml: |
+            version: rudder/0.1
+            kind: custom-types
+            metadata:
+              name: my-custom-types
+            spec:
+              types:
+                - id: address
+                  name: Address
+                  description: Physical address structure
+                  type: object
+                - id: user_status
+                  name: UserStatus
+                  type: string
+    invalid:
+      - example_id: "ct-spec-legacy-missing-name"
+        title: "Legacy custom type missing the required name field"
+        files:
+          spec.yaml: |
+            version: rudder/0.1
+            kind: custom-types
+            metadata:
+              name: my-custom-types
+            spec:
+              types:
+                - id: user_status
+                  type: string
+        expected_diagnostics:
+          - file: "spec.yaml"
+            reference: "/types/0/name"
+            severity: "error"
+            message_contains: "'name' is required"
+      - example_id: "ct-spec-legacy-missing-type"
+        title: "Legacy custom type missing the required type field"
+        files:
+          spec.yaml: |
+            version: rudder/0.1
+            kind: custom-types
+            metadata:
+              name: my-custom-types
+            spec:
+              types:
+                - id: address
+                  name: Address
+        expected_diagnostics:
+          - file: "spec.yaml"
+            reference: "/types/0/type"
+            severity: "error"
+            message_contains: "'type' is required"
+  # Current spec version (rudder/v1).
+  - applies_to:
+      - kind: "custom-types"
+        version: "rudder/v1"
+    valid:
+      - example_id: "ct-spec-v1-valid"
+        title: "Valid v1 custom-types spec"
+        files:
+          spec.yaml: |
+            version: rudder/v1
+            kind: custom-types
+            metadata:
+              name: my-custom-types
+            spec:
+              types:
+                - id: address
+                  name: Address
+                  type: object
+                - id: user_status
+                  name: UserStatus
+                  type: string
+    invalid:
+      - example_id: "ct-spec-v1-missing-id"
+        title: "v1 custom type missing the required id field"
+        files:
+          spec.yaml: |
+            version: rudder/v1
+            kind: custom-types
+            metadata:
+              name: my-custom-types
+            spec:
+              types:
+                - name: UserStatus
+                  type: string
+        expected_diagnostics:
+          - file: "spec.yaml"
+            reference: "/types/0/id"
+            severity: "error"
+            message_contains: "'id' is required"

--- a/cli/internal/providers/datacatalog/docs/embed.go
+++ b/cli/internal/providers/datacatalog/docs/embed.go
@@ -1,0 +1,6 @@
+package docs
+
+import "embed"
+
+//go:embed *.docs.yaml
+var FragmentsFS embed.FS

--- a/cli/internal/providers/datacatalog/docs/events-semantic-valid.docs.yaml
+++ b/cli/internal/providers/datacatalog/docs/events-semantic-valid.docs.yaml
@@ -1,0 +1,86 @@
+rule_id: "datacatalog/events/semantic-valid"
+match_behavior:
+  # Legacy spec versions share the same semantic validation path.
+  - applies_to:
+      - kind: "events"
+        version: "rudder/0.1"
+      - kind: "events"
+        version: "rudder/v0.1"
+    valid:
+      - example_id: "ev-sem-legacy-valid"
+        title: "Unique event (name, type) combinations (legacy)"
+        files:
+          spec.yaml: |
+            version: rudder/0.1
+            kind: events
+            metadata:
+              name: my-events
+            spec:
+              events:
+                - id: page_viewed
+                  event_type: track
+                  name: Page Viewed
+                - id: product_clicked
+                  event_type: track
+                  name: Product Clicked
+    invalid:
+      - example_id: "ev-sem-legacy-duplicate"
+        title: "Duplicate (name, type) event combination across files (legacy)"
+        description: "Two events with the same name and event_type in the resource graph trigger this error."
+        files:
+          spec.yaml: |
+            version: rudder/0.1
+            kind: events
+            metadata:
+              name: my-events
+            spec:
+              events:
+                - id: page_viewed_2
+                  event_type: track
+                  name: Page Viewed
+        expected_diagnostics:
+          - file: "spec.yaml"
+            reference: "/events/0"
+            severity: "error"
+            message_contains: "duplicate name 'Page Viewed' within kind 'events'"
+  # Current spec version (rudder/v1).
+  - applies_to:
+      - kind: "events"
+        version: "rudder/v1"
+    valid:
+      - example_id: "ev-sem-v1-valid"
+        title: "Unique event (name, type) combinations (v1)"
+        files:
+          spec.yaml: |
+            version: rudder/v1
+            kind: events
+            metadata:
+              name: my-events
+            spec:
+              events:
+                - id: page_viewed
+                  event_type: track
+                  name: Page Viewed
+                - id: product_clicked
+                  event_type: track
+                  name: Product Clicked
+    invalid:
+      - example_id: "ev-sem-v1-duplicate"
+        title: "Duplicate (name, type) event combination across files (v1)"
+        description: "Two events with the same name and event_type in the resource graph trigger this error."
+        files:
+          spec.yaml: |
+            version: rudder/v1
+            kind: events
+            metadata:
+              name: my-events
+            spec:
+              events:
+                - id: page_viewed_2
+                  event_type: track
+                  name: Page Viewed
+        expected_diagnostics:
+          - file: "spec.yaml"
+            reference: "/events/0"
+            severity: "error"
+            message_contains: "duplicate name 'Page Viewed' within kind 'events'"

--- a/cli/internal/providers/datacatalog/docs/events-spec-syntax-valid.docs.yaml
+++ b/cli/internal/providers/datacatalog/docs/events-spec-syntax-valid.docs.yaml
@@ -1,0 +1,98 @@
+rule_id: "datacatalog/events/spec-syntax-valid"
+match_behavior:
+  # Legacy spec versions share the same event spec shape and validation.
+  - applies_to:
+      - kind: "events"
+        version: "rudder/0.1"
+      - kind: "events"
+        version: "rudder/v0.1"
+    valid:
+      - example_id: "ev-spec-legacy-valid"
+        title: "Valid legacy events spec"
+        files:
+          spec.yaml: |
+            version: rudder/0.1
+            kind: events
+            metadata:
+              name: my-events
+            spec:
+              events:
+                - id: page_viewed
+                  event_type: track
+                  name: Page Viewed
+                  description: User viewed a page
+                - id: user_identified
+                  event_type: identify
+    invalid:
+      - example_id: "ev-spec-legacy-missing-id"
+        title: "Legacy event missing the required id field"
+        files:
+          spec.yaml: |
+            version: rudder/0.1
+            kind: events
+            metadata:
+              name: my-events
+            spec:
+              events:
+                - name: Page Viewed
+                  event_type: track
+        expected_diagnostics:
+          - file: "spec.yaml"
+            reference: "/events/0/id"
+            severity: "error"
+            message_contains: "'id' is required"
+      - example_id: "ev-spec-legacy-invalid-type"
+        title: "Legacy event with invalid event_type"
+        files:
+          spec.yaml: |
+            version: rudder/0.1
+            kind: events
+            metadata:
+              name: my-events
+            spec:
+              events:
+                - id: my_event
+                  event_type: custom
+        expected_diagnostics:
+          - file: "spec.yaml"
+            reference: "/events/0/event_type"
+            severity: "error"
+            message_contains: "oneof"
+  # Current spec version (rudder/v1).
+  - applies_to:
+      - kind: "events"
+        version: "rudder/v1"
+    valid:
+      - example_id: "ev-spec-v1-valid"
+        title: "Valid v1 events spec"
+        files:
+          spec.yaml: |
+            version: rudder/v1
+            kind: events
+            metadata:
+              name: my-events
+            spec:
+              events:
+                - id: page_viewed
+                  event_type: track
+                  name: Page Viewed
+                - id: user_identified
+                  event_type: identify
+    invalid:
+      - example_id: "ev-spec-v1-missing-event-type"
+        title: "v1 event missing the required event_type field"
+        files:
+          spec.yaml: |
+            version: rudder/v1
+            kind: events
+            metadata:
+              name: my-events
+            spec:
+              events:
+                - id: page_viewed
+                  name: Page Viewed
+        expected_diagnostics:
+          - file: "spec.yaml"
+            reference: "/events/0/event_type"
+            severity: "error"
+            message_contains: "'event_type' is required"

--- a/cli/internal/providers/datacatalog/docs/properties-config-valid.docs.yaml
+++ b/cli/internal/providers/datacatalog/docs/properties-config-valid.docs.yaml
@@ -1,0 +1,105 @@
+rule_id: "datacatalog/properties/config-valid"
+match_behavior:
+  # Legacy spec versions share the same config validation path.
+  - applies_to:
+      - kind: "properties"
+        version: "rudder/0.1"
+      - kind: "properties"
+        version: "rudder/v0.1"
+    valid:
+      - example_id: "prop-cfg-legacy-valid-string"
+        title: "Valid string property config with format (legacy)"
+        files:
+          spec.yaml: |
+            version: rudder/0.1
+            kind: properties
+            metadata:
+              name: my-properties
+            spec:
+              properties:
+                - id: user_email
+                  name: User Email
+                  type: string
+                  propConfig:
+                    format: "email"
+                    minLength: 5
+                    maxLength: 100
+      - example_id: "prop-cfg-legacy-valid-integer"
+        title: "Valid integer property config with range (legacy)"
+        files:
+          spec.yaml: |
+            version: rudder/0.1
+            kind: properties
+            metadata:
+              name: my-properties
+            spec:
+              properties:
+                - id: age
+                  name: Age
+                  type: integer
+                  propConfig:
+                    minimum: 0
+                    maximum: 120
+    invalid:
+      - example_id: "prop-cfg-legacy-invalid-format"
+        title: "String property config with invalid format value (legacy)"
+        files:
+          spec.yaml: |
+            version: rudder/0.1
+            kind: properties
+            metadata:
+              name: my-properties
+            spec:
+              properties:
+                - id: user_email
+                  name: User Email
+                  type: string
+                  propConfig:
+                    format: not_valid
+        expected_diagnostics:
+          - file: "spec.yaml"
+            reference: "/properties/0/propConfig/format"
+            severity: "error"
+            message_contains: "not_valid"
+  # Current spec version (rudder/v1).
+  - applies_to:
+      - kind: "properties"
+        version: "rudder/v1"
+    valid:
+      - example_id: "prop-cfg-v1-valid-string"
+        title: "Valid v1 string property config"
+        files:
+          spec.yaml: |
+            version: rudder/v1
+            kind: properties
+            metadata:
+              name: my-properties
+            spec:
+              properties:
+                - id: user_email
+                  name: User Email
+                  type: string
+                  config:
+                    format: "email"
+                    min_length: 5
+    invalid:
+      - example_id: "prop-cfg-v1-invalid-format"
+        title: "v1 string property config with invalid format value"
+        files:
+          spec.yaml: |
+            version: rudder/v1
+            kind: properties
+            metadata:
+              name: my-properties
+            spec:
+              properties:
+                - id: user_email
+                  name: User Email
+                  type: string
+                  config:
+                    format: totally_wrong
+        expected_diagnostics:
+          - file: "spec.yaml"
+            reference: "/properties/0/propConfig/format"
+            severity: "error"
+            message_contains: "totally_wrong"

--- a/cli/internal/providers/datacatalog/docs/properties-semantic-valid.docs.yaml
+++ b/cli/internal/providers/datacatalog/docs/properties-semantic-valid.docs.yaml
@@ -1,0 +1,86 @@
+rule_id: "datacatalog/properties/semantic-valid"
+match_behavior:
+  # Legacy spec versions share the same semantic validation path.
+  - applies_to:
+      - kind: "properties"
+        version: "rudder/0.1"
+      - kind: "properties"
+        version: "rudder/v0.1"
+    valid:
+      - example_id: "prop-sem-legacy-valid"
+        title: "Unique (name, type) property combinations (legacy)"
+        files:
+          spec.yaml: |
+            version: rudder/0.1
+            kind: properties
+            metadata:
+              name: my-properties
+            spec:
+              properties:
+                - id: user_id
+                  name: User ID
+                  type: string
+                - id: email
+                  name: Email
+                  type: string
+    invalid:
+      - example_id: "prop-sem-legacy-duplicate"
+        title: "Duplicate (name, type, itemTypes) property combination across files (legacy)"
+        description: "Two properties with the same name, type, and itemTypes in the resource graph trigger this error."
+        files:
+          spec.yaml: |
+            version: rudder/0.1
+            kind: properties
+            metadata:
+              name: my-properties
+            spec:
+              properties:
+                - id: user_id_2
+                  name: User ID
+                  type: string
+        expected_diagnostics:
+          - file: "spec.yaml"
+            reference: "/properties/0"
+            severity: "error"
+            message_contains: "duplicate name, type and itemTypes: 'User ID' within kind 'properties'"
+  # Current spec version (rudder/v1).
+  - applies_to:
+      - kind: "properties"
+        version: "rudder/v1"
+    valid:
+      - example_id: "prop-sem-v1-valid"
+        title: "Unique (name, type) property combinations (v1)"
+        files:
+          spec.yaml: |
+            version: rudder/v1
+            kind: properties
+            metadata:
+              name: my-properties
+            spec:
+              properties:
+                - id: user_id
+                  name: User ID
+                  type: string
+                - id: email
+                  name: Email
+                  type: string
+    invalid:
+      - example_id: "prop-sem-v1-duplicate"
+        title: "Duplicate (name, type, itemTypes) property combination across files (v1)"
+        description: "Two properties with the same name, type, and itemTypes in the resource graph trigger this error."
+        files:
+          spec.yaml: |
+            version: rudder/v1
+            kind: properties
+            metadata:
+              name: my-properties
+            spec:
+              properties:
+                - id: user_id_2
+                  name: User ID
+                  type: string
+        expected_diagnostics:
+          - file: "spec.yaml"
+            reference: "/properties/0"
+            severity: "error"
+            message_contains: "duplicate name, type and itemTypes: 'User ID' within kind 'properties'"

--- a/cli/internal/providers/datacatalog/docs/properties-spec-syntax-valid.docs.yaml
+++ b/cli/internal/providers/datacatalog/docs/properties-spec-syntax-valid.docs.yaml
@@ -1,0 +1,100 @@
+rule_id: "datacatalog/properties/spec-syntax-valid"
+match_behavior:
+  # Legacy spec versions share the same property spec shape and validation.
+  - applies_to:
+      - kind: "properties"
+        version: "rudder/0.1"
+      - kind: "properties"
+        version: "rudder/v0.1"
+    valid:
+      - example_id: "prop-spec-legacy-valid"
+        title: "Valid legacy properties spec"
+        files:
+          spec.yaml: |
+            version: rudder/0.1
+            kind: properties
+            metadata:
+              name: my-properties
+            spec:
+              properties:
+                - id: user_id
+                  name: User ID
+                  description: Unique identifier for the user
+                  type: string
+                - id: email
+                  name: Email
+                  type: string
+    invalid:
+      - example_id: "prop-spec-legacy-missing-id"
+        title: "Legacy property missing the required id field"
+        files:
+          spec.yaml: |
+            version: rudder/0.1
+            kind: properties
+            metadata:
+              name: my-properties
+            spec:
+              properties:
+                - name: User ID
+                  type: string
+        expected_diagnostics:
+          - file: "spec.yaml"
+            reference: "/properties/0/id"
+            severity: "error"
+            message_contains: "'id' is required"
+      - example_id: "prop-spec-legacy-missing-name"
+        title: "Legacy property missing the required name field"
+        files:
+          spec.yaml: |
+            version: rudder/0.1
+            kind: properties
+            metadata:
+              name: my-properties
+            spec:
+              properties:
+                - id: user_id
+                  type: string
+        expected_diagnostics:
+          - file: "spec.yaml"
+            reference: "/properties/0/name"
+            severity: "error"
+            message_contains: "'name' is required"
+  # Current spec version (rudder/v1).
+  - applies_to:
+      - kind: "properties"
+        version: "rudder/v1"
+    valid:
+      - example_id: "prop-spec-v1-valid"
+        title: "Valid v1 properties spec"
+        files:
+          spec.yaml: |
+            version: rudder/v1
+            kind: properties
+            metadata:
+              name: my-properties
+            spec:
+              properties:
+                - id: user_id
+                  name: User ID
+                  type: string
+                - id: age
+                  name: Age
+                  type: integer
+    invalid:
+      - example_id: "prop-spec-v1-missing-id"
+        title: "v1 property missing the required id field"
+        files:
+          spec.yaml: |
+            version: rudder/v1
+            kind: properties
+            metadata:
+              name: my-properties
+            spec:
+              properties:
+                - name: User ID
+                  type: string
+        expected_diagnostics:
+          - file: "spec.yaml"
+            reference: "/properties/0/id"
+            severity: "error"
+            message_contains: "'id' is required"

--- a/cli/internal/providers/datacatalog/docs/tracking-plans-semantic-valid.docs.yaml
+++ b/cli/internal/providers/datacatalog/docs/tracking-plans-semantic-valid.docs.yaml
@@ -1,0 +1,91 @@
+rule_id: "datacatalog/tracking-plans/semantic-valid"
+match_behavior:
+  # Legacy spec versions (rudder/0.1 and rudder/v0.1) use kind "tp" and share the same
+  # semantic validation path.
+  - applies_to:
+      - kind: "tp"
+        version: "rudder/0.1"
+      - kind: "tp"
+        version: "rudder/v0.1"
+    valid:
+      - example_id: "tp-sem-legacy-valid"
+        title: "Tracking plan with unique display_name and no duplicate events (legacy)"
+        files:
+          spec.yaml: |
+            version: rudder/0.1
+            kind: tp
+            metadata:
+              name: my-tracking-plan
+            spec:
+              id: my_tp
+              display_name: My Tracking Plan
+              rules:
+                - id: signup_rule
+                  type: event_rule
+                  event:
+                    $ref: "#/events/user-events/signup"
+    invalid:
+      - example_id: "tp-sem-legacy-duplicate-display-name"
+        title: "Duplicate tracking plan display_name across files (legacy)"
+        description: "Two tracking plans with the same display_name in the resource graph trigger this error."
+        files:
+          spec.yaml: |
+            version: rudder/0.1
+            kind: tp
+            metadata:
+              name: my-tracking-plan-2
+            spec:
+              id: my_tp_2
+              display_name: My Tracking Plan
+              rules:
+                - id: page_rule
+                  type: event_rule
+                  event:
+                    $ref: "#/events/user-events/page_view"
+        expected_diagnostics:
+          - file: "spec.yaml"
+            reference: "/display_name"
+            severity: "error"
+            message_contains: "duplicate display_name 'My Tracking Plan' within kind 'tp'"
+  # Current spec version (rudder/v1) uses kind "tracking-plan".
+  - applies_to:
+      - kind: "tracking-plan"
+        version: "rudder/v1"
+    valid:
+      - example_id: "tp-sem-v1-valid"
+        title: "Tracking plan with unique display_name and no duplicate events (v1)"
+        files:
+          spec.yaml: |
+            version: rudder/v1
+            kind: tracking-plan
+            metadata:
+              name: my-tracking-plan
+            spec:
+              id: my_tp
+              display_name: My Tracking Plan
+              rules:
+                - id: signup_rule
+                  type: event_rule
+                  event: "#event:signup"
+    invalid:
+      - example_id: "tp-sem-v1-duplicate-display-name"
+        title: "Duplicate tracking plan display_name across files (v1)"
+        description: "Two tracking plans with the same display_name in the resource graph trigger this error."
+        files:
+          spec.yaml: |
+            version: rudder/v1
+            kind: tracking-plan
+            metadata:
+              name: my-tracking-plan-2
+            spec:
+              id: my_tp_2
+              display_name: My Tracking Plan
+              rules:
+                - id: page_rule
+                  type: event_rule
+                  event: "#event:page_view"
+        expected_diagnostics:
+          - file: "spec.yaml"
+            reference: "/display_name"
+            severity: "error"
+            message_contains: "duplicate display_name 'My Tracking Plan' within kind 'tracking-plan'"

--- a/cli/internal/providers/datacatalog/docs/tracking-plans-spec-syntax-valid.docs.yaml
+++ b/cli/internal/providers/datacatalog/docs/tracking-plans-spec-syntax-valid.docs.yaml
@@ -1,0 +1,98 @@
+rule_id: "datacatalog/tracking-plans/spec-syntax-valid"
+match_behavior:
+  # Legacy spec versions (rudder/0.1 and rudder/v0.1) use kind "tp" and share the same
+  # TrackingPlan spec shape.
+  - applies_to:
+      - kind: "tp"
+        version: "rudder/0.1"
+      - kind: "tp"
+        version: "rudder/v0.1"
+    valid:
+      - example_id: "tp-spec-legacy-valid"
+        title: "Valid legacy tracking plan spec"
+        files:
+          spec.yaml: |
+            version: rudder/0.1
+            kind: tp
+            metadata:
+              name: my-tracking-plan
+            spec:
+              id: my_tp
+              display_name: My Tracking Plan
+              rules:
+                - id: signup_rule
+                  type: event_rule
+                  event:
+                    $ref: "#/events/user-events/signup"
+                  properties:
+                    - $ref: "#/properties/common/user_id"
+                      required: true
+    invalid:
+      - example_id: "tp-spec-legacy-missing-event"
+        title: "Legacy tracking plan rule missing the event field"
+        files:
+          spec.yaml: |
+            version: rudder/0.1
+            kind: tp
+            metadata:
+              name: my-tracking-plan
+            spec:
+              id: my_tp
+              display_name: My Tracking Plan
+              rules:
+                - id: no_event_rule
+                  type: event_rule
+                  properties:
+                    - $ref: "#/properties/common/user_id"
+                      required: true
+        expected_diagnostics:
+          - file: "spec.yaml"
+            reference: "/rules/0/event"
+            severity: "error"
+            message_contains: "'event' is required"
+  # Current spec version (rudder/v1) uses kind "tracking-plan".
+  - applies_to:
+      - kind: "tracking-plan"
+        version: "rudder/v1"
+    valid:
+      - example_id: "tp-spec-v1-valid"
+        title: "Valid v1 tracking plan spec"
+        files:
+          spec.yaml: |
+            version: rudder/v1
+            kind: tracking-plan
+            metadata:
+              name: my-tracking-plan
+            spec:
+              id: my_tp
+              display_name: My Tracking Plan
+              rules:
+                - id: signup_rule
+                  type: event_rule
+                  event: "#event:signup"
+                  properties:
+                    - property: "#property:user_id"
+                      required: true
+    invalid:
+      - example_id: "tp-spec-v1-missing-event"
+        title: "v1 tracking plan rule missing the event field"
+        files:
+          spec.yaml: |
+            version: rudder/v1
+            kind: tracking-plan
+            metadata:
+              name: my-tracking-plan
+            spec:
+              id: my_tp
+              display_name: My Tracking Plan
+              rules:
+                - id: no_event_rule
+                  type: event_rule
+                  properties:
+                    - property: "#property:user_id"
+                      required: true
+        expected_diagnostics:
+          - file: "spec.yaml"
+            reference: "/rules/0/event"
+            severity: "error"
+            message_contains: "'event' is required"

--- a/cli/internal/providers/datacatalog/provider.go
+++ b/cli/internal/providers/datacatalog/provider.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rudderlabs/rudder-iac/cli/internal/project/specs"
 	"github.com/rudderlabs/rudder-iac/cli/internal/provider"
 	prules "github.com/rudderlabs/rudder-iac/cli/internal/provider/rules"
+	dcdocs "github.com/rudderlabs/rudder-iac/cli/internal/providers/datacatalog/docs"
 	"github.com/rudderlabs/rudder-iac/cli/internal/providers/datacatalog/localcatalog"
 	_ "github.com/rudderlabs/rudder-iac/cli/internal/providers/datacatalog/rules"
 	categoryRules "github.com/rudderlabs/rudder-iac/cli/internal/providers/datacatalog/rules/category"
@@ -22,6 +23,7 @@ import (
 	pstate "github.com/rudderlabs/rudder-iac/cli/internal/providers/datacatalog/state"
 	"github.com/rudderlabs/rudder-iac/cli/internal/providers/datacatalog/types"
 	"github.com/rudderlabs/rudder-iac/cli/internal/resources"
+	"github.com/rudderlabs/rudder-iac/cli/internal/validation/docs"
 	"github.com/rudderlabs/rudder-iac/cli/internal/validation/rules"
 	"github.com/samber/lo"
 )
@@ -364,6 +366,13 @@ func (p *Provider) SyntacticRules() []rules.Rule {
 	}
 
 	return syntactic
+}
+
+// RuleDocEntries returns the authored documentation fragments embedded with
+// the datacatalog provider, joined to registered rules by the docs generator.
+func (p *Provider) RuleDocEntries() []docs.RuleDocEntry {
+	entries, _ := docs.LoadRuleDocEntries(dcdocs.FragmentsFS, ".")
+	return entries
 }
 
 func (p *Provider) SemanticRules() []rules.Rule {

--- a/cli/internal/providers/datacatalog/ruledoc_test.go
+++ b/cli/internal/providers/datacatalog/ruledoc_test.go
@@ -1,0 +1,24 @@
+package datacatalog_test
+
+import (
+	"testing"
+
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/datacatalog"
+	"github.com/rudderlabs/rudder-iac/cli/internal/validation/docs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestProviderRuleDocs runs the provider's authored fragments through the real
+// docs generator together with its live rules, asserting every rule resolves
+// and passes the DocumentedRules validation invariants.
+func TestProviderRuleDocs(t *testing.T) {
+	p := datacatalog.New(&MockCategoryCatalog{})
+
+	syntactic := p.SyntacticRules()
+	semantic := p.SemanticRules()
+
+	doc, verrs := docs.Generate(syntactic, semantic, p.RuleDocEntries(), "test", "2026-06-03T00:00:00Z")
+	assert.Empty(t, verrs, "expected no validation errors, got: %v", verrs)
+	require.Len(t, doc.Rules, len(syntactic)+len(semantic))
+}

--- a/cli/internal/providers/datagraph/docs/datagraph-spec-syntax-valid.docs.yaml
+++ b/cli/internal/providers/datagraph/docs/datagraph-spec-syntax-valid.docs.yaml
@@ -1,0 +1,116 @@
+rule_id: "datagraph/data-graph/spec-syntax-valid"
+match_behavior:
+  - applies_to:
+      - kind: "data-graph"
+        version: "rudder/v1"
+    valid:
+      - example_id: "dg-spec-syntax-valid-entity-event"
+        title: "Valid data-graph spec with entity and event models"
+        files:
+          spec.yaml: |
+            version: rudder/v1
+            kind: data-graph
+            metadata:
+              name: my-data-graph
+            spec:
+              id: my-data-graph
+              account_id: wh-account-123
+              models:
+                - id: user
+                  display_name: User
+                  type: entity
+                  table: db.schema.users
+                  primary_id: user_id
+                  root: true
+                - id: purchase
+                  display_name: Purchase
+                  type: event
+                  table: db.schema.purchases
+                  timestamp: purchased_at
+                  relationships:
+                    - id: purchase-user
+                      display_name: Purchase User
+                      cardinality: many-to-one
+                      target: "#data-graph-model:user"
+                      source_join_key: user_id
+                      target_join_key: user_id
+    invalid:
+      - example_id: "dg-spec-syntax-missing-account-id"
+        title: "Data-graph missing required account_id"
+        files:
+          spec.yaml: |
+            version: rudder/v1
+            kind: data-graph
+            metadata:
+              name: my-data-graph
+            spec:
+              id: my-data-graph
+        expected_diagnostics:
+          - file: "spec.yaml"
+            reference: "/account_id"
+            severity: "error"
+            message_contains: "'account_id' is required"
+      - example_id: "dg-spec-syntax-entity-missing-primary-id"
+        title: "Entity model missing required primary_id field"
+        files:
+          spec.yaml: |
+            version: rudder/v1
+            kind: data-graph
+            metadata:
+              name: my-data-graph
+            spec:
+              id: my-data-graph
+              account_id: wh-account-123
+              models:
+                - id: user
+                  display_name: User
+                  type: entity
+                  table: db.schema.users
+        expected_diagnostics:
+          - file: "spec.yaml"
+            reference: "/models/0/primary_id"
+            severity: "error"
+            message_contains: "'primary_id' is required for entity models"
+      - example_id: "dg-spec-syntax-event-missing-timestamp"
+        title: "Event model missing required timestamp field"
+        files:
+          spec.yaml: |
+            version: rudder/v1
+            kind: data-graph
+            metadata:
+              name: my-data-graph
+            spec:
+              id: my-data-graph
+              account_id: wh-account-123
+              models:
+                - id: purchase
+                  display_name: Purchase
+                  type: event
+                  table: db.schema.purchases
+        expected_diagnostics:
+          - file: "spec.yaml"
+            reference: "/models/0/timestamp"
+            severity: "error"
+            message_contains: "'timestamp' is required for event models"
+      - example_id: "dg-spec-syntax-invalid-table-format"
+        title: "Model table must be a 3-part catalog.schema.table reference"
+        files:
+          spec.yaml: |
+            version: rudder/v1
+            kind: data-graph
+            metadata:
+              name: my-data-graph
+            spec:
+              id: my-data-graph
+              account_id: wh-account-123
+              models:
+                - id: user
+                  display_name: User
+                  type: entity
+                  table: schema.users
+                  primary_id: user_id
+        expected_diagnostics:
+          - file: "spec.yaml"
+            reference: "/models/0/table"
+            severity: "error"
+            message_contains: "'table' must be a 3-part reference in the format catalog.schema.table"

--- a/cli/internal/providers/datagraph/docs/embed.go
+++ b/cli/internal/providers/datagraph/docs/embed.go
@@ -1,0 +1,6 @@
+package docs
+
+import "embed"
+
+//go:embed *.docs.yaml
+var FragmentsFS embed.FS

--- a/cli/internal/providers/datagraph/docs/relationship-cardinality-valid.docs.yaml
+++ b/cli/internal/providers/datagraph/docs/relationship-cardinality-valid.docs.yaml
@@ -1,0 +1,167 @@
+rule_id: "datagraph/data-graph/relationship-cardinality-valid"
+match_behavior:
+  - applies_to:
+      - kind: "data-graph"
+        version: "rudder/v1"
+    valid:
+      - example_id: "dg-cardinality-entity-to-entity"
+        title: "Entity-to-entity relationship with any cardinality is valid"
+        files:
+          spec.yaml: |
+            version: rudder/v1
+            kind: data-graph
+            metadata:
+              name: my-data-graph
+            spec:
+              id: my-data-graph
+              account_id: wh-account-123
+              models:
+                - id: user
+                  display_name: User
+                  type: entity
+                  table: db.schema.users
+                  primary_id: user_id
+                  relationships:
+                    - id: user-account
+                      display_name: User Account
+                      cardinality: one-to-one
+                      target: "#data-graph-model:account"
+                      source_join_key: account_id
+                      target_join_key: account_id
+                - id: account
+                  display_name: Account
+                  type: entity
+                  table: db.schema.accounts
+                  primary_id: account_id
+      - example_id: "dg-cardinality-event-to-entity-many-to-one"
+        title: "Event-to-entity relationship must use many-to-one cardinality"
+        files:
+          spec.yaml: |
+            version: rudder/v1
+            kind: data-graph
+            metadata:
+              name: my-data-graph
+            spec:
+              id: my-data-graph
+              account_id: wh-account-123
+              models:
+                - id: purchase
+                  display_name: Purchase
+                  type: event
+                  table: db.schema.purchases
+                  timestamp: purchased_at
+                  relationships:
+                    - id: purchase-user
+                      display_name: Purchase User
+                      cardinality: many-to-one
+                      target: "#data-graph-model:user"
+                      source_join_key: user_id
+                      target_join_key: user_id
+                - id: user
+                  display_name: User
+                  type: entity
+                  table: db.schema.users
+                  primary_id: user_id
+    invalid:
+      - example_id: "dg-cardinality-event-to-event-rejected"
+        title: "Event models cannot be connected to other event models"
+        files:
+          spec.yaml: |
+            version: rudder/v1
+            kind: data-graph
+            metadata:
+              name: my-data-graph
+            spec:
+              id: my-data-graph
+              account_id: wh-account-123
+              models:
+                - id: purchase
+                  display_name: Purchase
+                  type: event
+                  table: db.schema.purchases
+                  timestamp: purchased_at
+                  relationships:
+                    - id: purchase-click
+                      display_name: Purchase Click
+                      cardinality: many-to-one
+                      target: "#data-graph-model:click"
+                      source_join_key: session_id
+                      target_join_key: session_id
+                - id: click
+                  display_name: Click
+                  type: event
+                  table: db.schema.clicks
+                  timestamp: clicked_at
+        expected_diagnostics:
+          - file: "spec.yaml"
+            reference: "/models/0/relationships/0/cardinality"
+            severity: "error"
+            message_contains: "event models cannot be connected to other event models"
+      - example_id: "dg-cardinality-event-to-entity-wrong-cardinality"
+        title: "Event-to-entity relationship must have cardinality many-to-one"
+        files:
+          spec.yaml: |
+            version: rudder/v1
+            kind: data-graph
+            metadata:
+              name: my-data-graph
+            spec:
+              id: my-data-graph
+              account_id: wh-account-123
+              models:
+                - id: purchase
+                  display_name: Purchase
+                  type: event
+                  table: db.schema.purchases
+                  timestamp: purchased_at
+                  relationships:
+                    - id: purchase-user
+                      display_name: Purchase User
+                      cardinality: one-to-many
+                      target: "#data-graph-model:user"
+                      source_join_key: user_id
+                      target_join_key: user_id
+                - id: user
+                  display_name: User
+                  type: entity
+                  table: db.schema.users
+                  primary_id: user_id
+        expected_diagnostics:
+          - file: "spec.yaml"
+            reference: "/models/0/relationships/0/cardinality"
+            severity: "error"
+            message_contains: "must have cardinality 'many-to-one'"
+      - example_id: "dg-cardinality-entity-to-event-wrong-cardinality"
+        title: "Entity-to-event relationship must have cardinality one-to-many"
+        files:
+          spec.yaml: |
+            version: rudder/v1
+            kind: data-graph
+            metadata:
+              name: my-data-graph
+            spec:
+              id: my-data-graph
+              account_id: wh-account-123
+              models:
+                - id: user
+                  display_name: User
+                  type: entity
+                  table: db.schema.users
+                  primary_id: user_id
+                  relationships:
+                    - id: user-purchase
+                      display_name: User Purchase
+                      cardinality: many-to-one
+                      target: "#data-graph-model:purchase"
+                      source_join_key: user_id
+                      target_join_key: user_id
+                - id: purchase
+                  display_name: Purchase
+                  type: event
+                  table: db.schema.purchases
+                  timestamp: purchased_at
+        expected_diagnostics:
+          - file: "spec.yaml"
+            reference: "/models/0/relationships/0/cardinality"
+            severity: "error"
+            message_contains: "must have cardinality 'one-to-many'"

--- a/cli/internal/providers/datagraph/docs/relationship-refs-valid.docs.yaml
+++ b/cli/internal/providers/datagraph/docs/relationship-refs-valid.docs.yaml
@@ -1,0 +1,65 @@
+rule_id: "datagraph/data-graph/relationship-refs-valid"
+match_behavior:
+  - applies_to:
+      - kind: "data-graph"
+        version: "rudder/v1"
+    valid:
+      - example_id: "dg-refs-valid-target-exists"
+        title: "Relationship target references an existing model in the same data-graph"
+        files:
+          spec.yaml: |
+            version: rudder/v1
+            kind: data-graph
+            metadata:
+              name: my-data-graph
+            spec:
+              id: my-data-graph
+              account_id: wh-account-123
+              models:
+                - id: user
+                  display_name: User
+                  type: entity
+                  table: db.schema.users
+                  primary_id: user_id
+                  relationships:
+                    - id: user-account
+                      display_name: User Account
+                      cardinality: one-to-one
+                      target: "#data-graph-model:account"
+                      source_join_key: account_id
+                      target_join_key: account_id
+                - id: account
+                  display_name: Account
+                  type: entity
+                  table: db.schema.accounts
+                  primary_id: account_id
+    invalid:
+      - example_id: "dg-refs-invalid-target-missing"
+        title: "Relationship target references a model that does not exist"
+        files:
+          spec.yaml: |
+            version: rudder/v1
+            kind: data-graph
+            metadata:
+              name: my-data-graph
+            spec:
+              id: my-data-graph
+              account_id: wh-account-123
+              models:
+                - id: user
+                  display_name: User
+                  type: entity
+                  table: db.schema.users
+                  primary_id: user_id
+                  relationships:
+                    - id: user-missing
+                      display_name: User Missing
+                      cardinality: one-to-one
+                      target: "#data-graph-model:non-existent"
+                      source_join_key: ref_id
+                      target_join_key: ref_id
+        expected_diagnostics:
+          - file: "spec.yaml"
+            reference: "/models/0/relationships/0/target"
+            severity: "error"
+            message_contains: "does not exist"

--- a/cli/internal/providers/datagraph/docs/relationship-unique-pair.docs.yaml
+++ b/cli/internal/providers/datagraph/docs/relationship-unique-pair.docs.yaml
@@ -1,0 +1,127 @@
+rule_id: "datagraph/data-graph/relationship-unique-pair"
+match_behavior:
+  - applies_to:
+      - kind: "data-graph"
+        version: "rudder/v1"
+    valid:
+      - example_id: "dg-unique-pair-different-targets"
+        title: "Multiple relationships from the same model to different targets are allowed"
+        files:
+          spec.yaml: |
+            version: rudder/v1
+            kind: data-graph
+            metadata:
+              name: my-data-graph
+            spec:
+              id: my-data-graph
+              account_id: wh-account-123
+              models:
+                - id: user
+                  display_name: User
+                  type: entity
+                  table: db.schema.users
+                  primary_id: user_id
+                  relationships:
+                    - id: user-account
+                      display_name: User Account
+                      cardinality: one-to-one
+                      target: "#data-graph-model:account"
+                      source_join_key: account_id
+                      target_join_key: account_id
+                    - id: user-profile
+                      display_name: User Profile
+                      cardinality: one-to-one
+                      target: "#data-graph-model:profile"
+                      source_join_key: profile_id
+                      target_join_key: profile_id
+                - id: account
+                  display_name: Account
+                  type: entity
+                  table: db.schema.accounts
+                  primary_id: account_id
+                - id: profile
+                  display_name: Profile
+                  type: entity
+                  table: db.schema.profiles
+                  primary_id: profile_id
+      - example_id: "dg-unique-pair-reversed-pair-allowed"
+        title: "A relationship A-to-B and B-to-A are distinct and both allowed"
+        files:
+          spec.yaml: |
+            version: rudder/v1
+            kind: data-graph
+            metadata:
+              name: my-data-graph
+            spec:
+              id: my-data-graph
+              account_id: wh-account-123
+              models:
+                - id: user
+                  display_name: User
+                  type: entity
+                  table: db.schema.users
+                  primary_id: user_id
+                  relationships:
+                    - id: user-to-account
+                      display_name: User to Account
+                      cardinality: one-to-one
+                      target: "#data-graph-model:account"
+                      source_join_key: account_id
+                      target_join_key: account_id
+                - id: account
+                  display_name: Account
+                  type: entity
+                  table: db.schema.accounts
+                  primary_id: account_id
+                  relationships:
+                    - id: account-to-user
+                      display_name: Account to User
+                      cardinality: one-to-one
+                      target: "#data-graph-model:user"
+                      source_join_key: account_id
+                      target_join_key: account_id
+    invalid:
+      - example_id: "dg-unique-pair-duplicate-source-target"
+        title: "Two relationships with the same source-target model pair are not allowed"
+        files:
+          spec.yaml: |
+            version: rudder/v1
+            kind: data-graph
+            metadata:
+              name: my-data-graph
+            spec:
+              id: my-data-graph
+              account_id: wh-account-123
+              models:
+                - id: user
+                  display_name: User
+                  type: entity
+                  table: db.schema.users
+                  primary_id: user_id
+                  relationships:
+                    - id: user-account-v1
+                      display_name: User Account v1
+                      cardinality: one-to-one
+                      target: "#data-graph-model:account"
+                      source_join_key: account_id
+                      target_join_key: account_id
+                    - id: user-account-v2
+                      display_name: User Account v2
+                      cardinality: one-to-many
+                      target: "#data-graph-model:account"
+                      source_join_key: account_id
+                      target_join_key: id
+                - id: account
+                  display_name: Account
+                  type: entity
+                  table: db.schema.accounts
+                  primary_id: account_id
+        expected_diagnostics:
+          - file: "spec.yaml"
+            reference: "/models/0/relationships/0"
+            severity: "error"
+            message_contains: "at most one relationship is allowed per source-target pair"
+          - file: "spec.yaml"
+            reference: "/models/0/relationships/1"
+            severity: "error"
+            message_contains: "at most one relationship is allowed per source-target pair"

--- a/cli/internal/providers/datagraph/docs/unique-names-valid.docs.yaml
+++ b/cli/internal/providers/datagraph/docs/unique-names-valid.docs.yaml
@@ -1,0 +1,117 @@
+rule_id: "datagraph/data-graph/unique-names-valid"
+match_behavior:
+  - applies_to:
+      - kind: "data-graph"
+        version: "rudder/v1"
+    valid:
+      - example_id: "dg-unique-names-all-unique"
+        title: "All model and relationship display names are unique within the data graph"
+        files:
+          spec.yaml: |
+            version: rudder/v1
+            kind: data-graph
+            metadata:
+              name: my-data-graph
+            spec:
+              id: my-data-graph
+              account_id: wh-account-123
+              models:
+                - id: user
+                  display_name: User
+                  type: entity
+                  table: db.schema.users
+                  primary_id: user_id
+                  relationships:
+                    - id: user-order
+                      display_name: User Order
+                      cardinality: one-to-many
+                      target: "#data-graph-model:order"
+                      source_join_key: user_id
+                      target_join_key: user_id
+                - id: order
+                  display_name: Order
+                  type: entity
+                  table: db.schema.orders
+                  primary_id: order_id
+    invalid:
+      - example_id: "dg-unique-names-duplicate-model-display-name"
+        title: "Two models share the same display name within a data graph"
+        files:
+          spec.yaml: |
+            version: rudder/v1
+            kind: data-graph
+            metadata:
+              name: my-data-graph
+            spec:
+              id: my-data-graph
+              account_id: wh-account-123
+              models:
+                - id: user
+                  display_name: User
+                  type: entity
+                  table: db.schema.users
+                  primary_id: user_id
+                - id: user-v2
+                  display_name: User
+                  type: entity
+                  table: db.schema.users_v2
+                  primary_id: user_id
+        expected_diagnostics:
+          - file: "spec.yaml"
+            reference: "/models/0/display_name"
+            severity: "error"
+            message_contains: "duplicate model display name"
+          - file: "spec.yaml"
+            reference: "/models/1/display_name"
+            severity: "error"
+            message_contains: "duplicate model display name"
+      - example_id: "dg-unique-names-duplicate-relationship-display-name"
+        title: "Two relationships share the same display name within a data graph"
+        files:
+          spec.yaml: |
+            version: rudder/v1
+            kind: data-graph
+            metadata:
+              name: my-data-graph
+            spec:
+              id: my-data-graph
+              account_id: wh-account-123
+              models:
+                - id: user
+                  display_name: User
+                  type: entity
+                  table: db.schema.users
+                  primary_id: user_id
+                  relationships:
+                    - id: user-order
+                      display_name: Links To
+                      cardinality: one-to-many
+                      target: "#data-graph-model:order"
+                      source_join_key: user_id
+                      target_join_key: user_id
+                - id: order
+                  display_name: Order
+                  type: entity
+                  table: db.schema.orders
+                  primary_id: order_id
+                  relationships:
+                    - id: order-product
+                      display_name: Links To
+                      cardinality: one-to-many
+                      target: "#data-graph-model:product"
+                      source_join_key: order_id
+                      target_join_key: order_id
+                - id: product
+                  display_name: Product
+                  type: entity
+                  table: db.schema.products
+                  primary_id: product_id
+        expected_diagnostics:
+          - file: "spec.yaml"
+            reference: "/models/0/relationships/0/display_name"
+            severity: "error"
+            message_contains: "duplicate relationship display name"
+          - file: "spec.yaml"
+            reference: "/models/1/relationships/0/display_name"
+            severity: "error"
+            message_contains: "duplicate relationship display name"

--- a/cli/internal/providers/datagraph/provider.go
+++ b/cli/internal/providers/datagraph/provider.go
@@ -13,6 +13,8 @@ import (
 	"github.com/rudderlabs/rudder-iac/cli/internal/project/specs"
 	"github.com/rudderlabs/rudder-iac/cli/internal/project/writer"
 	"github.com/rudderlabs/rudder-iac/cli/internal/provider"
+	prules "github.com/rudderlabs/rudder-iac/cli/internal/provider/rules"
+	dgdocs "github.com/rudderlabs/rudder-iac/cli/internal/providers/datagraph/docs"
 	"github.com/rudderlabs/rudder-iac/cli/internal/providers/datagraph/handlers/datagraph"
 	"github.com/rudderlabs/rudder-iac/cli/internal/providers/datagraph/handlers/model"
 	"github.com/rudderlabs/rudder-iac/cli/internal/providers/datagraph/handlers/relationship"
@@ -20,8 +22,8 @@ import (
 	dgRules "github.com/rudderlabs/rudder-iac/cli/internal/providers/datagraph/rules"
 	"github.com/rudderlabs/rudder-iac/cli/internal/resolver"
 	"github.com/rudderlabs/rudder-iac/cli/internal/resources"
+	"github.com/rudderlabs/rudder-iac/cli/internal/validation/docs"
 	"github.com/rudderlabs/rudder-iac/cli/internal/validation/rules"
-	prules "github.com/rudderlabs/rudder-iac/cli/internal/provider/rules"
 )
 
 // Provider wraps the base provider to provide a concrete type for dependency injection
@@ -106,6 +108,13 @@ func (p *Provider) SemanticRules() []rules.Rule {
 		dgRules.NewRelationshipUniquePairRule(),
 		dgRules.NewUniqueNamesValidRule(),
 	}
+}
+
+// RuleDocEntries returns the authored documentation fragments embedded with
+// the datagraph provider, joined to registered rules by the docs generator.
+func (p *Provider) RuleDocEntries() []docs.RuleDocEntry {
+	entries, _ := docs.LoadRuleDocEntries(dgdocs.FragmentsFS, ".")
+	return entries
 }
 
 func (p *Provider) parseDataGraphWithInlineModels(s *specs.Spec) (*specs.ParsedSpec, error) {
@@ -208,7 +217,6 @@ func (p *Provider) processInlineModel(dataGraphID string, modelSpec dgModel.Mode
 	return nil
 }
 
-
 // extractModelResource creates a ModelResource from an inline model spec
 func (p *Provider) extractModelResource(dataGraphID string, spec *dgModel.ModelSpec) (*dgModel.ModelResource, error) {
 	// Create URN for the parent data graph
@@ -262,7 +270,6 @@ func columnsFromSpec(specColumns []dgModel.ColumnMetadataYAML) []map[string]any 
 	return out
 }
 
-
 // extractDataGraphResource creates a DataGraphResource from a spec
 func (p *Provider) extractDataGraphResource(spec *dgModel.DataGraphSpec) (*dgModel.DataGraphResource, error) {
 	resource := &dgModel.DataGraphResource{
@@ -286,7 +293,6 @@ func (p *Provider) processInlineRelationship(dataGraphID, sourceModelID string, 
 
 	return nil
 }
-
 
 func (p *Provider) extractRelationshipResource(dataGraphID, sourceModelID string, spec *dgModel.RelationshipSpec) (*dgModel.RelationshipResource, error) {
 	// Create URN for data graph (parent)

--- a/cli/internal/providers/datagraph/ruledoc_test.go
+++ b/cli/internal/providers/datagraph/ruledoc_test.go
@@ -1,0 +1,25 @@
+package datagraph_test
+
+import (
+	"testing"
+
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/datagraph"
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/datagraph/testutils"
+	"github.com/rudderlabs/rudder-iac/cli/internal/validation/docs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestProviderRuleDocs runs the provider's authored fragments through the real
+// docs generator together with its live rules, asserting every rule resolves
+// and passes the DocumentedRules validation invariants.
+func TestProviderRuleDocs(t *testing.T) {
+	p := datagraph.NewProvider(&testutils.MockDataGraphClient{}, nil)
+
+	syntactic := p.SyntacticRules()
+	semantic := p.SemanticRules()
+
+	doc, verrs := docs.Generate(syntactic, semantic, p.RuleDocEntries(), "test", "2026-06-03T00:00:00Z")
+	assert.Empty(t, verrs, "expected no validation errors, got: %v", verrs)
+	require.Len(t, doc.Rules, len(syntactic)+len(semantic))
+}

--- a/cli/internal/providers/event-stream/docs/embed.go
+++ b/cli/internal/providers/event-stream/docs/embed.go
@@ -1,0 +1,6 @@
+package docs
+
+import "embed"
+
+//go:embed *.docs.yaml
+var FragmentsFS embed.FS

--- a/cli/internal/providers/event-stream/docs/source-semantic-valid.docs.yaml
+++ b/cli/internal/providers/event-stream/docs/source-semantic-valid.docs.yaml
@@ -1,0 +1,187 @@
+rule_id: "event-stream/source/semantic-valid"
+match_behavior:
+  # Legacy spec versions (rudder/0.1 and rudder/v0.1) apply the same semantic checks
+  # (tracking plan existence and source name uniqueness), so they are documented together.
+  - applies_to:
+      - kind: "event-stream-source"
+        version: "rudder/0.1"
+      - kind: "event-stream-source"
+        version: "rudder/v0.1"
+    valid:
+      - example_id: "es-source-legacy-semantic-valid-no-governance"
+        title: "Valid legacy source without governance — no cross-references to resolve"
+        files:
+          spec.yaml: |
+            version: rudder/0.1
+            kind: event-stream-source
+            metadata:
+              name: my-source
+            spec:
+              id: src-1
+              name: My JavaScript Source
+              type: javascript
+      - example_id: "es-source-legacy-semantic-valid-with-tp"
+        title: "Valid legacy source whose tracking plan exists in the project"
+        files:
+          spec.yaml: |
+            version: rudder/0.1
+            kind: event-stream-source
+            metadata:
+              name: my-source
+            spec:
+              id: src-1
+              name: My JavaScript Source
+              type: javascript
+              governance:
+                validations:
+                  tracking_plan: "#/tp/my-group/tp-main"
+                  config: {}
+          tracking_plan.yaml: |
+            version: rudder/0.1
+            kind: tracking-plan
+            metadata:
+              name: tp-main
+            spec:
+              id: tp-main
+              name: Main Tracking Plan
+              description: Default plan
+              rules: []
+    invalid:
+      - example_id: "es-source-legacy-semantic-tp-not-found"
+        title: "Legacy source references a tracking plan that does not exist in the project"
+        files:
+          spec.yaml: |
+            version: rudder/0.1
+            kind: event-stream-source
+            metadata:
+              name: my-source
+            spec:
+              id: src-1
+              name: My JavaScript Source
+              type: javascript
+              governance:
+                validations:
+                  tracking_plan: "#/tp/my-group/tp-missing"
+                  config: {}
+        expected_diagnostics:
+          - file: "spec.yaml"
+            reference: "/governance/validations/tracking_plan"
+            severity: "error"
+            message_contains: "not found in the project"
+      - example_id: "es-source-legacy-semantic-duplicate-name"
+        title: "Legacy source shares a name with another source in the same project"
+        files:
+          source-a.yaml: |
+            version: rudder/0.1
+            kind: event-stream-source
+            metadata:
+              name: source-a
+            spec:
+              id: src-a
+              name: Shared Name
+              type: javascript
+          source-b.yaml: |
+            version: rudder/0.1
+            kind: event-stream-source
+            metadata:
+              name: source-b
+            spec:
+              id: src-b
+              name: Shared Name
+              type: node
+        expected_diagnostics:
+          - file: "source-a.yaml"
+            reference: "/name"
+            severity: "error"
+            message_contains: "duplicate name 'Shared Name' within kind 'event-stream-source'"
+  # Current spec version (rudder/v1) applies the same semantic checks with the modern ref format.
+  - applies_to:
+      - kind: "event-stream-source"
+        version: "rudder/v1"
+    valid:
+      - example_id: "es-source-v1-semantic-valid-no-governance"
+        title: "Valid v1 source without governance"
+        files:
+          spec.yaml: |
+            version: rudder/v1
+            kind: event-stream-source
+            metadata:
+              name: my-source
+            spec:
+              id: src-1
+              name: My Python Source
+              type: python
+      - example_id: "es-source-v1-semantic-valid-with-tp"
+        title: "Valid v1 source whose tracking plan exists in the project"
+        files:
+          spec.yaml: |
+            version: rudder/v1
+            kind: event-stream-source
+            metadata:
+              name: my-source
+            spec:
+              id: src-1
+              name: My Python Source
+              type: python
+              governance:
+                validations:
+                  tracking_plan: "#tracking-plan:tp-main"
+                  config: {}
+          tracking_plan.yaml: |
+            version: rudder/v1
+            kind: tracking-plan
+            metadata:
+              name: tp-main
+            spec:
+              id: tp-main
+              name: Main Tracking Plan
+              description: Default plan
+              rules: []
+    invalid:
+      - example_id: "es-source-v1-semantic-tp-not-found"
+        title: "v1 source references a tracking plan that does not exist in the project"
+        files:
+          spec.yaml: |
+            version: rudder/v1
+            kind: event-stream-source
+            metadata:
+              name: my-source
+            spec:
+              id: src-1
+              name: My Python Source
+              type: python
+              governance:
+                validations:
+                  tracking_plan: "#tracking-plan:tp-missing"
+                  config: {}
+        expected_diagnostics:
+          - file: "spec.yaml"
+            reference: "/governance/validations/tracking_plan"
+            severity: "error"
+            message_contains: "not found in the project"
+      - example_id: "es-source-v1-semantic-duplicate-name"
+        title: "v1 source shares a name with another source in the same project"
+        files:
+          source-a.yaml: |
+            version: rudder/v1
+            kind: event-stream-source
+            metadata:
+              name: source-a
+            spec:
+              id: src-a
+              name: Shared Name
+              type: javascript
+          source-b.yaml: |
+            version: rudder/v1
+            kind: event-stream-source
+            metadata:
+              name: source-b
+            spec:
+              id: src-b
+              name: Shared Name
+              type: node
+        expected_diagnostics:
+          - file: "source-a.yaml"
+            reference: "/name"
+            severity: "error"
+            message_contains: "duplicate name 'Shared Name' within kind 'event-stream-source'"

--- a/cli/internal/providers/event-stream/docs/source-spec-syntax-valid.docs.yaml
+++ b/cli/internal/providers/event-stream/docs/source-spec-syntax-valid.docs.yaml
@@ -1,0 +1,164 @@
+rule_id: "event-stream/source/spec-syntax-valid"
+match_behavior:
+  # Legacy spec versions (rudder/0.1 and rudder/v0.1) share the same source spec
+  # shape and tracking plan ref pattern (#/tp/<group>/<id>), so they are documented together.
+  - applies_to:
+      - kind: "event-stream-source"
+        version: "rudder/0.1"
+      - kind: "event-stream-source"
+        version: "rudder/v0.1"
+    valid:
+      - example_id: "es-source-legacy-valid-minimal"
+        title: "Valid legacy source spec with required fields"
+        files:
+          spec.yaml: |
+            version: rudder/0.1
+            kind: event-stream-source
+            metadata:
+              name: my-js-source
+            spec:
+              id: src-js-1
+              name: My JavaScript Source
+              type: javascript
+      - example_id: "es-source-legacy-valid-with-governance"
+        title: "Valid legacy source spec with tracking plan governance"
+        files:
+          spec.yaml: |
+            version: rudder/0.1
+            kind: event-stream-source
+            metadata:
+              name: my-node-source
+            spec:
+              id: src-node-1
+              name: My Node.js Source
+              type: node
+              governance:
+                validations:
+                  tracking_plan: "#/tp/my-group/tp-main"
+                  config: {}
+    invalid:
+      - example_id: "es-source-legacy-missing-id"
+        title: "Legacy source spec missing required id field"
+        files:
+          spec.yaml: |
+            version: rudder/0.1
+            kind: event-stream-source
+            metadata:
+              name: my-source
+            spec:
+              name: My Source
+              type: javascript
+        expected_diagnostics:
+          - file: "spec.yaml"
+            reference: "/id"
+            severity: "error"
+            message_contains: "'id' is required"
+      - example_id: "es-source-legacy-invalid-type"
+        title: "Legacy source spec with an unsupported source type"
+        files:
+          spec.yaml: |
+            version: rudder/0.1
+            kind: event-stream-source
+            metadata:
+              name: my-source
+            spec:
+              id: src-1
+              name: My Source
+              type: unknown_sdk
+        expected_diagnostics:
+          - file: "spec.yaml"
+            reference: "/type"
+            severity: "error"
+            message_contains: "'type' must be one of"
+      - example_id: "es-source-legacy-invalid-tp-ref"
+        title: "Legacy source spec with tracking plan ref in wrong format"
+        files:
+          spec.yaml: |
+            version: rudder/0.1
+            kind: event-stream-source
+            metadata:
+              name: my-source
+            spec:
+              id: src-1
+              name: My Source
+              type: javascript
+              governance:
+                validations:
+                  tracking_plan: "#tracking-plan:tp-1"
+                  config: {}
+        expected_diagnostics:
+          - file: "spec.yaml"
+            reference: "/governance/validations/tracking_plan"
+            severity: "error"
+            message_contains: "'tracking_plan' is invalid: must be of pattern #/tp/<group>/<id>"
+  # Current spec version (rudder/v1) uses the modern tracking plan ref format (#tracking-plan:<id>).
+  - applies_to:
+      - kind: "event-stream-source"
+        version: "rudder/v1"
+    valid:
+      - example_id: "es-source-v1-valid-minimal"
+        title: "Valid v1 source spec with required fields"
+        files:
+          spec.yaml: |
+            version: rudder/v1
+            kind: event-stream-source
+            metadata:
+              name: my-python-source
+            spec:
+              id: src-py-1
+              name: My Python Source
+              type: python
+      - example_id: "es-source-v1-valid-with-governance"
+        title: "Valid v1 source spec with tracking plan governance"
+        files:
+          spec.yaml: |
+            version: rudder/v1
+            kind: event-stream-source
+            metadata:
+              name: my-android-source
+            spec:
+              id: src-android-1
+              name: My Android Source
+              type: android
+              governance:
+                validations:
+                  tracking_plan: "#tracking-plan:tp-main"
+                  config: {}
+    invalid:
+      - example_id: "es-source-v1-missing-name"
+        title: "v1 source spec missing required name field"
+        files:
+          spec.yaml: |
+            version: rudder/v1
+            kind: event-stream-source
+            metadata:
+              name: my-source
+            spec:
+              id: src-1
+              type: javascript
+        expected_diagnostics:
+          - file: "spec.yaml"
+            reference: "/name"
+            severity: "error"
+            message_contains: "'name' is required"
+      - example_id: "es-source-v1-invalid-tp-ref"
+        title: "v1 source spec with tracking plan ref in legacy format"
+        files:
+          spec.yaml: |
+            version: rudder/v1
+            kind: event-stream-source
+            metadata:
+              name: my-source
+            spec:
+              id: src-1
+              name: My Source
+              type: javascript
+              governance:
+                validations:
+                  tracking_plan: "#/tp/my-group/tp-1"
+                  config: {}
+        expected_diagnostics:
+          - file: "spec.yaml"
+            reference: "/governance/validations/tracking_plan"
+            severity: "error"
+            message_contains: "'tracking_plan' is invalid: must be of pattern #tracking-plan:<id>"

--- a/cli/internal/providers/event-stream/provider.go
+++ b/cli/internal/providers/event-stream/provider.go
@@ -10,11 +10,13 @@ import (
 	"github.com/rudderlabs/rudder-iac/cli/internal/project/writer"
 	"github.com/rudderlabs/rudder-iac/cli/internal/provider"
 	prules "github.com/rudderlabs/rudder-iac/cli/internal/provider/rules"
+	esdocs "github.com/rudderlabs/rudder-iac/cli/internal/providers/event-stream/docs"
 	sourceRules "github.com/rudderlabs/rudder-iac/cli/internal/providers/event-stream/rules/source"
 	sourceHandler "github.com/rudderlabs/rudder-iac/cli/internal/providers/event-stream/source"
 	"github.com/rudderlabs/rudder-iac/cli/internal/resolver"
 	"github.com/rudderlabs/rudder-iac/cli/internal/resources"
 	"github.com/rudderlabs/rudder-iac/cli/internal/resources/state"
+	"github.com/rudderlabs/rudder-iac/cli/internal/validation/docs"
 	"github.com/rudderlabs/rudder-iac/cli/internal/validation/rules"
 )
 
@@ -233,6 +235,13 @@ func (p *Provider) FormatForExport(
 		result = append(result, entities...)
 	}
 	return result, nil
+}
+
+// RuleDocEntries returns the authored documentation fragments embedded with
+// the event-stream provider, joined to registered rules by the docs generator.
+func (p *Provider) RuleDocEntries() []docs.RuleDocEntry {
+	entries, _ := docs.LoadRuleDocEntries(esdocs.FragmentsFS, ".")
+	return entries
 }
 
 func (p *Provider) SyntacticRules() []rules.Rule {

--- a/cli/internal/providers/event-stream/ruledoc_test.go
+++ b/cli/internal/providers/event-stream/ruledoc_test.go
@@ -1,0 +1,25 @@
+package eventstream_test
+
+import (
+	"testing"
+
+	eventstream "github.com/rudderlabs/rudder-iac/cli/internal/providers/event-stream"
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/event-stream/source"
+	"github.com/rudderlabs/rudder-iac/cli/internal/validation/docs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestProviderRuleDocs runs the provider's authored fragments through the real
+// docs generator together with its live rules, asserting every rule resolves
+// and passes the DocumentedRules validation invariants.
+func TestProviderRuleDocs(t *testing.T) {
+	p := eventstream.New(source.NewMockSourceClient())
+
+	syntactic := p.SyntacticRules()
+	semantic := p.SemanticRules()
+
+	doc, verrs := docs.Generate(syntactic, semantic, p.RuleDocEntries(), "test", "2026-06-03T00:00:00Z")
+	assert.Empty(t, verrs, "expected no validation errors, got: %v", verrs)
+	require.Len(t, doc.Rules, len(syntactic)+len(semantic))
+}

--- a/cli/internal/providers/retl/docs/embed.go
+++ b/cli/internal/providers/retl/docs/embed.go
@@ -1,0 +1,6 @@
+package docs
+
+import "embed"
+
+//go:embed *.docs.yaml
+var FragmentsFS embed.FS

--- a/cli/internal/providers/retl/docs/sqlmodel-semantic-valid.docs.yaml
+++ b/cli/internal/providers/retl/docs/sqlmodel-semantic-valid.docs.yaml
@@ -1,0 +1,87 @@
+rule_id: "retl/sqlmodel/semantic-valid"
+match_behavior:
+  # Legacy spec versions (rudder/0.1 and rudder/v0.1) share the same
+  # semantic constraints, so they are documented together.
+  - applies_to:
+      - kind: "retl-source-sql-model"
+        version: "rudder/0.1"
+      - kind: "retl-source-sql-model"
+        version: "rudder/v0.1"
+    valid:
+      - example_id: "sqlmodel-semantic-legacy-valid"
+        title: "Valid legacy SQL model — display_name is unique across all models"
+        files:
+          spec.yaml: |
+            version: rudder/0.1
+            kind: retl-source-sql-model
+            metadata:
+              name: revenue-model
+            spec:
+              id: revenue-model
+              display_name: Revenue Model
+              account_id: acc-123
+              primary_key: id
+              source_definition: postgres
+              sql: SELECT id, amount FROM revenue
+    invalid:
+      - example_id: "sqlmodel-semantic-legacy-duplicate-display-name"
+        title: "Legacy SQL model with a display_name that duplicates another model in the workspace"
+        files:
+          spec.yaml: |
+            version: rudder/0.1
+            kind: retl-source-sql-model
+            metadata:
+              name: revenue-model-copy
+            spec:
+              id: revenue-model-copy
+              display_name: Revenue Model
+              account_id: acc-123
+              primary_key: id
+              source_definition: postgres
+              sql: SELECT id, amount FROM revenue
+        expected_diagnostics:
+          - file: "spec.yaml"
+            reference: "/display_name"
+            severity: "error"
+            message_contains: "duplicate display_name 'Revenue Model' within kind 'retl-source-sql-model'"
+  # Current spec version (rudder/v1).
+  - applies_to:
+      - kind: "retl-source-sql-model"
+        version: "rudder/v1"
+    valid:
+      - example_id: "sqlmodel-semantic-v1-valid"
+        title: "Valid v1 SQL model — display_name is unique across all models"
+        files:
+          spec.yaml: |
+            version: rudder/v1
+            kind: retl-source-sql-model
+            metadata:
+              name: churn-model
+            spec:
+              id: churn-model
+              display_name: Churn Risk Model
+              account_id: acc-456
+              primary_key: user_id
+              source_definition: bigquery
+              sql: SELECT user_id FROM churn_signals
+    invalid:
+      - example_id: "sqlmodel-semantic-v1-duplicate-display-name"
+        title: "v1 SQL model with a display_name that duplicates another model in the workspace"
+        files:
+          spec.yaml: |
+            version: rudder/v1
+            kind: retl-source-sql-model
+            metadata:
+              name: churn-model-duplicate
+            spec:
+              id: churn-model-duplicate
+              display_name: Churn Risk Model
+              account_id: acc-456
+              primary_key: user_id
+              source_definition: bigquery
+              sql: SELECT user_id FROM churn_signals
+        expected_diagnostics:
+          - file: "spec.yaml"
+            reference: "/display_name"
+            severity: "error"
+            message_contains: "duplicate display_name 'Churn Risk Model' within kind 'retl-source-sql-model'"

--- a/cli/internal/providers/retl/docs/sqlmodel-spec-syntax-valid.docs.yaml
+++ b/cli/internal/providers/retl/docs/sqlmodel-spec-syntax-valid.docs.yaml
@@ -1,0 +1,126 @@
+rule_id: "retl/sqlmodel/spec-syntax-valid"
+match_behavior:
+  # Legacy spec versions (rudder/0.1 and rudder/v0.1) share the same
+  # SQL model spec shape and validation, so they are documented together.
+  - applies_to:
+      - kind: "retl-source-sql-model"
+        version: "rudder/0.1"
+      - kind: "retl-source-sql-model"
+        version: "rudder/v0.1"
+    valid:
+      - example_id: "sqlmodel-legacy-valid"
+        title: "Valid legacy SQL model spec with inline SQL"
+        files:
+          spec.yaml: |
+            version: rudder/0.1
+            kind: retl-source-sql-model
+            metadata:
+              name: user-orders-model
+            spec:
+              id: user-orders-model
+              display_name: User Orders
+              account_id: acc-123
+              primary_key: id
+              source_definition: postgres
+              sql: SELECT id, name FROM orders
+    invalid:
+      - example_id: "sqlmodel-legacy-missing-display-name"
+        title: "Legacy SQL model missing the required display_name field"
+        files:
+          spec.yaml: |
+            version: rudder/0.1
+            kind: retl-source-sql-model
+            metadata:
+              name: user-orders-model
+            spec:
+              id: user-orders-model
+              account_id: acc-123
+              primary_key: id
+              source_definition: postgres
+              sql: SELECT id, name FROM orders
+        expected_diagnostics:
+          - file: "spec.yaml"
+            reference: "/display_name"
+            severity: "error"
+            message_contains: "'display_name' is required"
+      - example_id: "sqlmodel-legacy-invalid-source-definition"
+        title: "Legacy SQL model with unsupported source_definition value"
+        files:
+          spec.yaml: |
+            version: rudder/0.1
+            kind: retl-source-sql-model
+            metadata:
+              name: user-orders-model
+            spec:
+              id: user-orders-model
+              display_name: User Orders
+              account_id: acc-123
+              primary_key: id
+              source_definition: oracle
+              sql: SELECT id FROM orders
+        expected_diagnostics:
+          - file: "spec.yaml"
+            reference: "/source_definition"
+            severity: "error"
+            message_contains: "'source_definition' must be one of [postgres redshift snowflake bigquery mysql databricks trino]"
+  # Current spec version (rudder/v1).
+  - applies_to:
+      - kind: "retl-source-sql-model"
+        version: "rudder/v1"
+    valid:
+      - example_id: "sqlmodel-v1-valid"
+        title: "Valid v1 SQL model spec with inline SQL"
+        files:
+          spec.yaml: |
+            version: rudder/v1
+            kind: retl-source-sql-model
+            metadata:
+              name: user-orders-model
+            spec:
+              id: user-orders-model
+              display_name: User Orders
+              account_id: acc-123
+              primary_key: id
+              source_definition: snowflake
+              sql: SELECT id, name FROM orders
+    invalid:
+      - example_id: "sqlmodel-v1-missing-account-id"
+        title: "v1 SQL model missing the required account_id field"
+        files:
+          spec.yaml: |
+            version: rudder/v1
+            kind: retl-source-sql-model
+            metadata:
+              name: user-orders-model
+            spec:
+              id: user-orders-model
+              display_name: User Orders
+              primary_key: id
+              source_definition: bigquery
+              sql: SELECT id, name FROM orders
+        expected_diagnostics:
+          - file: "spec.yaml"
+            reference: "/account_id"
+            severity: "error"
+            message_contains: "'account_id' is required"
+      - example_id: "sqlmodel-v1-both-sql-and-file"
+        title: "v1 SQL model specifying both sql and file (mutually exclusive)"
+        files:
+          spec.yaml: |
+            version: rudder/v1
+            kind: retl-source-sql-model
+            metadata:
+              name: user-orders-model
+            spec:
+              id: user-orders-model
+              display_name: User Orders
+              account_id: acc-123
+              primary_key: id
+              source_definition: postgres
+              sql: SELECT id FROM orders
+              file: ./query.sql
+        expected_diagnostics:
+          - file: "spec.yaml"
+            reference: "/sql"
+            severity: "error"
+            message_contains: "'sql' and 'file' cannot be specified together"

--- a/cli/internal/providers/retl/provider.go
+++ b/cli/internal/providers/retl/provider.go
@@ -13,10 +13,12 @@ import (
 	"github.com/rudderlabs/rudder-iac/cli/internal/project/writer"
 	"github.com/rudderlabs/rudder-iac/cli/internal/provider"
 	prules "github.com/rudderlabs/rudder-iac/cli/internal/provider/rules"
+	retldocs "github.com/rudderlabs/rudder-iac/cli/internal/providers/retl/docs"
 	"github.com/rudderlabs/rudder-iac/cli/internal/providers/retl/sqlmodel"
 	"github.com/rudderlabs/rudder-iac/cli/internal/resolver"
 	"github.com/rudderlabs/rudder-iac/cli/internal/resources"
 	"github.com/rudderlabs/rudder-iac/cli/internal/resources/state"
+	"github.com/rudderlabs/rudder-iac/cli/internal/validation/docs"
 	"github.com/rudderlabs/rudder-iac/cli/internal/validation/rules"
 
 	sqlmodelRules "github.com/rudderlabs/rudder-iac/cli/internal/providers/retl/rules/sqlmodel"
@@ -133,6 +135,13 @@ func (p *Provider) SemanticRules() []rules.Rule {
 	return []rules.Rule{
 		sqlmodelRules.NewSQLModelSemanticValidRule(),
 	}
+}
+
+// RuleDocEntries returns the authored documentation fragments embedded with
+// the retl provider, joined to registered rules by the docs generator.
+func (p *Provider) RuleDocEntries() []docs.RuleDocEntry {
+	entries, _ := docs.LoadRuleDocEntries(retldocs.FragmentsFS, ".")
+	return entries
 }
 
 // GetResourceGraph returns a graph of all resources

--- a/cli/internal/providers/retl/ruledoc_test.go
+++ b/cli/internal/providers/retl/ruledoc_test.go
@@ -1,0 +1,24 @@
+package retl_test
+
+import (
+	"testing"
+
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/retl"
+	"github.com/rudderlabs/rudder-iac/cli/internal/validation/docs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestProviderRuleDocs runs the provider's authored fragments through the real
+// docs generator together with its live rules, asserting every rule resolves
+// and passes the DocumentedRules validation invariants.
+func TestProviderRuleDocs(t *testing.T) {
+	p := retl.New(newDefaultMockClient())
+
+	syntactic := p.SyntacticRules()
+	semantic := p.SemanticRules()
+
+	doc, verrs := docs.Generate(syntactic, semantic, p.RuleDocEntries(), "test", "2026-06-03T00:00:00Z")
+	assert.Empty(t, verrs, "expected no validation errors, got: %v", verrs)
+	require.Len(t, doc.Rules, len(syntactic)+len(semantic))
+}

--- a/cli/internal/providers/transformations/docs/embed.go
+++ b/cli/internal/providers/transformations/docs/embed.go
@@ -1,0 +1,6 @@
+package docs
+
+import "embed"
+
+//go:embed *.docs.yaml
+var FragmentsFS embed.FS

--- a/cli/internal/providers/transformations/docs/transformation-library-semantic-valid.docs.yaml
+++ b/cli/internal/providers/transformations/docs/transformation-library-semantic-valid.docs.yaml
@@ -1,0 +1,56 @@
+rule_id: "transformations/transformation-library/semantic-valid"
+match_behavior:
+  - applies_to:
+      - kind: "transformation-library"
+        version: "rudder/v1"
+    valid:
+      - example_id: "transformation-library-semantic-valid-unique-import-name"
+        title: "Transformation library with a unique import_name across all libraries"
+        files:
+          spec.yaml: |
+            version: rudder/v1
+            kind: transformation-library
+            metadata:
+              name: my-libraries
+            spec:
+              libraries:
+                - id: math-utils
+                  name: Math Utils
+                  import_name: mathUtils
+                  language: javascript
+                  code: |
+                    export function round(value) {
+                      return Math.round(value);
+                    }
+    invalid:
+      - example_id: "transformation-library-semantic-valid-duplicate-import-name"
+        title: "Two transformation libraries sharing the same import_name"
+        files:
+          spec.yaml: |
+            version: rudder/v1
+            kind: transformation-library
+            metadata:
+              name: my-libraries
+            spec:
+              libraries:
+                - id: math-utils
+                  name: Math Utils
+                  import_name: mathUtils
+                  language: javascript
+                  code: |
+                    export function round(value) {
+                      return Math.round(value);
+                    }
+                - id: math-helpers
+                  name: Math Helpers
+                  import_name: mathUtils
+                  language: javascript
+                  code: |
+                    export function ceil(value) {
+                      return Math.ceil(value);
+                    }
+        expected_diagnostics:
+          - file: "spec.yaml"
+            reference: "/import_name"
+            severity: "error"
+            message_contains: "import_name 'mathUtils' is duplicate"

--- a/cli/internal/providers/transformations/docs/transformation-library-spec-syntax-valid.docs.yaml
+++ b/cli/internal/providers/transformations/docs/transformation-library-spec-syntax-valid.docs.yaml
@@ -1,0 +1,116 @@
+rule_id: "transformations/transformation-library/spec-syntax-valid"
+match_behavior:
+  - applies_to:
+      - kind: "transformation-library"
+        version: "rudder/v1"
+    valid:
+      - example_id: "transformation-library-spec-syntax-valid-inline-js"
+        title: "Valid transformation library spec with inline JavaScript code"
+        files:
+          spec.yaml: |
+            version: rudder/v1
+            kind: transformation-library
+            metadata:
+              name: my-libraries
+            spec:
+              libraries:
+                - id: math-utils
+                  name: Math Utils
+                  import_name: mathUtils
+                  description: Utility functions for math operations
+                  language: javascript
+                  code: |
+                    export function round(value) {
+                      return Math.round(value);
+                    }
+    invalid:
+      - example_id: "transformation-library-spec-syntax-valid-missing-id"
+        title: "Transformation library spec missing required id field"
+        files:
+          spec.yaml: |
+            version: rudder/v1
+            kind: transformation-library
+            metadata:
+              name: my-libraries
+            spec:
+              libraries:
+                - name: Math Utils
+                  import_name: mathUtils
+                  language: javascript
+                  code: |
+                    export function round(value) {
+                      return Math.round(value);
+                    }
+        expected_diagnostics:
+          - file: "spec.yaml"
+            reference: "/id"
+            severity: "error"
+            message_contains: "'id' is required"
+      - example_id: "transformation-library-spec-syntax-valid-missing-import-name"
+        title: "Transformation library spec missing required import_name field"
+        files:
+          spec.yaml: |
+            version: rudder/v1
+            kind: transformation-library
+            metadata:
+              name: my-libraries
+            spec:
+              libraries:
+                - id: math-utils
+                  name: Math Utils
+                  language: javascript
+                  code: |
+                    export function round(value) {
+                      return Math.round(value);
+                    }
+        expected_diagnostics:
+          - file: "spec.yaml"
+            reference: "/import_name"
+            severity: "error"
+            message_contains: "'import_name' is required"
+      - example_id: "transformation-library-spec-syntax-valid-wrong-import-name-case"
+        title: "Transformation library import_name not in camelCase of name"
+        files:
+          spec.yaml: |
+            version: rudder/v1
+            kind: transformation-library
+            metadata:
+              name: my-libraries
+            spec:
+              libraries:
+                - id: math-utils
+                  name: Math Utils
+                  import_name: MathUtils
+                  language: javascript
+                  code: |
+                    export function round(value) {
+                      return Math.round(value);
+                    }
+        expected_diagnostics:
+          - file: "spec.yaml"
+            reference: "/import_name"
+            severity: "error"
+            message_contains: "'import_name' must be camelCase of 'name'"
+      - example_id: "transformation-library-spec-syntax-valid-invalid-language"
+        title: "Transformation library spec with unsupported language"
+        files:
+          spec.yaml: |
+            version: rudder/v1
+            kind: transformation-library
+            metadata:
+              name: my-libraries
+            spec:
+              libraries:
+                - id: math-utils
+                  name: Math Utils
+                  import_name: mathUtils
+                  language: ruby
+                  code: |
+                    def round(value)
+                      value.round
+                    end
+        expected_diagnostics:
+          - file: "spec.yaml"
+            reference: "/language"
+            severity: "error"
+            message_contains: "'language' must be one of [javascript python]"

--- a/cli/internal/providers/transformations/docs/transformation-semantic-valid.docs.yaml
+++ b/cli/internal/providers/transformations/docs/transformation-semantic-valid.docs.yaml
@@ -1,0 +1,49 @@
+rule_id: "transformations/transformation/semantic-valid"
+match_behavior:
+  - applies_to:
+      - kind: "transformation"
+        version: "rudder/v1"
+    valid:
+      - example_id: "transformation-semantic-valid-no-imports"
+        title: "Transformation with no library imports is valid"
+        files:
+          spec.yaml: |
+            version: rudder/v1
+            kind: transformation
+            metadata:
+              name: my-transformations
+            spec:
+              transformations:
+                - id: my-transformation
+                  name: My Transformation
+                  language: javascript
+                  code: |
+                    export function transformEvent(event, metadata) {
+                      event.properties.processed = true;
+                      return event;
+                    }
+    invalid:
+      - example_id: "transformation-semantic-valid-missing-library"
+        title: "Transformation importing a library that does not exist in the graph"
+        files:
+          spec.yaml: |
+            version: rudder/v1
+            kind: transformation
+            metadata:
+              name: my-transformations
+            spec:
+              transformations:
+                - id: my-transformation
+                  name: My Transformation
+                  language: javascript
+                  code: |
+                    import mathUtils from 'mathUtils';
+                    export function transformEvent(event, metadata) {
+                      event.properties.value = mathUtils.round(event.properties.value);
+                      return event;
+                    }
+        expected_diagnostics:
+          - file: "spec.yaml"
+            reference: "/code"
+            severity: "error"
+            message_contains: "'mathUtils' imported library not found"

--- a/cli/internal/providers/transformations/docs/transformation-spec-syntax-valid.docs.yaml
+++ b/cli/internal/providers/transformations/docs/transformation-spec-syntax-valid.docs.yaml
@@ -1,0 +1,108 @@
+rule_id: "transformations/transformation/spec-syntax-valid"
+match_behavior:
+  - applies_to:
+      - kind: "transformation"
+        version: "rudder/v1"
+    valid:
+      - example_id: "transformation-spec-syntax-valid-inline-js"
+        title: "Valid transformation spec with inline JavaScript code"
+        files:
+          spec.yaml: |
+            version: rudder/v1
+            kind: transformation
+            metadata:
+              name: my-transformations
+            spec:
+              transformations:
+                - id: my-transformation
+                  name: My Transformation
+                  description: Enriches events with additional metadata
+                  language: javascript
+                  code: |
+                    export function transformEvent(event, metadata) {
+                      event.properties.enriched = true;
+                      return event;
+                    }
+    invalid:
+      - example_id: "transformation-spec-syntax-valid-missing-id"
+        title: "Transformation spec missing required id field"
+        files:
+          spec.yaml: |
+            version: rudder/v1
+            kind: transformation
+            metadata:
+              name: my-transformations
+            spec:
+              transformations:
+                - name: My Transformation
+                  language: javascript
+                  code: |
+                    export function transformEvent(event, metadata) {
+                      return event;
+                    }
+        expected_diagnostics:
+          - file: "spec.yaml"
+            reference: "/id"
+            severity: "error"
+            message_contains: "'id' is required"
+      - example_id: "transformation-spec-syntax-valid-missing-language"
+        title: "Transformation spec missing required language field"
+        files:
+          spec.yaml: |
+            version: rudder/v1
+            kind: transformation
+            metadata:
+              name: my-transformations
+            spec:
+              transformations:
+                - id: my-transformation
+                  name: My Transformation
+                  code: |
+                    export function transformEvent(event, metadata) {
+                      return event;
+                    }
+        expected_diagnostics:
+          - file: "spec.yaml"
+            reference: "/language"
+            severity: "error"
+            message_contains: "'language' is required"
+      - example_id: "transformation-spec-syntax-valid-invalid-language"
+        title: "Transformation spec with unsupported language"
+        files:
+          spec.yaml: |
+            version: rudder/v1
+            kind: transformation
+            metadata:
+              name: my-transformations
+            spec:
+              transformations:
+                - id: my-transformation
+                  name: My Transformation
+                  language: ruby
+                  code: |
+                    def transform_event(event, metadata)
+                      event
+                    end
+        expected_diagnostics:
+          - file: "spec.yaml"
+            reference: "/language"
+            severity: "error"
+            message_contains: "'language' must be one of [javascript python]"
+      - example_id: "transformation-spec-syntax-valid-missing-code-and-file"
+        title: "Transformation spec with neither code nor file specified"
+        files:
+          spec.yaml: |
+            version: rudder/v1
+            kind: transformation
+            metadata:
+              name: my-transformations
+            spec:
+              transformations:
+                - id: my-transformation
+                  name: My Transformation
+                  language: javascript
+        expected_diagnostics:
+          - file: "spec.yaml"
+            reference: "/code"
+            severity: "error"
+            message_contains: "'code' is required when 'file' is not specified"

--- a/cli/internal/providers/transformations/provider.go
+++ b/cli/internal/providers/transformations/provider.go
@@ -22,8 +22,11 @@ import (
 	ttypes "github.com/rudderlabs/rudder-iac/cli/internal/providers/transformations/types"
 	"github.com/rudderlabs/rudder-iac/cli/internal/resources"
 	"github.com/rudderlabs/rudder-iac/cli/internal/resources/state"
+	vdocs "github.com/rudderlabs/rudder-iac/cli/internal/validation/docs"
 	vrules "github.com/rudderlabs/rudder-iac/cli/internal/validation/rules"
 	"github.com/samber/lo"
+
+	tfdocs "github.com/rudderlabs/rudder-iac/cli/internal/providers/transformations/docs"
 )
 
 var log = logger.New("transformationsprovider")
@@ -93,6 +96,13 @@ func (p *Provider) SemanticRules() []vrules.Rule {
 		trules.NewTransformationSemanticValidRule(),
 		lrules.NewLibrarySemanticValidRule(),
 	}
+}
+
+// RuleDocEntries returns the authored documentation fragments embedded with
+// the transformations provider, joined to registered rules by the docs generator.
+func (p *Provider) RuleDocEntries() []vdocs.RuleDocEntry {
+	entries, _ := vdocs.LoadRuleDocEntries(tfdocs.FragmentsFS, ".")
+	return entries
 }
 
 // MapRemoteToState overrides BaseProvider.MapRemoteToState to populate dependencies for transformations

--- a/cli/internal/providers/transformations/ruledoc_test.go
+++ b/cli/internal/providers/transformations/ruledoc_test.go
@@ -1,0 +1,25 @@
+package transformations_test
+
+import (
+	"testing"
+
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/transformations"
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/transformations/testutil"
+	"github.com/rudderlabs/rudder-iac/cli/internal/validation/docs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestProviderRuleDocs runs the provider's authored fragments through the real
+// docs generator together with its live rules, asserting every rule resolves
+// and passes the DocumentedRules validation invariants.
+func TestProviderRuleDocs(t *testing.T) {
+	p := transformations.NewProviderWithStore(&testutil.MockTransformationStore{})
+
+	syntactic := p.SyntacticRules()
+	semantic := p.SemanticRules()
+
+	doc, verrs := docs.Generate(syntactic, semantic, p.RuleDocEntries(), "test", "2026-06-03T00:00:00Z")
+	assert.Empty(t, verrs, "expected no validation errors, got: %v", verrs)
+	require.Len(t, doc.Rules, len(syntactic)+len(semantic))
+}

--- a/cli/internal/ruledoc/ruledoc.go
+++ b/cli/internal/ruledoc/ruledoc.go
@@ -1,0 +1,57 @@
+// Package ruledoc assembles the canonical validation rule documentation
+// catalog from an already-composed provider.
+//
+// It is the glue layer above the provider set, the rule registry, and the docs
+// generator: given a provider it builds the registry, joins the live rules
+// with every authored *.docs.yaml fragment — provider-contributed plus the
+// project-level gatekeeper fragments — and runs the generator.
+//
+// Keeping this provider-in, catalog-out step in its own package lets it be
+// unit-tested with a stub provider, free of any client, config, or auth, while
+// the composition root (package app) owns only the credentialled provider
+// wiring. Sharing project.BuildRegistry with project validation guarantees the
+// documented rule set cannot drift from what validation observes.
+package ruledoc
+
+import (
+	"fmt"
+
+	"github.com/rudderlabs/rudder-iac/cli/internal/project"
+	projectdocs "github.com/rudderlabs/rudder-iac/cli/internal/project/docs"
+	"github.com/rudderlabs/rudder-iac/cli/internal/provider"
+	"github.com/rudderlabs/rudder-iac/cli/internal/validation/docs"
+)
+
+// Build joins the rules registered for cp with the authored doc fragments and
+// returns the validated catalog.
+//
+// verrs carries catalog validation failures (e.g. a registered rule with no
+// authored fragment) and is returned rather than raised so the caller can
+// surface every problem at once; a non-nil error means the catalog could not
+// be assembled at all. generatedAt is injected so callers own the timestamp —
+// the real clock in the command, a fixed value in tests.
+func Build(cp provider.Provider, cliVersion, generatedAt string) (docs.DocumentedRules, []error, error) {
+	reg, err := project.BuildRegistry(cp)
+	if err != nil {
+		return docs.DocumentedRules{}, nil, fmt.Errorf("building rule registry: %w", err)
+	}
+
+	// Project-level (gatekeeper) rules are registered outside any provider, so
+	// their authored fragments are embedded here and appended to the
+	// provider-contributed entries.
+	entries := cp.RuleDocEntries()
+	projectEntries, err := docs.LoadRuleDocEntries(projectdocs.FragmentsFS, ".")
+	if err != nil {
+		return docs.DocumentedRules{}, nil, fmt.Errorf("loading project rule docs: %w", err)
+	}
+	entries = append(entries, projectEntries...)
+
+	doc, verrs := docs.Generate(
+		reg.AllSyntacticRules(),
+		reg.AllSemanticRules(),
+		entries,
+		cliVersion,
+		generatedAt,
+	)
+	return doc, verrs, nil
+}

--- a/cli/internal/ruledoc/ruledoc_test.go
+++ b/cli/internal/ruledoc/ruledoc_test.go
@@ -1,0 +1,33 @@
+package ruledoc_test
+
+import (
+	"testing"
+
+	"github.com/rudderlabs/rudder-iac/cli/internal/ruledoc"
+	"github.com/rudderlabs/rudder-iac/cli/internal/testutils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBuild_GatekeeperOnly proves Build assembles a valid catalog from a
+// provider in isolation — no client, config, or auth. An empty provider still
+// yields the four project-level gatekeeper rules (always registered by
+// BuildRegistry), and their embedded fragments cover them exactly, so the
+// catalog validates with zero errors. This is the assembly seam that package
+// app exercises end-to-end against the real composed providers.
+func TestBuild_GatekeeperOnly(t *testing.T) {
+	cp := &testutils.MockProvider{}
+
+	doc, verrs, err := ruledoc.Build(cp, "test", "2026-01-01T00:00:00Z")
+	require.NoError(t, err)
+	assert.Empty(t, verrs, "gatekeeper fragments must cover the gatekeeper rules exactly")
+
+	// spec-syntax-valid, resource-kind-version-valid, metadata-syntax-valid,
+	// duplicate-urn — the rules BuildRegistry always registers.
+	require.Len(t, doc.Rules, 4)
+	for _, r := range doc.Rules {
+		require.Len(t, r.AppliesTo, 1)
+		assert.Equal(t, "*", r.AppliesTo[0].Kind)
+		assert.Equal(t, "*", r.AppliesTo[0].Version)
+	}
+}

--- a/cli/internal/validation/docs/rules_doc.go
+++ b/cli/internal/validation/docs/rules_doc.go
@@ -45,22 +45,66 @@ func validateUniqueExampleIDs(rule *DocumentedRule) []error {
 	return errs
 }
 
+// validateAppliesToCoverage enforces a bidirectional, wildcard-aware
+// equivalence between the rule's real AppliesTo() (the "code" side, serialized
+// by the generator) and the union of authored match_behavior.applies_to (the
+// "docs" side). Both directions guard against docs↔code drift (DEX-406):
+//
+//   - code ⊆ docs: every (kind, version) the rule actually matches must be
+//     documented by some authored match_behavior — otherwise a rule that grows
+//     a new kind/version goes undocumented.
+//   - docs ⊆ code: every authored (kind, version) must be matched by the rule —
+//     otherwise a stale/over-declared fragment (referencing a kind/version the
+//     rule no longer matches) passes silently.
+//
+// Coverage uses pattern-subset semantics rather than string equality so "*"
+// wildcards (e.g. MatchAll gatekeeper rules) are handled consistently in both
+// directions.
 func validateAppliesToCoverage(rule *DocumentedRule) []error {
-	covered := make(map[string]struct{})
+	var authored []MatchPatternDoc
 	for _, mb := range rule.MatchBehavior {
-		for _, p := range mb.AppliesTo {
-			covered[p.Kind+":"+p.Version] = struct{}{}
-		}
+		authored = append(authored, mb.AppliesTo...)
 	}
 
 	var errs []error
-	for _, p := range rule.AppliesTo {
-		key := p.Kind + ":" + p.Version
-		if _, ok := covered[key]; !ok {
-			errs = append(errs, fmt.Errorf("rule %s: applies_to entry {kind: %s, version: %s} has no matching match_behavior coverage", rule.RuleID, p.Kind, p.Version))
+
+	// code ⊆ docs: each rule pattern must be contained in some authored pattern.
+	for _, c := range rule.AppliesTo {
+		if !coveredBy(c, authored) {
+			errs = append(errs, fmt.Errorf("rule %s: applies_to entry {kind: %s, version: %s} has no matching match_behavior coverage", rule.RuleID, c.Kind, c.Version))
 		}
 	}
+
+	// docs ⊆ code: each authored pattern must be contained in some rule pattern.
+	for _, a := range authored {
+		if !coveredBy(a, rule.AppliesTo) {
+			errs = append(errs, fmt.Errorf("rule %s: match_behavior applies_to entry {kind: %s, version: %s} is not covered by the rule's AppliesTo() (stale or over-declared)", rule.RuleID, a.Kind, a.Version))
+		}
+	}
+
 	return errs
+}
+
+// coveredBy reports whether pattern p is a subset of at least one pattern in
+// set — i.e. every concrete (kind, version) that p would match is also matched
+// by some pattern in set.
+func coveredBy(p MatchPatternDoc, set []MatchPatternDoc) bool {
+	for _, q := range set {
+		if patternSubset(p, q) {
+			return true
+		}
+	}
+	return false
+}
+
+// patternSubset reports whether every concrete (kind, version) matched by a is
+// also matched by b. A "*" on b widens b's coverage; a "*" on a widens what a
+// must have covered, so a wildcard in a is only a subset of a correspondingly
+// wildcarded b.
+func patternSubset(a, b MatchPatternDoc) bool {
+	kindOK := b.Kind == "*" || (a.Kind != "*" && a.Kind == b.Kind)
+	versionOK := b.Version == "*" || (a.Version != "*" && a.Version == b.Version)
+	return kindOK && versionOK
 }
 
 func validateRuleStruct(rule *DocumentedRule) []error {

--- a/cli/internal/validation/docs/rules_doc_test.go
+++ b/cli/internal/validation/docs/rules_doc_test.go
@@ -107,6 +107,9 @@ func TestCatalogValidate_UniqueExampleIDs(t *testing.T) {
 			name: "duplicate example_id across valid and invalid in same entry is flagged",
 			rule: func() DocumentedRule {
 				r := minimalRule("rule-A")
+				// Keep applies_to coverage clean so this case isolates
+				// duplicate-example_id detection, not coverage drift.
+				r.AppliesTo = append(r.AppliesTo, MatchPatternDoc{Kind: "source", Version: "v2"})
 				r.MatchBehavior = append(r.MatchBehavior, MatchBehaviorEntry{
 					AppliesTo: []MatchPatternDoc{{Kind: "source", Version: "v2"}},
 					Valid: []ValidExample{
@@ -131,6 +134,12 @@ func TestCatalogValidate_UniqueExampleIDs(t *testing.T) {
 			name: "duplicate example_id across match_behavior entries is flagged",
 			rule: func() DocumentedRule {
 				r := minimalRule("rule-A")
+				// Keep applies_to coverage clean so this case isolates
+				// duplicate-example_id detection, not coverage drift.
+				r.AppliesTo = append(r.AppliesTo,
+					MatchPatternDoc{Kind: "source", Version: "v2"},
+					MatchPatternDoc{Kind: "source", Version: "v3"},
+				)
 				mbWithDup := func(kind, version string) MatchBehaviorEntry {
 					return MatchBehaviorEntry{
 						AppliesTo: []MatchPatternDoc{{Kind: kind, Version: version}},
@@ -189,6 +198,55 @@ func TestCatalogValidate_AppliesToCoverage(t *testing.T) {
 				return r
 			}(),
 			wantLen: 2,
+		},
+		{
+			// authored ⊆ code direction (DEX-406): an authored pair the rule
+			// no longer matches is stale/over-declared and must be flagged.
+			name: "authored pair absent from rule AppliesTo is flagged (over-declaration)",
+			rule: func() DocumentedRule {
+				r := minimalRule("rule-A")
+				r.MatchBehavior[0].AppliesTo = append(r.MatchBehavior[0].AppliesTo,
+					MatchPatternDoc{Kind: "destination", Version: "v1"})
+				return r
+			}(),
+			wantLen: 1,
+		},
+		{
+			// wildcard-aware (DEX-406): MatchAll gatekeeper shape — code {*,*}
+			// documented by authored {*,*} is exact coverage, no errors.
+			name: "wildcard code covered by wildcard authored produces no errors",
+			rule: func() DocumentedRule {
+				r := minimalRule("rule-A")
+				r.AppliesTo = []MatchPatternDoc{{Kind: "*", Version: "*"}}
+				r.MatchBehavior[0].AppliesTo = []MatchPatternDoc{{Kind: "*", Version: "*"}}
+				return r
+			}(),
+			wantLen: 0,
+		},
+		{
+			// wildcard-aware (DEX-406): concrete code {source,v1} is contained
+			// in authored {*,*} (so code⊆authored holds), but authored {*,*}
+			// claims more than the rule matches → authored⊄code → 1 error.
+			name: "concrete code under wildcard authored flags over-declaration only",
+			rule: func() DocumentedRule {
+				r := minimalRule("rule-A")
+				r.AppliesTo = []MatchPatternDoc{{Kind: "source", Version: "v1"}}
+				r.MatchBehavior[0].AppliesTo = []MatchPatternDoc{{Kind: "*", Version: "*"}}
+				return r
+			}(),
+			wantLen: 1,
+		},
+		{
+			// wildcard-aware (DEX-406): authored {*,v1} claims all kinds at v1
+			// but the rule only matches {source,v1} → over-declared.
+			name: "wildcard-kind authored not fully covered by concrete code is flagged",
+			rule: func() DocumentedRule {
+				r := minimalRule("rule-A")
+				r.AppliesTo = []MatchPatternDoc{{Kind: "source", Version: "v1"}}
+				r.MatchBehavior[0].AppliesTo = []MatchPatternDoc{{Kind: "*", Version: "v1"}}
+				return r
+			}(),
+			wantLen: 1,
 		},
 	}
 


### PR DESCRIPTION
## 🔗 Ticket

Resolves [DEX-272](https://linear.app/rudderstack/issue/DEX-272) — Phase 4: authoring `*.docs.yaml` fragments + provider wiring.
Sub-tasks: [DEX-398](https://linear.app/rudderstack/issue/DEX-398), [DEX-399](https://linear.app/rudderstack/issue/DEX-399), [DEX-400](https://linear.app/rudderstack/issue/DEX-400), [DEX-406](https://linear.app/rudderstack/issue/DEX-406).

> **Stacked on #604** (DEX-271 Phase 3). Base is the Phase 3 branch, so this diff is Phase 4 only. Merge #604 first (or retarget this to `main` once #604 lands).

---

## Summary

Phase 4: author the per-rule `*.docs.yaml` fragments, wire each provider to contribute them, and generate the canonical catalog. The branch was rewritten so the two load-bearing semantic changes land **before** the content, each in its own commit, and the large generated catalog is isolated **last** behind a `linguist-generated` marker — keeping the reviewable surface small.

---

## Changes

Four commits, ordered semantics → wiring → content:

1. **`refactor(rules): gatekeeper rules apply to all patterns`** — `metadata-syntax-valid` and `duplicate-urn` match every spec independently of the provider's active patterns, so they drop the `activePatterns` parameter and `AppliesTo` reports `MatchAll`. (`spec-syntax-valid` / `resource-kind-version-valid` still consume `activePatterns`.) Previously this signature change was mixed into a content commit.
2. **`feat(docs): make applies_to coverage bidirectional + wildcard-aware (DEX-406)`** — `validateAppliesToCoverage` replaces the one-directional string-equality check with a bidirectional subset test (`code ⊆ docs` *and* `docs ⊆ code` via `patternSubset` / `coveredBy`), so a wildcard pattern (e.g. `rudder/*`) is correctly recognized as covered by, and covering, a concrete registry pattern. This flags stale / over-declared authored entries that previously passed silently. Previously this was fused with commit 1.
3. **`feat(docs): author rule-doc fragments and wire RuleDocEntries into providers`** — embed each provider's authored `*.docs.yaml` and expose them via `RuleDocEntries()`; load the project-level gatekeeper fragments in the docs command. Per-provider tests now run the fragments through the real `docs.Generate` against the live rules instead of re-implementing the resolve/validate path.
4. **`docs: generate canonical rule catalog and mark as generated`** — add `docs/generated/rules.{yaml,json}` plus a `.gitattributes` entry marking them `linguist-generated -diff` so the ~5.7k-line catalog collapses in review and in diffs.

---

## Testing

- Per-provider tests assert every authored fragment resolves and passes `docs.Generate` validation against the live rules.
- Full `make test` suite green; `make lint` clean.
- `make gen-rule-docs` is reproducible — regeneration yields byte-identical output apart from the `generated_at` timestamp.

---

## Risk / Impact

Low–Medium. The gatekeeper `AppliesTo` change and the coverage rewrite affect validation metadata/diagnostics; both are covered by unit tests. No change to the apply cycle. Generated catalog is documentation output only.

---

## Checklist

- [x] Ticket linked
- [x] Tests added/updated
- [x] No breaking changes (or documented)
