### PR TITLE
feat(ruledoc): executable rule-doc verifier — syntactic (subset + strict + CI gate)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,8 +39,12 @@ RULE_DOCS_OUTPUT_DIR ?= docs/generated
 gen-rule-docs: ## Generate the validation rule documentation artifact
 	$(GO) run ./cli/cmd/gen-rule-docs --output-dir $(RULE_DOCS_OUTPUT_DIR)
 
+.PHONY: verify-rule-docs
+verify-rule-docs: ## Verify authored rule-doc examples against the engine (writes nothing into the tree)
+	$(GO) run ./cli/cmd/gen-rule-docs --output-dir $(shell mktemp -d)
+
 .PHONY: test
-test: ## Run all unit tests (excluding e2e)
+test: verify-rule-docs ## Run all unit tests (excluding e2e)
 	@go test --race --covermode=atomic --coverprofile=coverage-unit.out $(shell go list ./... | grep -v /cli/tests)
 
 .PHONY: test-e2e

--- a/cli/cmd/gen-rule-docs/main.go
+++ b/cli/cmd/gen-rule-docs/main.go
@@ -34,6 +34,7 @@ func main() {
 
 func run() error {
 	outputDir := flag.String("output-dir", "./docs/generated/", "Directory to write the generated rules.yaml artifact")
+	strict := flag.Bool("strict-verify", false, "Fail if the engine produces diagnostics beyond those documented (exact-match)")
 	flag.Parse()
 
 	app.Initialise(version)
@@ -42,7 +43,7 @@ func run() error {
 	// All composition lives in app.GenerateRuleCatalog so the documented rule
 	// set is built from the same providers and registry project validation
 	// uses; this command only chooses the timestamp and writes the result.
-	doc, verrs, err := app.GenerateRuleCatalog(time.Now().UTC().Format(time.RFC3339))
+	doc, verrs, err := app.GenerateRuleCatalog(time.Now().UTC().Format(time.RFC3339), *strict)
 	if err != nil {
 		return err
 	}

--- a/cli/internal/app/dependencies.go
+++ b/cli/internal/app/dependencies.go
@@ -120,13 +120,18 @@ func NewDeps() (Deps, error) {
 // verrs carries catalog validation failures (e.g. a registered rule with no
 // authored fragment); a non-nil error means the catalog could not be assembled
 // at all. generatedAt is injected so callers own the timestamp.
-func GenerateRuleCatalog(generatedAt string) (docs.DocumentedRules, []error, error) {
+func GenerateRuleCatalog(generatedAt string, strict bool) (docs.DocumentedRules, []error, error) {
 	cp, err := newCompositeProvider()
 	if err != nil {
 		return docs.DocumentedRules{}, nil, fmt.Errorf("building composite provider: %w", err)
 	}
 
-	return ruledoc.Build(cp, GetVersion(), generatedAt, docs.ModeSubset)
+	mode := docs.ModeSubset
+	if strict {
+		mode = docs.ModeStrict
+	}
+
+	return ruledoc.Build(cp, GetVersion(), generatedAt, mode)
 }
 
 // newCompositeProvider builds the composite provider without requiring

--- a/cli/internal/app/dependencies.go
+++ b/cli/internal/app/dependencies.go
@@ -126,7 +126,7 @@ func GenerateRuleCatalog(generatedAt string) (docs.DocumentedRules, []error, err
 		return docs.DocumentedRules{}, nil, fmt.Errorf("building composite provider: %w", err)
 	}
 
-	return ruledoc.Build(cp, GetVersion(), generatedAt)
+	return ruledoc.Build(cp, GetVersion(), generatedAt, docs.ModeSubset)
 }
 
 // newCompositeProvider builds the composite provider without requiring

--- a/cli/internal/app/ruledoc_test.go
+++ b/cli/internal/app/ruledoc_test.go
@@ -23,7 +23,7 @@ func TestGenerateRuleCatalog_CompleteAndDriftFree(t *testing.T) {
 	// never touches the developer's ~/.rudder config.
 	config.InitConfig(filepath.Join(t.TempDir(), "config.json"))
 
-	doc, verrs, err := GenerateRuleCatalog("2026-01-01T00:00:00Z")
+	doc, verrs, err := GenerateRuleCatalog("2026-01-01T00:00:00Z", false)
 	require.NoError(t, err)
 	assert.Empty(t, verrs, "every registered rule must have an authored fragment and vice versa")
 	assert.NotEmpty(t, doc.Rules, "catalog should document at least one rule")

--- a/cli/internal/app/ruledoc_verify_test.go
+++ b/cli/internal/app/ruledoc_verify_test.go
@@ -1,0 +1,29 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/rudderlabs/rudder-iac/cli/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGenerateRuleCatalog_VerifiesCleanly drives the real composite provider
+// (no network) and runs the executable verifier over every authored syntactic
+// example. Unlike the structural drift test, this asserts the authored
+// examples actually behave as documented when run through the real validation
+// engine: every invalid example produces its expected diagnostics and every
+// valid example produces none.
+//
+// The DataGraph experimental flag is off by default, so the datagraph provider
+// and its fragments are excluded here — that is expected and consistent with
+// the rest of the catalog gate.
+func TestGenerateRuleCatalog_VerifiesCleanly(t *testing.T) {
+	Initialise("0.0.0-test")
+	config.InitConfig(config.DefaultConfigFile())
+
+	doc, verrs, err := GenerateRuleCatalog("2026-01-01T00:00:00Z")
+	require.NoError(t, err)
+	assert.Empty(t, verrs, "every authored example must verify cleanly through the real engine")
+	assert.NotEmpty(t, doc.Rules, "catalog should document at least one rule")
+}

--- a/cli/internal/app/ruledoc_verify_test.go
+++ b/cli/internal/app/ruledoc_verify_test.go
@@ -22,7 +22,7 @@ func TestGenerateRuleCatalog_VerifiesCleanly(t *testing.T) {
 	Initialise("0.0.0-test")
 	config.InitConfig(config.DefaultConfigFile())
 
-	doc, verrs, err := GenerateRuleCatalog("2026-01-01T00:00:00Z")
+	doc, verrs, err := GenerateRuleCatalog("2026-01-01T00:00:00Z", false)
 	require.NoError(t, err)
 	assert.Empty(t, verrs, "every authored example must verify cleanly through the real engine")
 	assert.NotEmpty(t, doc.Rules, "catalog should document at least one rule")

--- a/cli/internal/project/docs/duplicate-urn.docs.yaml
+++ b/cli/internal/project/docs/duplicate-urn.docs.yaml
@@ -22,6 +22,7 @@ match_behavior:
             spec:
               events:
                 - id: order_completed
+                  event_type: track
                   name: Order Completed
           b.yaml: |
             version: rudder/v1
@@ -31,6 +32,7 @@ match_behavior:
             spec:
               events:
                 - id: cart_viewed
+                  event_type: track
                   name: Cart Viewed
     invalid:
       - example_id: "duplicate-urn-across-files"
@@ -47,6 +49,7 @@ match_behavior:
             spec:
               events:
                 - id: order_completed
+                  event_type: track
                   name: Order Completed
           b.yaml: |
             version: rudder/v1
@@ -56,6 +59,7 @@ match_behavior:
             spec:
               events:
                 - id: order_completed
+                  event_type: track
                   name: Order Completed (duplicate)
         expected_diagnostics:
           - file: "a.yaml"

--- a/cli/internal/project/docs/metadata-syntax-valid.docs.yaml
+++ b/cli/internal/project/docs/metadata-syntax-valid.docs.yaml
@@ -40,6 +40,7 @@ match_behavior:
             spec:
               events:
                 - id: order_completed
+                  event_type: track
                   name: Order Completed
     invalid:
       - example_id: "metadata-missing-name"
@@ -77,6 +78,7 @@ match_behavior:
             spec:
               events:
                 - id: order_completed
+                  event_type: track
                   name: Order Completed
         expected_diagnostics:
           - file: "spec.yaml"

--- a/cli/internal/project/docs/resource-kind-version-valid.docs.yaml
+++ b/cli/internal/project/docs/resource-kind-version-valid.docs.yaml
@@ -24,23 +24,29 @@ match_behavior:
             spec:
               events:
                 - id: order_completed
+                  event_type: track
                   name: Order Completed
     invalid:
       - example_id: "kind-version-unsupported-version"
         title: "Known kind declared with an unsupported version"
         description: >
-          The events kind is recognised, but it is not registered for version
-          rudder/v0.1. The rule reports the unsupported kind/version pairing.
+          The transformation kind is recognised, but it is only registered for
+          version rudder/v1, not rudder/0.1. The rule reports the unsupported
+          kind/version pairing.
         files:
           spec.yaml: |
-            version: rudder/v0.1
-            kind: events
+            version: rudder/0.1
+            kind: transformation
             metadata:
-              name: my-events
+              name: my-transformations
             spec:
-              events:
-                - id: order_completed
-                  name: Order Completed
+              id: my-transformation
+              name: My Transformation
+              language: javascript
+              code: |
+                export function transformEvent(event, metadata) {
+                  return event;
+                }
         expected_diagnostics:
           - file: "spec.yaml"
             reference: "/kind"

--- a/cli/internal/project/docs/spec-syntax-valid.docs.yaml
+++ b/cli/internal/project/docs/spec-syntax-valid.docs.yaml
@@ -71,7 +71,8 @@ match_behavior:
             kind: properties
             spec:
               properties:
-                - name: MyTestProperty
+                - id: my_test_property
+                  name: MyTestProperty
                   type: string
         expected_diagnostics:
           - file: "spec.yaml"

--- a/cli/internal/project/docs/spec-syntax-valid.docs.yaml
+++ b/cli/internal/project/docs/spec-syntax-valid.docs.yaml
@@ -22,7 +22,8 @@ match_behavior:
               name: my-properties
             spec:
               properties:
-                - name: MyTestProperty
+                - id: my_test_property
+                  name: MyTestProperty
                   type: string
     invalid:
       - example_id: "spec-syntax-missing-kind"

--- a/cli/internal/providers/datacatalog/docs/custom-types-config-valid.docs.yaml
+++ b/cli/internal/providers/datacatalog/docs/custom-types-config-valid.docs.yaml
@@ -59,7 +59,7 @@ match_behavior:
           - file: "spec.yaml"
             reference: "/types/0/config/format"
             severity: "error"
-            message_contains: "invalid_format"
+            message_contains: "'format' must be one of"
   # Current spec version (rudder/v1).
   - applies_to:
       - kind: "custom-types"
@@ -100,4 +100,4 @@ match_behavior:
           - file: "spec.yaml"
             reference: "/types/0/config/format"
             severity: "error"
-            message_contains: "not_a_valid_format"
+            message_contains: "'format' must be one of"

--- a/cli/internal/providers/datacatalog/docs/events-spec-syntax-valid.docs.yaml
+++ b/cli/internal/providers/datacatalog/docs/events-spec-syntax-valid.docs.yaml
@@ -57,7 +57,7 @@ match_behavior:
           - file: "spec.yaml"
             reference: "/events/0/event_type"
             severity: "error"
-            message_contains: "oneof"
+            message_contains: "'event_type' must be one of [track screen identify group page]"
   # Current spec version (rudder/v1).
   - applies_to:
       - kind: "events"

--- a/cli/internal/providers/datacatalog/docs/properties-config-valid.docs.yaml
+++ b/cli/internal/providers/datacatalog/docs/properties-config-valid.docs.yaml
@@ -60,7 +60,7 @@ match_behavior:
           - file: "spec.yaml"
             reference: "/properties/0/propConfig/format"
             severity: "error"
-            message_contains: "not_valid"
+            message_contains: "'format' must be one of"
   # Current spec version (rudder/v1).
   - applies_to:
       - kind: "properties"
@@ -102,4 +102,4 @@ match_behavior:
           - file: "spec.yaml"
             reference: "/properties/0/propConfig/format"
             severity: "error"
-            message_contains: "totally_wrong"
+            message_contains: "'format' must be one of"

--- a/cli/internal/providers/transformations/docs/transformation-library-spec-syntax-valid.docs.yaml
+++ b/cli/internal/providers/transformations/docs/transformation-library-spec-syntax-valid.docs.yaml
@@ -13,16 +13,15 @@ match_behavior:
             metadata:
               name: my-libraries
             spec:
-              libraries:
-                - id: math-utils
-                  name: Math Utils
-                  import_name: mathUtils
-                  description: Utility functions for math operations
-                  language: javascript
-                  code: |
-                    export function round(value) {
-                      return Math.round(value);
-                    }
+              id: math-utils
+              name: Math Utils
+              import_name: mathUtils
+              description: Utility functions for math operations
+              language: javascript
+              code: |
+                export function round(value) {
+                  return Math.round(value);
+                }
     invalid:
       - example_id: "transformation-library-spec-syntax-valid-missing-id"
         title: "Transformation library spec missing required id field"
@@ -33,14 +32,13 @@ match_behavior:
             metadata:
               name: my-libraries
             spec:
-              libraries:
-                - name: Math Utils
-                  import_name: mathUtils
-                  language: javascript
-                  code: |
-                    export function round(value) {
-                      return Math.round(value);
-                    }
+              name: Math Utils
+              import_name: mathUtils
+              language: javascript
+              code: |
+                export function round(value) {
+                  return Math.round(value);
+                }
         expected_diagnostics:
           - file: "spec.yaml"
             reference: "/id"
@@ -55,14 +53,13 @@ match_behavior:
             metadata:
               name: my-libraries
             spec:
-              libraries:
-                - id: math-utils
-                  name: Math Utils
-                  language: javascript
-                  code: |
-                    export function round(value) {
-                      return Math.round(value);
-                    }
+              id: math-utils
+              name: Math Utils
+              language: javascript
+              code: |
+                export function round(value) {
+                  return Math.round(value);
+                }
         expected_diagnostics:
           - file: "spec.yaml"
             reference: "/import_name"
@@ -77,15 +74,14 @@ match_behavior:
             metadata:
               name: my-libraries
             spec:
-              libraries:
-                - id: math-utils
-                  name: Math Utils
-                  import_name: MathUtils
-                  language: javascript
-                  code: |
-                    export function round(value) {
-                      return Math.round(value);
-                    }
+              id: math-utils
+              name: Math Utils
+              import_name: MathUtils
+              language: javascript
+              code: |
+                export function round(value) {
+                  return Math.round(value);
+                }
         expected_diagnostics:
           - file: "spec.yaml"
             reference: "/import_name"
@@ -100,15 +96,14 @@ match_behavior:
             metadata:
               name: my-libraries
             spec:
-              libraries:
-                - id: math-utils
-                  name: Math Utils
-                  import_name: mathUtils
-                  language: ruby
-                  code: |
-                    def round(value)
-                      value.round
-                    end
+              id: math-utils
+              name: Math Utils
+              import_name: mathUtils
+              language: ruby
+              code: |
+                def round(value)
+                  value.round
+                end
         expected_diagnostics:
           - file: "spec.yaml"
             reference: "/language"

--- a/cli/internal/providers/transformations/docs/transformation-spec-syntax-valid.docs.yaml
+++ b/cli/internal/providers/transformations/docs/transformation-spec-syntax-valid.docs.yaml
@@ -13,16 +13,15 @@ match_behavior:
             metadata:
               name: my-transformations
             spec:
-              transformations:
-                - id: my-transformation
-                  name: My Transformation
-                  description: Enriches events with additional metadata
-                  language: javascript
-                  code: |
-                    export function transformEvent(event, metadata) {
-                      event.properties.enriched = true;
-                      return event;
-                    }
+              id: my-transformation
+              name: My Transformation
+              description: Enriches events with additional metadata
+              language: javascript
+              code: |
+                export function transformEvent(event, metadata) {
+                  event.properties.enriched = true;
+                  return event;
+                }
     invalid:
       - example_id: "transformation-spec-syntax-valid-missing-id"
         title: "Transformation spec missing required id field"
@@ -33,13 +32,12 @@ match_behavior:
             metadata:
               name: my-transformations
             spec:
-              transformations:
-                - name: My Transformation
-                  language: javascript
-                  code: |
-                    export function transformEvent(event, metadata) {
-                      return event;
-                    }
+              name: My Transformation
+              language: javascript
+              code: |
+                export function transformEvent(event, metadata) {
+                  return event;
+                }
         expected_diagnostics:
           - file: "spec.yaml"
             reference: "/id"
@@ -54,13 +52,12 @@ match_behavior:
             metadata:
               name: my-transformations
             spec:
-              transformations:
-                - id: my-transformation
-                  name: My Transformation
-                  code: |
-                    export function transformEvent(event, metadata) {
-                      return event;
-                    }
+              id: my-transformation
+              name: My Transformation
+              code: |
+                export function transformEvent(event, metadata) {
+                  return event;
+                }
         expected_diagnostics:
           - file: "spec.yaml"
             reference: "/language"
@@ -75,14 +72,13 @@ match_behavior:
             metadata:
               name: my-transformations
             spec:
-              transformations:
-                - id: my-transformation
-                  name: My Transformation
-                  language: ruby
-                  code: |
-                    def transform_event(event, metadata)
-                      event
-                    end
+              id: my-transformation
+              name: My Transformation
+              language: ruby
+              code: |
+                def transform_event(event, metadata)
+                  event
+                end
         expected_diagnostics:
           - file: "spec.yaml"
             reference: "/language"
@@ -97,10 +93,9 @@ match_behavior:
             metadata:
               name: my-transformations
             spec:
-              transformations:
-                - id: my-transformation
-                  name: My Transformation
-                  language: javascript
+              id: my-transformation
+              name: My Transformation
+              language: javascript
         expected_diagnostics:
           - file: "spec.yaml"
             reference: "/code"

--- a/cli/internal/providers/transformations/docs/transformation-spec-syntax-valid.docs.yaml
+++ b/cli/internal/providers/transformations/docs/transformation-spec-syntax-valid.docs.yaml
@@ -101,3 +101,7 @@ match_behavior:
             reference: "/code"
             severity: "error"
             message_contains: "'code' is required when 'file' is not specified"
+          - file: "spec.yaml"
+            reference: "/file"
+            severity: "error"
+            message_contains: "'file' is required when 'code' is not specified"

--- a/cli/internal/ruledoc/ruledoc.go
+++ b/cli/internal/ruledoc/ruledoc.go
@@ -29,8 +29,9 @@ import (
 // authored fragment) and is returned rather than raised so the caller can
 // surface every problem at once; a non-nil error means the catalog could not
 // be assembled at all. generatedAt is injected so callers own the timestamp —
-// the real clock in the command, a fixed value in tests.
-func Build(cp provider.Provider, cliVersion, generatedAt string) (docs.DocumentedRules, []error, error) {
+// the real clock in the command, a fixed value in tests. mode controls how
+// strictly example expectations are matched during verification.
+func Build(cp provider.Provider, cliVersion, generatedAt string, mode docs.VerifyMode) (docs.DocumentedRules, []error, error) {
 	reg, err := project.BuildRegistry(cp)
 	if err != nil {
 		return docs.DocumentedRules{}, nil, fmt.Errorf("building rule registry: %w", err)
@@ -53,5 +54,13 @@ func Build(cp provider.Provider, cliVersion, generatedAt string) (docs.Documente
 		cliVersion,
 		generatedAt,
 	)
+
+	// Run example verification only when structural validation is clean: an
+	// incomplete or invalid catalog (missing fragments, mismatched rule IDs)
+	// cannot be meaningfully executed — fix structure first, then verify behaviour.
+	if len(verrs) == 0 {
+		verrs = append(verrs, verify(reg, doc, mode)...)
+	}
+
 	return doc, verrs, nil
 }

--- a/cli/internal/ruledoc/ruledoc_test.go
+++ b/cli/internal/ruledoc/ruledoc_test.go
@@ -1,11 +1,15 @@
 package ruledoc_test
 
 import (
+	"strconv"
 	"testing"
 
+	"github.com/rudderlabs/rudder-iac/cli/internal/project/specs"
+	"github.com/rudderlabs/rudder-iac/cli/internal/resources"
 	"github.com/rudderlabs/rudder-iac/cli/internal/ruledoc"
 	"github.com/rudderlabs/rudder-iac/cli/internal/testutils"
 	"github.com/rudderlabs/rudder-iac/cli/internal/validation/docs"
+	vrules "github.com/rudderlabs/rudder-iac/cli/internal/validation/rules"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -16,11 +20,32 @@ import (
 // BuildRegistry), and their embedded fragments cover them exactly, so the
 // catalog validates with zero errors. This is the assembly seam that package
 // app exercises end-to-end against the real composed providers.
+//
+// Two gatekeeper rules consult the provider for context: duplicate-urn and the
+// metadata import cross-check both call provider.ParseSpec to learn the URNs a
+// spec declares, and resource-kind-version-valid keys off the provider's
+// supported kind/version patterns. Their authored examples document that
+// behaviour, so the mock is given just enough provider context — event-URN
+// extraction and the events/transformation patterns — for those examples to
+// run as documented. Everything else still flows through the real engine.
 func TestBuild_GatekeeperOnly(t *testing.T) {
-	// NewMockProvider initialises ParseSpecVal to a non-nil ParsedSpec so that
-	// the duplicate-urn rule (wired via provider.ParseSpec) can safely iterate
-	// URNs when verify() runs examples through the engine.
-	cp := testutils.NewMockProvider(nil, nil)
+	cp := &testutils.MockProvider{
+		// The gatekeeper examples span the events, properties and transformation
+		// kinds. Declaring these patterns lets spec-syntax-valid accept every
+		// example's kind/version, while resource-kind-version-valid recognises
+		// transformation as a known kind and rudder/0.1 as a known version yet
+		// still flags transformation@rudder/0.1 as an unregistered pairing.
+		MatchPatterns: []vrules.MatchPattern{
+			vrules.MatchKindVersion("events", "rudder/v1"),
+			vrules.MatchKindVersion("events", "rudder/0.1"),
+			vrules.MatchKindVersion("properties", "rudder/v1"),
+			vrules.MatchKindVersion("transformation", "rudder/v1"),
+		},
+		// duplicate-urn and the metadata import cross-check resolve URNs via
+		// ParseSpec; mirror how the datacatalog provider derives event URNs so
+		// those examples collide / resolve exactly as documented.
+		ParseSpecFn: extractEventURNs,
+	}
 
 	doc, verrs, err := ruledoc.Build(cp, "test", "2026-01-01T00:00:00Z", docs.ModeSubset)
 	require.NoError(t, err)
@@ -34,4 +59,37 @@ func TestBuild_GatekeeperOnly(t *testing.T) {
 		assert.Equal(t, "*", r.AppliesTo[0].Kind)
 		assert.Equal(t, "*", r.AppliesTo[0].Version)
 	}
+}
+
+// extractEventURNs mirrors the datacatalog provider's URN extraction for the
+// events kind: each entry under spec.events with an id yields an "event:<id>"
+// URN. It is intentionally minimal — only the events kind, the only kind the
+// gatekeeper fragments declare.
+func extractEventURNs(_ string, s *specs.Spec) (*specs.ParsedSpec, error) {
+	parsed := &specs.ParsedSpec{URNs: []specs.URNEntry{}}
+	if s == nil || s.Spec == nil {
+		return parsed, nil
+	}
+
+	rawEvents, ok := s.Spec["events"].([]any)
+	if !ok {
+		return parsed, nil
+	}
+
+	for i, raw := range rawEvents {
+		event, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		id, ok := event["id"].(string)
+		if !ok || id == "" {
+			continue
+		}
+		parsed.URNs = append(parsed.URNs, specs.URNEntry{
+			URN:             resources.URN(id, "event"),
+			JSONPointerPath: "/spec/events/" + strconv.Itoa(i) + "/id",
+		})
+	}
+
+	return parsed, nil
 }

--- a/cli/internal/ruledoc/ruledoc_test.go
+++ b/cli/internal/ruledoc/ruledoc_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/rudderlabs/rudder-iac/cli/internal/ruledoc"
 	"github.com/rudderlabs/rudder-iac/cli/internal/testutils"
+	"github.com/rudderlabs/rudder-iac/cli/internal/validation/docs"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -16,9 +17,12 @@ import (
 // catalog validates with zero errors. This is the assembly seam that package
 // app exercises end-to-end against the real composed providers.
 func TestBuild_GatekeeperOnly(t *testing.T) {
-	cp := &testutils.MockProvider{}
+	// NewMockProvider initialises ParseSpecVal to a non-nil ParsedSpec so that
+	// the duplicate-urn rule (wired via provider.ParseSpec) can safely iterate
+	// URNs when verify() runs examples through the engine.
+	cp := testutils.NewMockProvider(nil, nil)
 
-	doc, verrs, err := ruledoc.Build(cp, "test", "2026-01-01T00:00:00Z")
+	doc, verrs, err := ruledoc.Build(cp, "test", "2026-01-01T00:00:00Z", docs.ModeSubset)
 	require.NoError(t, err)
 	assert.Empty(t, verrs, "gatekeeper fragments must cover the gatekeeper rules exactly")
 

--- a/cli/internal/ruledoc/verify.go
+++ b/cli/internal/ruledoc/verify.go
@@ -1,0 +1,106 @@
+package ruledoc
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/rudderlabs/rudder-iac/cli/internal/logger"
+	"github.com/rudderlabs/rudder-iac/cli/internal/project/specs"
+	"github.com/rudderlabs/rudder-iac/cli/internal/validation"
+	"github.com/rudderlabs/rudder-iac/cli/internal/validation/docs"
+	"github.com/rudderlabs/rudder-iac/cli/internal/validation/rules"
+)
+
+var verifyLog = logger.New("ruledoc-verify")
+
+// verify runs every authored example of a syntactic-phase rule through the real
+// engine; semantic-phase examples are skipped (counted, logged once).
+func verify(reg rules.Registry, doc docs.DocumentedRules, mode docs.VerifyMode) []error {
+	engine, err := validation.NewValidationEngine(reg, verifyLog)
+	if err != nil {
+		return []error{fmt.Errorf("creating validation engine: %w", err)}
+	}
+
+	var (
+		errs    []error
+		skipped int
+	)
+
+	for _, r := range doc.Rules {
+		if r.Phase != "syntactic" {
+			for _, mb := range r.MatchBehavior {
+				skipped += len(mb.Valid) + len(mb.Invalid)
+			}
+			continue
+		}
+
+		for _, mb := range r.MatchBehavior {
+			for _, ex := range mb.Invalid {
+				produced, err := runSyntactic(engine, ex.Files)
+				if err != nil {
+					errs = append(errs, fmt.Errorf("rule %s example %s: %w", r.RuleID, ex.ExampleID, err))
+					continue
+				}
+				for _, miss := range docs.MatchInvalid(ex, produced, mode) {
+					errs = append(errs, fmt.Errorf("rule %s: %s", r.RuleID, miss))
+				}
+			}
+
+			for _, ex := range mb.Valid {
+				produced, err := runSyntactic(engine, ex.Files)
+				if err != nil {
+					errs = append(errs, fmt.Errorf("rule %s example %s: %w", r.RuleID, ex.ExampleID, err))
+					continue
+				}
+				for _, miss := range docs.MatchValid(ex, produced) {
+					errs = append(errs, fmt.Errorf("rule %s: %s", r.RuleID, miss))
+				}
+			}
+		}
+	}
+
+	if skipped > 0 {
+		verifyLog.Info("skipped semantic-phase examples (syntactic-only verifier)", "count", skipped)
+	}
+
+	return errs
+}
+
+// runSyntactic mirrors project.parseSpecs + ValidateSyntax: parse each file,
+// collect parse-error diagnostics inline, then run the engine over the
+// successfully-parsed specs. The map is keyed by filename so produced
+// Diagnostic.File equals the authored example filename.
+func runSyntactic(engine validation.ValidationEngine, files map[string]string) ([]docs.ProducedDiagnostic, error) {
+	var (
+		parsed   = map[string]*specs.RawSpec{}
+		produced []docs.ProducedDiagnostic
+	)
+
+	for name, content := range files {
+		rs := &specs.RawSpec{Data: []byte(content)}
+		if _, err := rs.Parse(); err != nil {
+			produced = append(produced, docs.ProducedDiagnostic{
+				File:     name,
+				Severity: rules.Error.String(),
+				Message:  fmt.Sprintf("failed to parse spec from path %s: %s", name, err.Error()),
+			})
+			continue
+		}
+		parsed[name] = rs
+	}
+
+	diags, err := engine.ValidateSyntax(context.Background(), parsed)
+	if err != nil {
+		return nil, fmt.Errorf("validate syntax: %w", err)
+	}
+
+	for _, d := range diags {
+		produced = append(produced, docs.ProducedDiagnostic{
+			File:     d.File,
+			Severity: d.Severity.String(),
+			Message:  d.Message,
+		})
+	}
+
+	return produced, nil
+}

--- a/cli/internal/ruledoc/verify_test.go
+++ b/cli/internal/ruledoc/verify_test.go
@@ -1,0 +1,95 @@
+package ruledoc
+
+import (
+	"testing"
+
+	"github.com/rudderlabs/rudder-iac/cli/internal/project"
+	"github.com/rudderlabs/rudder-iac/cli/internal/testutils"
+	"github.com/rudderlabs/rudder-iac/cli/internal/validation/docs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestVerify_SyntacticInvalidExampleMatches exercises the full path: build a real
+// registry (gatekeeper rules only), craft an invalid example that triggers
+// "project/spec-syntax-valid", and confirm verify() returns no misses.
+func TestVerify_SyntacticInvalidExampleMatches(t *testing.T) {
+	cp := &testutils.MockProvider{}
+	reg, err := project.BuildRegistry(cp)
+	require.NoError(t, err)
+
+	// A spec that parses fine as YAML but is missing the `kind` field, which
+	// triggers the "'kind' is required" diagnostic from spec-syntax-valid.
+	missingKindYAML := `version: rudder/v1
+metadata:
+  name: test-spec
+spec:
+  properties: []
+`
+	doc := docs.DocumentedRules{
+		Rules: []docs.DocumentedRule{
+			{
+				RuleID: "project/spec-syntax-valid",
+				Phase:  "syntactic",
+				MatchBehavior: []docs.MatchBehaviorEntry{
+					{
+						AppliesTo: []docs.MatchPatternDoc{{Kind: "*", Version: "*"}},
+						Invalid: []docs.InvalidExample{
+							{
+								ExampleID:   "missing-kind",
+								Title:       "spec missing kind field",
+								Files:       map[string]string{"spec.yaml": missingKindYAML},
+								ExpectedDiagnostics: []docs.ExpectedDiagnostic{
+									{
+										File:            "spec.yaml",
+										Reference:       "/kind",
+										Severity:        "error",
+										MessageContains: "'kind' is required",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	errs := verify(reg, doc, docs.ModeSubset)
+	assert.Empty(t, errs, "expected no verification misses for a matching invalid example")
+}
+
+// TestVerify_SkipsSemanticPhase ensures that semantic-phase rules are silently
+// skipped (counted and logged) without triggering any errors or panics.
+func TestVerify_SkipsSemanticPhase(t *testing.T) {
+	cp := &testutils.MockProvider{}
+	reg, err := project.BuildRegistry(cp)
+	require.NoError(t, err)
+
+	doc := docs.DocumentedRules{
+		Rules: []docs.DocumentedRule{
+			{
+				RuleID: "datacatalog/properties/some-semantic-rule",
+				Phase:  "semantic",
+				MatchBehavior: []docs.MatchBehaviorEntry{
+					{
+						AppliesTo: []docs.MatchPatternDoc{{Kind: "properties", Version: "rudder/v1"}},
+						Invalid: []docs.InvalidExample{
+							{
+								ExampleID:   "semantic-invalid",
+								Title:       "semantic invalid example",
+								Files:       map[string]string{"spec.yaml": "version: rudder/v1\nkind: properties\n"},
+								ExpectedDiagnostics: []docs.ExpectedDiagnostic{
+									{File: "spec.yaml", Reference: "/spec/properties", Severity: "error", MessageContains: "some message"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	errs := verify(reg, doc, docs.ModeSubset)
+	assert.Empty(t, errs, "semantic-phase examples must be skipped without error")
+}

--- a/cli/internal/testutils/mockprovider.go
+++ b/cli/internal/testutils/mockprovider.go
@@ -10,17 +10,17 @@ import (
 	"github.com/rudderlabs/rudder-iac/cli/internal/resolver"
 	"github.com/rudderlabs/rudder-iac/cli/internal/resources"
 	"github.com/rudderlabs/rudder-iac/cli/internal/resources/state"
-	"github.com/rudderlabs/rudder-iac/cli/internal/validation/rules"
 	"github.com/rudderlabs/rudder-iac/cli/internal/validation/docs"
+	"github.com/rudderlabs/rudder-iac/cli/internal/validation/rules"
 )
 
 // MockProvider is a mock implementation of the provider.Provider interface for testing.
 type MockProvider struct {
 	provider.EmptyProvider
-	supportedKinds             []string
-	supportedTypes             []string
+	supportedKinds []string
+	supportedTypes []string
 	// MatchPatterns when non-nil is returned by SupportedMatchPatterns; when nil, defers to EmptyProvider (nil).
-	MatchPatterns []rules.MatchPattern
+	MatchPatterns              []rules.MatchPattern
 	LoadSpecErr                error
 	LoadLegacySpecErr          error
 	GetResourceGraphVal        *resources.Graph
@@ -42,8 +42,8 @@ type MockProvider struct {
 	// It lets a test return URNs derived from the spec content — needed by
 	// gatekeeper rules (duplicate-urn, metadata import cross-check) whose
 	// behaviour depends on the actual URNs a provider would extract.
-	ParseSpecFn func(path string, s *specs.Spec) (*specs.ParsedSpec, error)
-	RuleDocEntriesVal          []docs.RuleDocEntry
+	ParseSpecFn       func(path string, s *specs.Spec) (*specs.ParsedSpec, error)
+	RuleDocEntriesVal []docs.RuleDocEntry
 
 	// Tracking calls
 	LoadSpecCalledWithArgs             []LoadSpecArgs

--- a/cli/internal/testutils/mockprovider.go
+++ b/cli/internal/testutils/mockprovider.go
@@ -38,6 +38,11 @@ type MockProvider struct {
 	ImportErr                  error
 	ParseSpecVal               *specs.ParsedSpec
 	ParseSpecErr               error
+	// ParseSpecFn, when non-nil, takes precedence over ParseSpecVal/ParseSpecErr.
+	// It lets a test return URNs derived from the spec content — needed by
+	// gatekeeper rules (duplicate-urn, metadata import cross-check) whose
+	// behaviour depends on the actual URNs a provider would extract.
+	ParseSpecFn func(path string, s *specs.Spec) (*specs.ParsedSpec, error)
 	RuleDocEntriesVal          []docs.RuleDocEntry
 
 	// Tracking calls
@@ -124,6 +129,9 @@ func (m *MockProvider) SupportedMatchPatterns() []rules.MatchPattern {
 
 func (m *MockProvider) ParseSpec(path string, s *specs.Spec) (*specs.ParsedSpec, error) {
 	m.ParseSpecCalledWithArgs = append(m.ParseSpecCalledWithArgs, ParseSpecArgs{Path: path, Spec: s})
+	if m.ParseSpecFn != nil {
+		return m.ParseSpecFn(path, s)
+	}
 	return m.ParseSpecVal, m.ParseSpecErr
 }
 

--- a/cli/internal/validation/docs/verifier.go
+++ b/cli/internal/validation/docs/verifier.go
@@ -1,0 +1,90 @@
+package docs
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ProducedDiagnostic is a single diagnostic emitted by the validation engine
+// for a given example file.
+type ProducedDiagnostic struct {
+	File     string
+	Severity string
+	Message  string
+}
+
+// VerifyMode controls how strictly MatchInvalid compares expectations to produced diagnostics.
+type VerifyMode int
+
+const (
+	// ModeSubset requires every expected diagnostic to match at least one produced
+	// diagnostic, but ignores unmatched produced diagnostics.
+	ModeSubset VerifyMode = iota
+
+	// ModeStrict extends ModeSubset: also flags every produced diagnostic that no
+	// expectation matched, catching unexpected noise.
+	ModeStrict
+)
+
+// MatchInvalid checks that each expected diagnostic in ex is satisfied by at least one
+// entry in produced (subset semantics). In ModeStrict, any produced diagnostic that no
+// expectation covers is also reported as a miss. Returns human-readable miss strings; an
+// empty slice means the example verified cleanly.
+func MatchInvalid(ex InvalidExample, produced []ProducedDiagnostic, mode VerifyMode) []string {
+	// matchedProduced tracks which produced indices were claimed by an expectation;
+	// only relevant in ModeStrict.
+	matchedProduced := make([]bool, len(produced))
+
+	var misses []string
+
+	for _, exp := range ex.ExpectedDiagnostics {
+		matched := false
+		for i, p := range produced {
+			if p.File != exp.File || p.Severity != exp.Severity {
+				continue
+			}
+			if exp.MessageContains != "" && !strings.Contains(p.Message, exp.MessageContains) {
+				continue
+			}
+			matchedProduced[i] = true
+			matched = true
+			break
+		}
+		if !matched {
+			misses = append(misses, fmt.Sprintf(
+				"%s: expected diagnostic not found (file=%q severity=%q contains=%q)",
+				ex.ExampleID, exp.File, exp.Severity, exp.MessageContains,
+			))
+		}
+	}
+
+	if mode == ModeStrict {
+		for i, p := range produced {
+			if matchedProduced[i] {
+				continue
+			}
+			misses = append(misses, fmt.Sprintf(
+				"%s: unexpected diagnostic (file=%q severity=%q message=%q)",
+				ex.ExampleID, p.File, p.Severity, p.Message,
+			))
+		}
+	}
+
+	return misses
+}
+
+// MatchValid checks that no error or warning diagnostics were produced for a valid example.
+// Any such diagnostic is a miss — the example should have been clean.
+func MatchValid(ex ValidExample, produced []ProducedDiagnostic) []string {
+	var misses []string
+	for _, p := range produced {
+		if p.Severity != "error" && p.Severity != "warning" {
+			continue
+		}
+		misses = append(misses, fmt.Sprintf(
+			"%s: unexpected %s diagnostic on valid example (file=%q message=%q)",
+			ex.ExampleID, p.Severity, p.File, p.Message,
+		))
+	}
+	return misses
+}

--- a/cli/internal/validation/docs/verifier_test.go
+++ b/cli/internal/validation/docs/verifier_test.go
@@ -1,0 +1,65 @@
+package docs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMatchExample_SubsetHit(t *testing.T) {
+	ex := InvalidExample{
+		ExampleID: "ex1",
+		ExpectedDiagnostics: []ExpectedDiagnostic{
+			{File: "a.yaml", Severity: "error", MessageContains: "name is required"},
+		},
+	}
+	produced := []ProducedDiagnostic{
+		{File: "a.yaml", Severity: "error", Message: "spec.name is required"},
+		{File: "a.yaml", Severity: "warning", Message: "unrelated"},
+	}
+
+	misses := MatchInvalid(ex, produced, ModeSubset)
+	assert.Empty(t, misses)
+}
+
+func TestMatchExample_SubsetMiss(t *testing.T) {
+	ex := InvalidExample{
+		ExampleID: "ex2",
+		ExpectedDiagnostics: []ExpectedDiagnostic{
+			{File: "a.yaml", Severity: "error", MessageContains: "name is required"},
+		},
+	}
+	produced := []ProducedDiagnostic{
+		{File: "a.yaml", Severity: "error", Message: "something else"},
+	}
+
+	misses := MatchInvalid(ex, produced, ModeSubset)
+	assert.Len(t, misses, 1)
+}
+
+func TestMatchExample_EmptyMessageContains_MatchesOnFileSeverity(t *testing.T) {
+	ex := InvalidExample{
+		ExampleID: "ex3",
+		ExpectedDiagnostics: []ExpectedDiagnostic{
+			{File: "a.yaml", Severity: "error", MessageContains: ""},
+		},
+	}
+	produced := []ProducedDiagnostic{
+		{File: "a.yaml", Severity: "error", Message: "anything"},
+	}
+
+	misses := MatchInvalid(ex, produced, ModeSubset)
+	assert.Empty(t, misses)
+}
+
+func TestMatchValid_ProducesDiagnostic_Fails(t *testing.T) {
+	ex := ValidExample{
+		ExampleID: "v",
+	}
+	produced := []ProducedDiagnostic{
+		{File: "a.yaml", Severity: "error", Message: "boom"},
+	}
+
+	misses := MatchValid(ex, produced)
+	assert.NotEmpty(t, misses)
+}

--- a/cli/internal/validation/docs/verifier_test.go
+++ b/cli/internal/validation/docs/verifier_test.go
@@ -63,3 +63,10 @@ func TestMatchValid_ProducesDiagnostic_Fails(t *testing.T) {
 	misses := MatchValid(ex, produced)
 	assert.NotEmpty(t, misses)
 }
+
+func TestMatchInvalid_StrictRejectsExtra(t *testing.T) {
+	ex := InvalidExample{ExampleID: "x", ExpectedDiagnostics: []ExpectedDiagnostic{{File: "a.yaml", Severity: "error", MessageContains: "boom"}}}
+	produced := []ProducedDiagnostic{{File: "a.yaml", Severity: "error", Message: "boom"}, {File: "a.yaml", Severity: "error", Message: "surprise extra"}}
+	assert.Empty(t, MatchInvalid(ex, produced, ModeSubset))   // subset passes
+	assert.Len(t, MatchInvalid(ex, produced, ModeStrict), 1)  // strict flags the extra
+}


### PR DESCRIPTION
## 🔗 Ticket

Closes DEX-273 (Phase-5 acceptance-harness umbrella) · Closes DEX-389 (subset verification) · Closes DEX-372 (`--strict-verify` exact-match).

> **Scope: syntactic verifier** (subset + strict + CI gate), ends at `c0f9e60f`. The **semantic** half is stacked in **#610** — merge #610 into this branch before this PR lands on `main` so the semantic work is included. (Supersedes the DEX-413 spike tree, now closed.)

---

## Summary

Executable acceptance verifier for the auto-generated validation-rule docs. Every authored **syntactic** example is run through the *real* validation engine at catalog-build time (`gen-rule-docs` / `make test`), so a documented diagnostic that drifts from code fails the build. Semantic examples are skipped + counted here (delivered in #610).

## Changes
- **Pure matcher** (`cli/internal/validation/docs/verifier.go`) — `ProducedDiagnostic`, `VerifyMode` (subset/strict), `MatchInvalid`/`MatchValid`. Leaf package, no engine import.
- **Engine harness** (`cli/internal/ruledoc/verify.go`) — runs syntactic examples through the real engine, mirroring `project.handleValidation` (in-memory specs keyed by filename); semantic skipped + counted.
- **Wired into `ruledoc.Build`** after structural validation; `--strict-verify` opt-in (default subset), full strict coverage of the syntactic corpus.
- **`make verify-rule-docs`** gate (throwaway dir; no committed artifact) wired into `make test`; CI runs verify via `gen-rule-docs.yml`.
- Faithful fixes to Phase-4 fragment authoring bugs surfaced by the verifier.

## Testing
`make test` · `make lint` · `make gen-rule-docs` · `make verify-rule-docs` · `--strict-verify` all exit 0. Unit + real-corpus integration tests; built via subagent-driven development with spec + code-quality review per task.

## Risk / Impact
Low. Net-new verification + CI gate; no apply-cycle/runtime change. No committed artifact (`docs/generated/` gitignored).

## Checklist
- [x] Ticket linked
- [x] Tests added/updated
- [x] No breaking changes (or documented)
