### PR TITLE
feat(ruledoc): semantic rule-doc verification (engine-isolated)

### DIFF
--- a/cli/internal/app/dependencies.go
+++ b/cli/internal/app/dependencies.go
@@ -131,7 +131,15 @@ func GenerateRuleCatalog(generatedAt string, strict bool) (docs.DocumentedRules,
 		mode = docs.ModeStrict
 	}
 
-	return ruledoc.Build(cp, GetVersion(), generatedAt, mode)
+	// Semantic verification loads each example into an isolated provider and
+	// reads back its resource graph; a fresh provider per example prevents
+	// state from one example bleeding into the next. newCompositeProvider is
+	// credential-free, matching the catalog provider above.
+	newProvider := func() (provider.Provider, error) {
+		return newCompositeProvider()
+	}
+
+	return ruledoc.Build(cp, GetVersion(), generatedAt, mode, newProvider)
 }
 
 // newCompositeProvider builds the composite provider without requiring

--- a/cli/internal/providers/datacatalog/docs/categories-semantic-valid.docs.yaml
+++ b/cli/internal/providers/datacatalog/docs/categories-semantic-valid.docs.yaml
@@ -24,8 +24,8 @@ match_behavior:
                   name: System Events
     invalid:
       - example_id: "cat-sem-legacy-duplicate"
-        title: "Duplicate category name across files (legacy)"
-        description: "Two categories with the same name in the resource graph trigger this error."
+        title: "Duplicate category name (legacy)"
+        description: "Two categories sharing the same name collide in the resource graph and trigger this error."
         files:
           spec.yaml: |
             version: rudder/0.1
@@ -34,6 +34,8 @@ match_behavior:
               name: my-categories
             spec:
               categories:
+                - id: user_actions
+                  name: User Actions
                 - id: user_actions_2
                   name: User Actions
         expected_diagnostics:
@@ -62,8 +64,8 @@ match_behavior:
                   name: System Events
     invalid:
       - example_id: "cat-sem-v1-duplicate"
-        title: "Duplicate category name across files (v1)"
-        description: "Two categories with the same name in the resource graph trigger this error."
+        title: "Duplicate category name (v1)"
+        description: "Two categories sharing the same name collide in the resource graph and trigger this error."
         files:
           spec.yaml: |
             version: rudder/v1
@@ -72,6 +74,8 @@ match_behavior:
               name: my-categories
             spec:
               categories:
+                - id: user_actions
+                  name: User Actions
                 - id: user_actions_2
                   name: User Actions
         expected_diagnostics:

--- a/cli/internal/providers/datacatalog/docs/categories-semantic-valid.docs.yaml
+++ b/cli/internal/providers/datacatalog/docs/categories-semantic-valid.docs.yaml
@@ -24,8 +24,8 @@ match_behavior:
                   name: System Events
     invalid:
       - example_id: "cat-sem-legacy-duplicate"
-        title: "Duplicate category name (legacy)"
-        description: "Two categories sharing the same name collide in the resource graph and trigger this error."
+        title: "Duplicate category name across files (legacy)"
+        description: "Two categories in separate files sharing the same name collide in the resource graph and trigger this error on each file."
         files:
           spec.yaml: |
             version: rudder/0.1
@@ -36,10 +36,21 @@ match_behavior:
               categories:
                 - id: user_actions
                   name: User Actions
-                - id: user_actions_2
+          spec2.yaml: |
+            version: rudder/0.1
+            kind: categories
+            metadata:
+              name: my-categories-2
+            spec:
+              categories:
+                - id: user_actions_copy
                   name: User Actions
         expected_diagnostics:
           - file: "spec.yaml"
+            reference: "/categories/0/name"
+            severity: "error"
+            message_contains: "duplicate name 'User Actions' within kind 'categories'"
+          - file: "spec2.yaml"
             reference: "/categories/0/name"
             severity: "error"
             message_contains: "duplicate name 'User Actions' within kind 'categories'"
@@ -64,8 +75,8 @@ match_behavior:
                   name: System Events
     invalid:
       - example_id: "cat-sem-v1-duplicate"
-        title: "Duplicate category name (v1)"
-        description: "Two categories sharing the same name collide in the resource graph and trigger this error."
+        title: "Duplicate category name across files (v1)"
+        description: "Two categories in separate files sharing the same name collide in the resource graph and trigger this error on each file."
         files:
           spec.yaml: |
             version: rudder/v1
@@ -76,10 +87,21 @@ match_behavior:
               categories:
                 - id: user_actions
                   name: User Actions
-                - id: user_actions_2
+          spec2.yaml: |
+            version: rudder/v1
+            kind: categories
+            metadata:
+              name: my-categories-2
+            spec:
+              categories:
+                - id: user_actions_copy
                   name: User Actions
         expected_diagnostics:
           - file: "spec.yaml"
+            reference: "/categories/0/name"
+            severity: "error"
+            message_contains: "duplicate name 'User Actions' within kind 'categories'"
+          - file: "spec2.yaml"
             reference: "/categories/0/name"
             severity: "error"
             message_contains: "duplicate name 'User Actions' within kind 'categories'"

--- a/cli/internal/providers/datacatalog/docs/custom-types-semantic-valid.docs.yaml
+++ b/cli/internal/providers/datacatalog/docs/custom-types-semantic-valid.docs.yaml
@@ -25,8 +25,8 @@ match_behavior:
                   type: string
     invalid:
       - example_id: "ct-sem-legacy-duplicate-name"
-        title: "Duplicate custom type name across files (legacy)"
-        description: "Two custom types with the same name in the resource graph trigger this error."
+        title: "Duplicate custom type name (legacy)"
+        description: "Two custom types sharing the same name collide in the resource graph and trigger this error."
         files:
           spec.yaml: |
             version: rudder/0.1
@@ -35,6 +35,9 @@ match_behavior:
               name: my-custom-types
             spec:
               types:
+                - id: address
+                  name: Address
+                  type: object
                 - id: address_v2
                   name: Address
                   type: object
@@ -66,8 +69,8 @@ match_behavior:
                   type: string
     invalid:
       - example_id: "ct-sem-v1-duplicate-name"
-        title: "Duplicate custom type name across files (v1)"
-        description: "Two custom types with the same name in the resource graph trigger this error."
+        title: "Duplicate custom type name (v1)"
+        description: "Two custom types sharing the same name collide in the resource graph and trigger this error."
         files:
           spec.yaml: |
             version: rudder/v1
@@ -76,6 +79,9 @@ match_behavior:
               name: my-custom-types
             spec:
               types:
+                - id: address
+                  name: Address
+                  type: object
                 - id: address_v2
                   name: Address
                   type: object

--- a/cli/internal/providers/datacatalog/docs/custom-types-semantic-valid.docs.yaml
+++ b/cli/internal/providers/datacatalog/docs/custom-types-semantic-valid.docs.yaml
@@ -25,8 +25,8 @@ match_behavior:
                   type: string
     invalid:
       - example_id: "ct-sem-legacy-duplicate-name"
-        title: "Duplicate custom type name (legacy)"
-        description: "Two custom types sharing the same name collide in the resource graph and trigger this error."
+        title: "Duplicate custom type name across files (legacy)"
+        description: "Two custom types in separate files sharing the same name collide in the resource graph and trigger this error on each file."
         files:
           spec.yaml: |
             version: rudder/0.1
@@ -38,11 +38,22 @@ match_behavior:
                 - id: address
                   name: Address
                   type: object
-                - id: address_v2
+          spec2.yaml: |
+            version: rudder/0.1
+            kind: custom-types
+            metadata:
+              name: my-custom-types-2
+            spec:
+              types:
+                - id: address_copy
                   name: Address
                   type: object
         expected_diagnostics:
           - file: "spec.yaml"
+            reference: "/types/0/name"
+            severity: "error"
+            message_contains: "duplicate name 'Address' within kind 'custom-types'"
+          - file: "spec2.yaml"
             reference: "/types/0/name"
             severity: "error"
             message_contains: "duplicate name 'Address' within kind 'custom-types'"
@@ -69,8 +80,8 @@ match_behavior:
                   type: string
     invalid:
       - example_id: "ct-sem-v1-duplicate-name"
-        title: "Duplicate custom type name (v1)"
-        description: "Two custom types sharing the same name collide in the resource graph and trigger this error."
+        title: "Duplicate custom type name across files (v1)"
+        description: "Two custom types in separate files sharing the same name collide in the resource graph and trigger this error on each file."
         files:
           spec.yaml: |
             version: rudder/v1
@@ -82,11 +93,22 @@ match_behavior:
                 - id: address
                   name: Address
                   type: object
-                - id: address_v2
+          spec2.yaml: |
+            version: rudder/v1
+            kind: custom-types
+            metadata:
+              name: my-custom-types-2
+            spec:
+              types:
+                - id: address_copy
                   name: Address
                   type: object
         expected_diagnostics:
           - file: "spec.yaml"
+            reference: "/types/0/name"
+            severity: "error"
+            message_contains: "duplicate name 'Address' within kind 'custom-types'"
+          - file: "spec2.yaml"
             reference: "/types/0/name"
             severity: "error"
             message_contains: "duplicate name 'Address' within kind 'custom-types'"

--- a/cli/internal/providers/datacatalog/docs/events-semantic-valid.docs.yaml
+++ b/cli/internal/providers/datacatalog/docs/events-semantic-valid.docs.yaml
@@ -25,8 +25,8 @@ match_behavior:
                   name: Product Clicked
     invalid:
       - example_id: "ev-sem-legacy-duplicate"
-        title: "Duplicate (name, type) event combination (legacy)"
-        description: "Two track events sharing the same name and event_type collide in the resource graph and trigger this error."
+        title: "Duplicate (name, type) event combination across files (legacy)"
+        description: "Two track events in separate files sharing the same name and event_type collide in the resource graph and trigger this error on each file."
         files:
           spec.yaml: |
             version: rudder/0.1
@@ -38,11 +38,22 @@ match_behavior:
                 - id: page_viewed
                   event_type: track
                   name: Page Viewed
-                - id: page_viewed_2
+          spec2.yaml: |
+            version: rudder/0.1
+            kind: events
+            metadata:
+              name: my-events-2
+            spec:
+              events:
+                - id: page_viewed_copy
                   event_type: track
                   name: Page Viewed
         expected_diagnostics:
           - file: "spec.yaml"
+            reference: "/events/0"
+            severity: "error"
+            message_contains: "duplicate name 'Page Viewed' within kind 'events'"
+          - file: "spec2.yaml"
             reference: "/events/0"
             severity: "error"
             message_contains: "duplicate name 'Page Viewed' within kind 'events'"
@@ -69,8 +80,8 @@ match_behavior:
                   name: Product Clicked
     invalid:
       - example_id: "ev-sem-v1-duplicate"
-        title: "Duplicate (name, type) event combination (v1)"
-        description: "Two track events sharing the same name and event_type collide in the resource graph and trigger this error."
+        title: "Duplicate (name, type) event combination across files (v1)"
+        description: "Two track events in separate files sharing the same name and event_type collide in the resource graph and trigger this error on each file."
         files:
           spec.yaml: |
             version: rudder/v1
@@ -82,11 +93,22 @@ match_behavior:
                 - id: page_viewed
                   event_type: track
                   name: Page Viewed
-                - id: page_viewed_2
+          spec2.yaml: |
+            version: rudder/v1
+            kind: events
+            metadata:
+              name: my-events-2
+            spec:
+              events:
+                - id: page_viewed_copy
                   event_type: track
                   name: Page Viewed
         expected_diagnostics:
           - file: "spec.yaml"
+            reference: "/events/0"
+            severity: "error"
+            message_contains: "duplicate name 'Page Viewed' within kind 'events'"
+          - file: "spec2.yaml"
             reference: "/events/0"
             severity: "error"
             message_contains: "duplicate name 'Page Viewed' within kind 'events'"

--- a/cli/internal/providers/datacatalog/docs/events-semantic-valid.docs.yaml
+++ b/cli/internal/providers/datacatalog/docs/events-semantic-valid.docs.yaml
@@ -25,8 +25,8 @@ match_behavior:
                   name: Product Clicked
     invalid:
       - example_id: "ev-sem-legacy-duplicate"
-        title: "Duplicate (name, type) event combination across files (legacy)"
-        description: "Two events with the same name and event_type in the resource graph trigger this error."
+        title: "Duplicate (name, type) event combination (legacy)"
+        description: "Two track events sharing the same name and event_type collide in the resource graph and trigger this error."
         files:
           spec.yaml: |
             version: rudder/0.1
@@ -35,6 +35,9 @@ match_behavior:
               name: my-events
             spec:
               events:
+                - id: page_viewed
+                  event_type: track
+                  name: Page Viewed
                 - id: page_viewed_2
                   event_type: track
                   name: Page Viewed
@@ -66,8 +69,8 @@ match_behavior:
                   name: Product Clicked
     invalid:
       - example_id: "ev-sem-v1-duplicate"
-        title: "Duplicate (name, type) event combination across files (v1)"
-        description: "Two events with the same name and event_type in the resource graph trigger this error."
+        title: "Duplicate (name, type) event combination (v1)"
+        description: "Two track events sharing the same name and event_type collide in the resource graph and trigger this error."
         files:
           spec.yaml: |
             version: rudder/v1
@@ -76,6 +79,9 @@ match_behavior:
               name: my-events
             spec:
               events:
+                - id: page_viewed
+                  event_type: track
+                  name: Page Viewed
                 - id: page_viewed_2
                   event_type: track
                   name: Page Viewed

--- a/cli/internal/providers/datacatalog/docs/properties-semantic-valid.docs.yaml
+++ b/cli/internal/providers/datacatalog/docs/properties-semantic-valid.docs.yaml
@@ -25,8 +25,8 @@ match_behavior:
                   type: string
     invalid:
       - example_id: "prop-sem-legacy-duplicate"
-        title: "Duplicate (name, type, itemTypes) property combination across files (legacy)"
-        description: "Two properties with the same name, type, and itemTypes in the resource graph trigger this error."
+        title: "Duplicate (name, type, itemTypes) property combination (legacy)"
+        description: "Two properties sharing the same name, type, and itemTypes collide in the resource graph and trigger this error."
         files:
           spec.yaml: |
             version: rudder/0.1
@@ -35,6 +35,9 @@ match_behavior:
               name: my-properties
             spec:
               properties:
+                - id: user_id
+                  name: User ID
+                  type: string
                 - id: user_id_2
                   name: User ID
                   type: string
@@ -66,8 +69,8 @@ match_behavior:
                   type: string
     invalid:
       - example_id: "prop-sem-v1-duplicate"
-        title: "Duplicate (name, type, itemTypes) property combination across files (v1)"
-        description: "Two properties with the same name, type, and itemTypes in the resource graph trigger this error."
+        title: "Duplicate (name, type, itemTypes) property combination (v1)"
+        description: "Two properties sharing the same name, type, and itemTypes collide in the resource graph and trigger this error."
         files:
           spec.yaml: |
             version: rudder/v1
@@ -76,6 +79,9 @@ match_behavior:
               name: my-properties
             spec:
               properties:
+                - id: user_id
+                  name: User ID
+                  type: string
                 - id: user_id_2
                   name: User ID
                   type: string

--- a/cli/internal/providers/datacatalog/docs/properties-semantic-valid.docs.yaml
+++ b/cli/internal/providers/datacatalog/docs/properties-semantic-valid.docs.yaml
@@ -25,8 +25,8 @@ match_behavior:
                   type: string
     invalid:
       - example_id: "prop-sem-legacy-duplicate"
-        title: "Duplicate (name, type, itemTypes) property combination (legacy)"
-        description: "Two properties sharing the same name, type, and itemTypes collide in the resource graph and trigger this error."
+        title: "Duplicate (name, type, itemTypes) property combination across files (legacy)"
+        description: "Two properties in separate files sharing the same name, type, and itemTypes collide in the resource graph and trigger this error on each file."
         files:
           spec.yaml: |
             version: rudder/0.1
@@ -38,11 +38,22 @@ match_behavior:
                 - id: user_id
                   name: User ID
                   type: string
-                - id: user_id_2
+          spec2.yaml: |
+            version: rudder/0.1
+            kind: properties
+            metadata:
+              name: my-properties-2
+            spec:
+              properties:
+                - id: user_id_copy
                   name: User ID
                   type: string
         expected_diagnostics:
           - file: "spec.yaml"
+            reference: "/properties/0"
+            severity: "error"
+            message_contains: "duplicate name, type and itemTypes: 'User ID' within kind 'properties'"
+          - file: "spec2.yaml"
             reference: "/properties/0"
             severity: "error"
             message_contains: "duplicate name, type and itemTypes: 'User ID' within kind 'properties'"
@@ -69,8 +80,8 @@ match_behavior:
                   type: string
     invalid:
       - example_id: "prop-sem-v1-duplicate"
-        title: "Duplicate (name, type, itemTypes) property combination (v1)"
-        description: "Two properties sharing the same name, type, and itemTypes collide in the resource graph and trigger this error."
+        title: "Duplicate (name, type, itemTypes) property combination across files (v1)"
+        description: "Two properties in separate files sharing the same name, type, and itemTypes collide in the resource graph and trigger this error on each file."
         files:
           spec.yaml: |
             version: rudder/v1
@@ -82,11 +93,22 @@ match_behavior:
                 - id: user_id
                   name: User ID
                   type: string
-                - id: user_id_2
+          spec2.yaml: |
+            version: rudder/v1
+            kind: properties
+            metadata:
+              name: my-properties-2
+            spec:
+              properties:
+                - id: user_id_copy
                   name: User ID
                   type: string
         expected_diagnostics:
           - file: "spec.yaml"
+            reference: "/properties/0"
+            severity: "error"
+            message_contains: "duplicate name, type and itemTypes: 'User ID' within kind 'properties'"
+          - file: "spec2.yaml"
             reference: "/properties/0"
             severity: "error"
             message_contains: "duplicate name, type and itemTypes: 'User ID' within kind 'properties'"

--- a/cli/internal/providers/datacatalog/docs/tracking-plans-semantic-valid.docs.yaml
+++ b/cli/internal/providers/datacatalog/docs/tracking-plans-semantic-valid.docs.yaml
@@ -84,6 +84,10 @@ match_behavior:
             reference: "/display_name"
             severity: "error"
             message_contains: "duplicate display_name 'My Tracking Plan' within kind 'tp'"
+          - file: "spec2.yaml"
+            reference: "/display_name"
+            severity: "error"
+            message_contains: "duplicate display_name 'My Tracking Plan' within kind 'tp'"
   # Current spec version (rudder/v1) uses kind "tracking-plan".
   - applies_to:
       - kind: "tracking-plan"
@@ -159,6 +163,10 @@ match_behavior:
                   event: "#event:page_view"
         expected_diagnostics:
           - file: "spec.yaml"
+            reference: "/display_name"
+            severity: "error"
+            message_contains: "duplicate display_name 'My Tracking Plan' within kind 'tracking-plan'"
+          - file: "spec2.yaml"
             reference: "/display_name"
             severity: "error"
             message_contains: "duplicate display_name 'My Tracking Plan' within kind 'tracking-plan'"

--- a/cli/internal/providers/datacatalog/docs/tracking-plans-semantic-valid.docs.yaml
+++ b/cli/internal/providers/datacatalog/docs/tracking-plans-semantic-valid.docs.yaml
@@ -9,8 +9,19 @@ match_behavior:
         version: "rudder/v0.1"
     valid:
       - example_id: "tp-sem-legacy-valid"
-        title: "Tracking plan with unique display_name and no duplicate events (legacy)"
+        title: "Tracking plan with unique display_name and resolvable event refs (legacy)"
+        description: "The referenced event exists in the catalog, so the tracking plan validates cleanly."
         files:
+          events.yaml: |
+            version: rudder/0.1
+            kind: events
+            metadata:
+              name: my-events
+            spec:
+              events:
+                - id: signup
+                  event_type: track
+                  name: Signup
           spec.yaml: |
             version: rudder/0.1
             kind: tp
@@ -27,9 +38,35 @@ match_behavior:
     invalid:
       - example_id: "tp-sem-legacy-duplicate-display-name"
         title: "Duplicate tracking plan display_name across files (legacy)"
-        description: "Two tracking plans with the same display_name in the resource graph trigger this error."
+        description: "Two tracking plans sharing the same display_name collide in the resource graph and trigger this error."
         files:
+          events.yaml: |
+            version: rudder/0.1
+            kind: events
+            metadata:
+              name: my-events
+            spec:
+              events:
+                - id: signup
+                  event_type: track
+                  name: Signup
+                - id: page_view
+                  event_type: track
+                  name: Page View
           spec.yaml: |
+            version: rudder/0.1
+            kind: tp
+            metadata:
+              name: my-tracking-plan
+            spec:
+              id: my_tp
+              display_name: My Tracking Plan
+              rules:
+                - id: signup_rule
+                  type: event_rule
+                  event:
+                    $ref: "#/events/user-events/signup"
+          spec2.yaml: |
             version: rudder/0.1
             kind: tp
             metadata:
@@ -53,8 +90,19 @@ match_behavior:
         version: "rudder/v1"
     valid:
       - example_id: "tp-sem-v1-valid"
-        title: "Tracking plan with unique display_name and no duplicate events (v1)"
+        title: "Tracking plan with unique display_name and resolvable event refs (v1)"
+        description: "The referenced event exists in the catalog, so the tracking plan validates cleanly."
         files:
+          events.yaml: |
+            version: rudder/v1
+            kind: events
+            metadata:
+              name: my-events
+            spec:
+              events:
+                - id: signup
+                  event_type: track
+                  name: Signup
           spec.yaml: |
             version: rudder/v1
             kind: tracking-plan
@@ -70,9 +118,34 @@ match_behavior:
     invalid:
       - example_id: "tp-sem-v1-duplicate-display-name"
         title: "Duplicate tracking plan display_name across files (v1)"
-        description: "Two tracking plans with the same display_name in the resource graph trigger this error."
+        description: "Two tracking plans sharing the same display_name collide in the resource graph and trigger this error."
         files:
+          events.yaml: |
+            version: rudder/v1
+            kind: events
+            metadata:
+              name: my-events
+            spec:
+              events:
+                - id: signup
+                  event_type: track
+                  name: Signup
+                - id: page_view
+                  event_type: track
+                  name: Page View
           spec.yaml: |
+            version: rudder/v1
+            kind: tracking-plan
+            metadata:
+              name: my-tracking-plan
+            spec:
+              id: my_tp
+              display_name: My Tracking Plan
+              rules:
+                - id: signup_rule
+                  type: event_rule
+                  event: "#event:signup"
+          spec2.yaml: |
             version: rudder/v1
             kind: tracking-plan
             metadata:

--- a/cli/internal/providers/event-stream/docs/source-semantic-valid.docs.yaml
+++ b/cli/internal/providers/event-stream/docs/source-semantic-valid.docs.yaml
@@ -94,6 +94,10 @@ match_behavior:
             reference: "/name"
             severity: "error"
             message_contains: "duplicate name 'Shared Name' within kind 'event-stream-source'"
+          - file: "source-b.yaml"
+            reference: "/name"
+            severity: "error"
+            message_contains: "duplicate name 'Shared Name' within kind 'event-stream-source'"
   # Current spec version (rudder/v1) applies the same semantic checks with the modern ref format.
   - applies_to:
       - kind: "event-stream-source"
@@ -182,6 +186,10 @@ match_behavior:
               type: node
         expected_diagnostics:
           - file: "source-a.yaml"
+            reference: "/name"
+            severity: "error"
+            message_contains: "duplicate name 'Shared Name' within kind 'event-stream-source'"
+          - file: "source-b.yaml"
             reference: "/name"
             severity: "error"
             message_contains: "duplicate name 'Shared Name' within kind 'event-stream-source'"

--- a/cli/internal/providers/event-stream/docs/source-semantic-valid.docs.yaml
+++ b/cli/internal/providers/event-stream/docs/source-semantic-valid.docs.yaml
@@ -38,12 +38,12 @@ match_behavior:
                   config: {}
           tracking_plan.yaml: |
             version: rudder/0.1
-            kind: tracking-plan
+            kind: tp
             metadata:
               name: tp-main
             spec:
               id: tp-main
-              name: Main Tracking Plan
+              display_name: Main Tracking Plan
               description: Default plan
               rules: []
     invalid:
@@ -134,7 +134,7 @@ match_behavior:
               name: tp-main
             spec:
               id: tp-main
-              name: Main Tracking Plan
+              display_name: Main Tracking Plan
               description: Default plan
               rules: []
     invalid:

--- a/cli/internal/providers/retl/docs/sqlmodel-semantic-valid.docs.yaml
+++ b/cli/internal/providers/retl/docs/sqlmodel-semantic-valid.docs.yaml
@@ -57,6 +57,10 @@ match_behavior:
             reference: "/display_name"
             severity: "error"
             message_contains: "duplicate display_name 'Revenue Model' within kind 'retl-source-sql-model'"
+          - file: "spec2.yaml"
+            reference: "/display_name"
+            severity: "error"
+            message_contains: "duplicate display_name 'Revenue Model' within kind 'retl-source-sql-model'"
   # Current spec version (rudder/v1).
   - applies_to:
       - kind: "retl-source-sql-model"
@@ -108,6 +112,10 @@ match_behavior:
               sql: SELECT user_id FROM churn_signals
         expected_diagnostics:
           - file: "spec.yaml"
+            reference: "/display_name"
+            severity: "error"
+            message_contains: "duplicate display_name 'Churn Risk Model' within kind 'retl-source-sql-model'"
+          - file: "spec2.yaml"
             reference: "/display_name"
             severity: "error"
             message_contains: "duplicate display_name 'Churn Risk Model' within kind 'retl-source-sql-model'"

--- a/cli/internal/providers/retl/docs/sqlmodel-semantic-valid.docs.yaml
+++ b/cli/internal/providers/retl/docs/sqlmodel-semantic-valid.docs.yaml
@@ -26,8 +26,21 @@ match_behavior:
     invalid:
       - example_id: "sqlmodel-semantic-legacy-duplicate-display-name"
         title: "Legacy SQL model with a display_name that duplicates another model in the workspace"
+        description: "Two SQL models sharing the same display_name collide in the resource graph and trigger this error."
         files:
           spec.yaml: |
+            version: rudder/0.1
+            kind: retl-source-sql-model
+            metadata:
+              name: revenue-model
+            spec:
+              id: revenue-model
+              display_name: Revenue Model
+              account_id: acc-123
+              primary_key: id
+              source_definition: postgres
+              sql: SELECT id, amount FROM revenue
+          spec2.yaml: |
             version: rudder/0.1
             kind: retl-source-sql-model
             metadata:
@@ -67,8 +80,21 @@ match_behavior:
     invalid:
       - example_id: "sqlmodel-semantic-v1-duplicate-display-name"
         title: "v1 SQL model with a display_name that duplicates another model in the workspace"
+        description: "Two SQL models sharing the same display_name collide in the resource graph and trigger this error."
         files:
           spec.yaml: |
+            version: rudder/v1
+            kind: retl-source-sql-model
+            metadata:
+              name: churn-model
+            spec:
+              id: churn-model
+              display_name: Churn Risk Model
+              account_id: acc-456
+              primary_key: user_id
+              source_definition: bigquery
+              sql: SELECT user_id FROM churn_signals
+          spec2.yaml: |
             version: rudder/v1
             kind: retl-source-sql-model
             metadata:

--- a/cli/internal/providers/transformations/docs/transformation-library-semantic-valid.docs.yaml
+++ b/cli/internal/providers/transformations/docs/transformation-library-semantic-valid.docs.yaml
@@ -6,6 +6,7 @@ match_behavior:
     valid:
       - example_id: "transformation-library-semantic-valid-unique-import-name"
         title: "Transformation library with a unique import_name across all libraries"
+        description: "A single library whose import_name no other library claims validates cleanly."
         files:
           spec.yaml: |
             version: rudder/v1
@@ -13,42 +14,47 @@ match_behavior:
             metadata:
               name: my-libraries
             spec:
-              libraries:
-                - id: math-utils
-                  name: Math Utils
-                  import_name: mathUtils
-                  language: javascript
-                  code: |
-                    export function round(value) {
-                      return Math.round(value);
-                    }
+              id: math-utils
+              name: Math Utils
+              import_name: mathUtils
+              language: javascript
+              code: |
+                export function round(value) {
+                  return Math.round(value);
+                }
     invalid:
       - example_id: "transformation-library-semantic-valid-duplicate-import-name"
         title: "Two transformation libraries sharing the same import_name"
+        description: "Two libraries declaring the same import_name collide in the resource graph and trigger this error."
         files:
           spec.yaml: |
             version: rudder/v1
             kind: transformation-library
             metadata:
-              name: my-libraries
+              name: math-utils
             spec:
-              libraries:
-                - id: math-utils
-                  name: Math Utils
-                  import_name: mathUtils
-                  language: javascript
-                  code: |
-                    export function round(value) {
-                      return Math.round(value);
-                    }
-                - id: math-helpers
-                  name: Math Helpers
-                  import_name: mathUtils
-                  language: javascript
-                  code: |
-                    export function ceil(value) {
-                      return Math.ceil(value);
-                    }
+              id: math-utils
+              name: Math Utils
+              import_name: mathUtils
+              language: javascript
+              code: |
+                export function round(value) {
+                  return Math.round(value);
+                }
+          spec2.yaml: |
+            version: rudder/v1
+            kind: transformation-library
+            metadata:
+              name: math-helpers
+            spec:
+              id: math-helpers
+              name: Math Utils
+              import_name: mathUtils
+              language: javascript
+              code: |
+                export function ceil(value) {
+                  return Math.ceil(value);
+                }
         expected_diagnostics:
           - file: "spec.yaml"
             reference: "/import_name"

--- a/cli/internal/providers/transformations/docs/transformation-library-semantic-valid.docs.yaml
+++ b/cli/internal/providers/transformations/docs/transformation-library-semantic-valid.docs.yaml
@@ -60,3 +60,7 @@ match_behavior:
             reference: "/import_name"
             severity: "error"
             message_contains: "import_name 'mathUtils' is duplicate"
+          - file: "spec2.yaml"
+            reference: "/import_name"
+            severity: "error"
+            message_contains: "import_name 'mathUtils' is duplicate"

--- a/cli/internal/providers/transformations/docs/transformation-semantic-valid.docs.yaml
+++ b/cli/internal/providers/transformations/docs/transformation-semantic-valid.docs.yaml
@@ -6,6 +6,7 @@ match_behavior:
     valid:
       - example_id: "transformation-semantic-valid-no-imports"
         title: "Transformation with no library imports is valid"
+        description: "Code that imports nothing has no library references to resolve, so the rule passes."
         files:
           spec.yaml: |
             version: rudder/v1
@@ -13,18 +14,18 @@ match_behavior:
             metadata:
               name: my-transformations
             spec:
-              transformations:
-                - id: my-transformation
-                  name: My Transformation
-                  language: javascript
-                  code: |
-                    export function transformEvent(event, metadata) {
-                      event.properties.processed = true;
-                      return event;
-                    }
+              id: my-transformation
+              name: My Transformation
+              language: javascript
+              code: |
+                export function transformEvent(event, metadata) {
+                  event.properties.processed = true;
+                  return event;
+                }
     invalid:
       - example_id: "transformation-semantic-valid-missing-library"
         title: "Transformation importing a library that does not exist in the graph"
+        description: "The code imports a library handle with no matching library resource in the project, so the import cannot be resolved."
         files:
           spec.yaml: |
             version: rudder/v1
@@ -32,16 +33,15 @@ match_behavior:
             metadata:
               name: my-transformations
             spec:
-              transformations:
-                - id: my-transformation
-                  name: My Transformation
-                  language: javascript
-                  code: |
-                    import mathUtils from 'mathUtils';
-                    export function transformEvent(event, metadata) {
-                      event.properties.value = mathUtils.round(event.properties.value);
-                      return event;
-                    }
+              id: my-transformation
+              name: My Transformation
+              language: javascript
+              code: |
+                import mathUtils from 'mathUtils';
+                export function transformEvent(event, metadata) {
+                  event.properties.value = mathUtils.round(event.properties.value);
+                  return event;
+                }
         expected_diagnostics:
           - file: "spec.yaml"
             reference: "/code"

--- a/cli/internal/ruledoc/ruledoc.go
+++ b/cli/internal/ruledoc/ruledoc.go
@@ -31,7 +31,15 @@ import (
 // be assembled at all. generatedAt is injected so callers own the timestamp —
 // the real clock in the command, a fixed value in tests. mode controls how
 // strictly example expectations are matched during verification.
-func Build(cp provider.Provider, cliVersion, generatedAt string, mode docs.VerifyMode) (docs.DocumentedRules, []error, error) {
+//
+// newProvider yields a fresh, isolated provider per semantic example. Semantic
+// verification loads each example's specs into a provider and reads back its
+// resource graph, so every example needs its own provider to avoid state
+// bleeding between examples. It originates in the composition root (package
+// app) and is passed as a plain func so ruledoc need not import app. Callers
+// with no semantic examples to exercise may pass nil; a semantic example
+// encountered with a nil factory surfaces a clear error rather than panicking.
+func Build(cp provider.Provider, cliVersion, generatedAt string, mode docs.VerifyMode, newProvider func() (provider.Provider, error)) (docs.DocumentedRules, []error, error) {
 	reg, err := project.BuildRegistry(cp)
 	if err != nil {
 		return docs.DocumentedRules{}, nil, fmt.Errorf("building rule registry: %w", err)
@@ -59,7 +67,7 @@ func Build(cp provider.Provider, cliVersion, generatedAt string, mode docs.Verif
 	// incomplete or invalid catalog (missing fragments, mismatched rule IDs)
 	// cannot be meaningfully executed — fix structure first, then verify behaviour.
 	if len(verrs) == 0 {
-		verrs = append(verrs, verify(reg, doc, mode)...)
+		verrs = append(verrs, verify(reg, doc, mode, newProvider)...)
 	}
 
 	return doc, verrs, nil

--- a/cli/internal/ruledoc/ruledoc_test.go
+++ b/cli/internal/ruledoc/ruledoc_test.go
@@ -47,7 +47,9 @@ func TestBuild_GatekeeperOnly(t *testing.T) {
 		ParseSpecFn: extractEventURNs,
 	}
 
-	doc, verrs, err := ruledoc.Build(cp, "test", "2026-01-01T00:00:00Z", docs.ModeSubset)
+	// Gatekeeper rules are syntactic, so no provider factory is exercised here;
+	// nil is intentional and asserts no semantic example sneaks into this path.
+	doc, verrs, err := ruledoc.Build(cp, "test", "2026-01-01T00:00:00Z", docs.ModeSubset, nil)
 	require.NoError(t, err)
 	assert.Empty(t, verrs, "gatekeeper fragments must cover the gatekeeper rules exactly")
 

--- a/cli/internal/ruledoc/verify.go
+++ b/cli/internal/ruledoc/verify.go
@@ -3,9 +3,11 @@ package ruledoc
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/rudderlabs/rudder-iac/cli/internal/logger"
 	"github.com/rudderlabs/rudder-iac/cli/internal/project/specs"
+	"github.com/rudderlabs/rudder-iac/cli/internal/provider"
 	"github.com/rudderlabs/rudder-iac/cli/internal/validation"
 	"github.com/rudderlabs/rudder-iac/cli/internal/validation/docs"
 	"github.com/rudderlabs/rudder-iac/cli/internal/validation/rules"
@@ -13,30 +15,31 @@ import (
 
 var verifyLog = logger.New("ruledoc-verify")
 
-// verify runs every authored example of a syntactic-phase rule through the real
-// engine; semantic-phase examples are skipped (counted, logged once).
-func verify(reg rules.Registry, doc docs.DocumentedRules, mode docs.VerifyMode) []error {
+// verify runs every authored example through the real engine. Syntactic-phase
+// examples go through ValidateSyntax; semantic-phase examples are loaded into a
+// fresh provider (built by newProvider) and run through the full
+// parse -> syntax -> graph -> semantic pipeline.
+//
+// newProvider supplies an isolated provider per semantic example: providers are
+// stateful (LoadSpec accumulates resources, ResourceGraph reads that state), so
+// each example needs its own. It originates in package app — which can build
+// providers — and is threaded down as a plain func value so ruledoc need not
+// import app. When nil, encountering a semantic example is a hard error rather
+// than a panic; syntactic-only callers (most unit tests) never trip it.
+func verify(reg rules.Registry, doc docs.DocumentedRules, mode docs.VerifyMode, newProvider func() (provider.Provider, error)) []error {
 	engine, err := validation.NewValidationEngine(reg, verifyLog)
 	if err != nil {
 		return []error{fmt.Errorf("creating validation engine: %w", err)}
 	}
 
-	var (
-		errs    []error
-		skipped int
-	)
+	var errs []error
 
 	for _, r := range doc.Rules {
-		if r.Phase != "syntactic" {
-			for _, mb := range r.MatchBehavior {
-				skipped += len(mb.Valid) + len(mb.Invalid)
-			}
-			continue
-		}
+		semantic := r.Phase == "semantic"
 
 		for _, mb := range r.MatchBehavior {
 			for _, ex := range mb.Invalid {
-				produced, err := runSyntactic(engine, ex.Files)
+				produced, err := runExample(engine, ex.Files, semantic, newProvider)
 				if err != nil {
 					errs = append(errs, fmt.Errorf("rule %s example %s: %w", r.RuleID, ex.ExampleID, err))
 					continue
@@ -47,7 +50,7 @@ func verify(reg rules.Registry, doc docs.DocumentedRules, mode docs.VerifyMode) 
 			}
 
 			for _, ex := range mb.Valid {
-				produced, err := runSyntactic(engine, ex.Files)
+				produced, err := runExample(engine, ex.Files, semantic, newProvider)
 				if err != nil {
 					errs = append(errs, fmt.Errorf("rule %s example %s: %w", r.RuleID, ex.ExampleID, err))
 					continue
@@ -59,11 +62,23 @@ func verify(reg rules.Registry, doc docs.DocumentedRules, mode docs.VerifyMode) 
 		}
 	}
 
-	if skipped > 0 {
-		verifyLog.Info("skipped semantic-phase examples (syntactic-only verifier)", "count", skipped)
-	}
-
 	return errs
+}
+
+// runExample dispatches an example to the syntactic or semantic execution path.
+func runExample(
+	engine validation.ValidationEngine,
+	files map[string]string,
+	semantic bool,
+	newProvider func() (provider.Provider, error),
+) ([]docs.ProducedDiagnostic, error) {
+	if !semantic {
+		return runSyntactic(engine, files)
+	}
+	if newProvider == nil {
+		return nil, fmt.Errorf("semantic example requires a provider factory but none was supplied")
+	}
+	return runSemantic(engine, newProvider, files)
 }
 
 // runSyntactic mirrors project.parseSpecs + ValidateSyntax: parse each file,
@@ -103,4 +118,105 @@ func runSyntactic(engine validation.ValidationEngine, files map[string]string) (
 	}
 
 	return produced, nil
+}
+
+// runSemantic mirrors project.handleValidation's semantic half: parse each
+// example file, load every parsed spec into a fresh isolated provider (legacy
+// vs v1 branch, exactly like project.loadSpec), build the resource graph,
+// detect cycles, then run ValidateSemantic over the parsed specs and convert
+// the diagnostics to ProducedDiagnostic.
+//
+// A fresh provider per call is essential: providers accumulate loaded specs as
+// state, so reusing one across examples would leak resources between them and
+// corrupt the graph. The factory yields that isolation.
+//
+// Syntax is validated first. A semantic example whose files don't even parse or
+// pass syntax isn't a faithful semantic fixture — it's a broken one — so those
+// cases return an error (surfaced as a verification failure) rather than being
+// silently reported as produced diagnostics. Only a syntactically clean
+// mini-project proceeds to graph building and semantic validation.
+func runSemantic(
+	engine validation.ValidationEngine,
+	newProvider func() (provider.Provider, error),
+	files map[string]string,
+) ([]docs.ProducedDiagnostic, error) {
+	p, err := newProvider()
+	if err != nil {
+		return nil, fmt.Errorf("building provider: %w", err)
+	}
+
+	parsed := map[string]*specs.RawSpec{}
+	for name, content := range files {
+		rs := &specs.RawSpec{Data: []byte(content)}
+		spec, err := rs.Parse()
+		if err != nil {
+			return nil, fmt.Errorf("parsing fixture file %s: %w", name, err)
+		}
+		parsed[name] = rs
+
+		if err := loadSpec(p, name, spec); err != nil {
+			return nil, fmt.Errorf("loading fixture file %s: %w", name, err)
+		}
+	}
+
+	ctx := context.Background()
+
+	// A semantic fixture must be syntactically valid; otherwise the example
+	// isn't exercising the semantic rule it claims to, so flag it as a bad
+	// fixture instead of leaking syntax diagnostics into the semantic match.
+	syntaxDiags, err := engine.ValidateSyntax(ctx, parsed)
+	if err != nil {
+		return nil, fmt.Errorf("validate syntax: %w", err)
+	}
+	if syntaxDiags.HasErrors() {
+		return nil, fmt.Errorf("semantic fixture is not syntactically valid: %s", diagSummary(syntaxDiags.Errors()))
+	}
+
+	graph, err := p.ResourceGraph()
+	if err != nil {
+		return nil, fmt.Errorf("building resource graph: %w", err)
+	}
+
+	if _, err := graph.DetectCycles(); err != nil {
+		return nil, fmt.Errorf("cycle detected in resource graph: %w", err)
+	}
+
+	diags, err := engine.ValidateSemantic(ctx, parsed, graph)
+	if err != nil {
+		return nil, fmt.Errorf("validate semantic: %w", err)
+	}
+
+	produced := make([]docs.ProducedDiagnostic, 0, len(diags))
+	for _, d := range diags {
+		produced = append(produced, docs.ProducedDiagnostic{
+			File:     d.File,
+			Severity: d.Severity.String(),
+			Message:  d.Message,
+		})
+	}
+
+	return produced, nil
+}
+
+// diagSummary renders diagnostics into a compact one-line summary for fixture
+// error messages — enough to point an author at what their fixture got wrong.
+func diagSummary(diags validation.Diagnostics) string {
+	parts := make([]string, 0, len(diags))
+	for _, d := range diags {
+		parts = append(parts, fmt.Sprintf("%s: %s", d.File, d.Message))
+	}
+	return strings.Join(parts, "; ")
+}
+
+// loadSpec mirrors project.loadSpec's legacy-vs-v1 branch so semantic examples
+// are loaded into the provider exactly as project validation would load them.
+func loadSpec(p provider.Provider, path string, spec *specs.Spec) error {
+	switch {
+	case spec.IsLegacyVersion():
+		return p.LoadLegacySpec(path, spec)
+	case spec.Version == specs.SpecVersionV1:
+		return p.LoadSpec(path, spec)
+	default:
+		return fmt.Errorf("unsupported spec version: %s", spec.Version)
+	}
 }

--- a/cli/internal/ruledoc/verify.go
+++ b/cli/internal/ruledoc/verify.go
@@ -148,28 +148,34 @@ func runSemantic(
 	parsed := map[string]*specs.RawSpec{}
 	for name, content := range files {
 		rs := &specs.RawSpec{Data: []byte(content)}
-		spec, err := rs.Parse()
-		if err != nil {
+		if _, err := rs.Parse(); err != nil {
 			return nil, fmt.Errorf("parsing fixture file %s: %w", name, err)
 		}
 		parsed[name] = rs
-
-		if err := loadSpec(p, name, spec); err != nil {
-			return nil, fmt.Errorf("loading fixture file %s: %w", name, err)
-		}
 	}
 
 	ctx := context.Background()
 
-	// A semantic fixture must be syntactically valid; otherwise the example
-	// isn't exercising the semantic rule it claims to, so flag it as a bad
-	// fixture instead of leaking syntax diagnostics into the semantic match.
+	// Mirror project.handleValidation ordering exactly: validate syntax over the
+	// parsed specs *before* loading them into the provider. LoadLegacySpec/LoadSpec
+	// mutate the spec while ingesting it (e.g. rewriting legacy refs), so loading
+	// first would corrupt what ValidateSyntax inspects.
+	//
+	// A semantic fixture must be syntactically valid; otherwise the example isn't
+	// exercising the semantic rule it claims to, so flag it as a bad fixture
+	// instead of leaking syntax diagnostics into the semantic match.
 	syntaxDiags, err := engine.ValidateSyntax(ctx, parsed)
 	if err != nil {
 		return nil, fmt.Errorf("validate syntax: %w", err)
 	}
 	if syntaxDiags.HasErrors() {
 		return nil, fmt.Errorf("semantic fixture is not syntactically valid: %s", diagSummary(syntaxDiags.Errors()))
+	}
+
+	for name, rs := range parsed {
+		if err := loadSpec(p, name, rs.Parsed()); err != nil {
+			return nil, fmt.Errorf("loading fixture file %s: %w", name, err)
+		}
 	}
 
 	graph, err := p.ResourceGraph()

--- a/cli/internal/ruledoc/verify_test.go
+++ b/cli/internal/ruledoc/verify_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/rudderlabs/rudder-iac/cli/internal/project"
+	"github.com/rudderlabs/rudder-iac/cli/internal/provider"
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/datacatalog"
 	"github.com/rudderlabs/rudder-iac/cli/internal/testutils"
 	"github.com/rudderlabs/rudder-iac/cli/internal/validation/docs"
 	"github.com/stretchr/testify/assert"
@@ -96,4 +98,107 @@ func TestVerify_SemanticWithoutFactoryErrors(t *testing.T) {
 	errs := verify(reg, doc, docs.ModeSubset, nil)
 	require.Len(t, errs, 1)
 	assert.Contains(t, errs[0].Error(), "provider factory")
+}
+
+// newDataCatalogProvider builds a fresh, credential-free datacatalog provider.
+// Each call yields an isolated provider, exactly what the semantic verifier
+// needs so resources from one example don't leak into the next.
+func newDataCatalogProvider() (provider.Provider, error) {
+	return datacatalog.New(nil), nil
+}
+
+// TestVerify_SemanticInvalidExampleMatches drives the full semantic path
+// (parse -> syntax -> graph -> ValidateSemantic) against a real datacatalog
+// provider built per example by the injected factory. The example declares two
+// categories with the same name, which the category name-uniqueness rule flags;
+// the verifier must find the expected diagnostic with no misses.
+func TestVerify_SemanticInvalidExampleMatches(t *testing.T) {
+	reg, err := project.BuildRegistry(datacatalog.New(nil))
+	require.NoError(t, err)
+
+	duplicateCategories := `version: rudder/v1
+kind: categories
+metadata:
+  name: my-categories
+spec:
+  categories:
+    - id: user_actions
+      name: User Actions
+    - id: user_actions_2
+      name: User Actions
+`
+	doc := docs.DocumentedRules{
+		Rules: []docs.DocumentedRule{
+			{
+				RuleID: "datacatalog/categories/semantic-valid",
+				Phase:  "semantic",
+				MatchBehavior: []docs.MatchBehaviorEntry{
+					{
+						AppliesTo: []docs.MatchPatternDoc{{Kind: "categories", Version: "rudder/v1"}},
+						Invalid: []docs.InvalidExample{
+							{
+								ExampleID: "categories-duplicate-name",
+								Title:     "two categories sharing a name",
+								Files:     map[string]string{"spec.yaml": duplicateCategories},
+								ExpectedDiagnostics: []docs.ExpectedDiagnostic{
+									{
+										File:            "spec.yaml",
+										Reference:       "/categories/0/name",
+										Severity:        "error",
+										MessageContains: "duplicate name 'User Actions' within kind 'categories'",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	errs := verify(reg, doc, docs.ModeSubset, newDataCatalogProvider)
+	assert.Empty(t, errs, "expected the duplicate-name semantic example to match cleanly")
+}
+
+// TestVerify_SemanticValidExampleProducesNoDiagnostics confirms a clean
+// semantic example (unique category names) yields no error/warning diagnostics
+// through the real engine.
+func TestVerify_SemanticValidExampleProducesNoDiagnostics(t *testing.T) {
+	reg, err := project.BuildRegistry(datacatalog.New(nil))
+	require.NoError(t, err)
+
+	uniqueCategories := `version: rudder/v1
+kind: categories
+metadata:
+  name: my-categories
+spec:
+  categories:
+    - id: user_actions
+      name: User Actions
+    - id: system_events
+      name: System Events
+`
+	doc := docs.DocumentedRules{
+		Rules: []docs.DocumentedRule{
+			{
+				RuleID: "datacatalog/categories/semantic-valid",
+				Phase:  "semantic",
+				MatchBehavior: []docs.MatchBehaviorEntry{
+					{
+						AppliesTo: []docs.MatchPatternDoc{{Kind: "categories", Version: "rudder/v1"}},
+						Valid: []docs.ValidExample{
+							{
+								ExampleID: "categories-unique-names",
+								Title:     "unique category names",
+								Files:     map[string]string{"spec.yaml": uniqueCategories},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	errs := verify(reg, doc, docs.ModeSubset, newDataCatalogProvider)
+	assert.Empty(t, errs, "a clean semantic example must produce no diagnostics")
 }

--- a/cli/internal/ruledoc/verify_test.go
+++ b/cli/internal/ruledoc/verify_test.go
@@ -55,13 +55,16 @@ spec:
 		},
 	}
 
-	errs := verify(reg, doc, docs.ModeSubset)
+	// Gatekeeper rules are syntactic, so no provider factory is needed.
+	errs := verify(reg, doc, docs.ModeSubset, nil)
 	assert.Empty(t, errs, "expected no verification misses for a matching invalid example")
 }
 
-// TestVerify_SkipsSemanticPhase ensures that semantic-phase rules are silently
-// skipped (counted and logged) without triggering any errors or panics.
-func TestVerify_SkipsSemanticPhase(t *testing.T) {
+// TestVerify_SemanticWithoutFactoryErrors proves the nil-factory guard: a
+// semantic-phase example encountered with no provider factory yields a clear
+// error rather than a panic. This is the contract syntactic-only callers rely
+// on when they pass nil.
+func TestVerify_SemanticWithoutFactoryErrors(t *testing.T) {
 	cp := &testutils.MockProvider{}
 	reg, err := project.BuildRegistry(cp)
 	require.NoError(t, err)
@@ -90,6 +93,7 @@ func TestVerify_SkipsSemanticPhase(t *testing.T) {
 		},
 	}
 
-	errs := verify(reg, doc, docs.ModeSubset)
-	assert.Empty(t, errs, "semantic-phase examples must be skipped without error")
+	errs := verify(reg, doc, docs.ModeSubset, nil)
+	require.Len(t, errs, 1)
+	assert.Contains(t, errs[0].Error(), "provider factory")
 }

--- a/cli/internal/ruledoc/verify_test.go
+++ b/cli/internal/ruledoc/verify_test.go
@@ -38,9 +38,9 @@ spec:
 						AppliesTo: []docs.MatchPatternDoc{{Kind: "*", Version: "*"}},
 						Invalid: []docs.InvalidExample{
 							{
-								ExampleID:   "missing-kind",
-								Title:       "spec missing kind field",
-								Files:       map[string]string{"spec.yaml": missingKindYAML},
+								ExampleID: "missing-kind",
+								Title:     "spec missing kind field",
+								Files:     map[string]string{"spec.yaml": missingKindYAML},
 								ExpectedDiagnostics: []docs.ExpectedDiagnostic{
 									{
 										File:            "spec.yaml",
@@ -81,9 +81,9 @@ func TestVerify_SemanticWithoutFactoryErrors(t *testing.T) {
 						AppliesTo: []docs.MatchPatternDoc{{Kind: "properties", Version: "rudder/v1"}},
 						Invalid: []docs.InvalidExample{
 							{
-								ExampleID:   "semantic-invalid",
-								Title:       "semantic invalid example",
-								Files:       map[string]string{"spec.yaml": "version: rudder/v1\nkind: properties\n"},
+								ExampleID: "semantic-invalid",
+								Title:     "semantic invalid example",
+								Files:     map[string]string{"spec.yaml": "version: rudder/v1\nkind: properties\n"},
 								ExpectedDiagnostics: []docs.ExpectedDiagnostic{
 									{File: "spec.yaml", Reference: "/spec/properties", Severity: "error", MessageContains: "some message"},
 								},

--- a/cli/internal/validation/docs/verifier.go
+++ b/cli/internal/validation/docs/verifier.go
@@ -26,31 +26,37 @@ const (
 	ModeStrict
 )
 
+// anyMatch returns true if at least one produced diagnostic satisfies exp.
+func anyMatch(exp ExpectedDiagnostic, produced []ProducedDiagnostic) bool {
+	for _, p := range produced {
+		if matchesExpected(exp, p) {
+			return true
+		}
+	}
+	return false
+}
+
+// matchesExpected reports whether produced satisfies the expectation.
+func matchesExpected(exp ExpectedDiagnostic, p ProducedDiagnostic) bool {
+	if p.File != exp.File || p.Severity != exp.Severity {
+		return false
+	}
+	if exp.MessageContains != "" && !strings.Contains(p.Message, exp.MessageContains) {
+		return false
+	}
+	return true
+}
+
 // MatchInvalid checks that each expected diagnostic in ex is satisfied by at least one
 // entry in produced (subset semantics). In ModeStrict, any produced diagnostic that no
-// expectation covers is also reported as a miss. Returns human-readable miss strings; an
-// empty slice means the example verified cleanly.
+// expectation covers is also reported as a miss via greedy one-to-one assignment. Returns
+// human-readable miss strings; an empty slice means the example verified cleanly.
 func MatchInvalid(ex InvalidExample, produced []ProducedDiagnostic, mode VerifyMode) []string {
-	// matchedProduced tracks which produced indices were claimed by an expectation;
-	// only relevant in ModeStrict.
-	matchedProduced := make([]bool, len(produced))
-
 	var misses []string
 
+	// Subset: each expected must match at least one produced (semantics unchanged).
 	for _, exp := range ex.ExpectedDiagnostics {
-		matched := false
-		for i, p := range produced {
-			if p.File != exp.File || p.Severity != exp.Severity {
-				continue
-			}
-			if exp.MessageContains != "" && !strings.Contains(p.Message, exp.MessageContains) {
-				continue
-			}
-			matchedProduced[i] = true
-			matched = true
-			break
-		}
-		if !matched {
+		if !anyMatch(exp, produced) {
 			misses = append(misses, fmt.Sprintf(
 				"%s: expected diagnostic not found (file=%q severity=%q contains=%q)",
 				ex.ExampleID, exp.File, exp.Severity, exp.MessageContains,
@@ -59,14 +65,25 @@ func MatchInvalid(ex InvalidExample, produced []ProducedDiagnostic, mode VerifyM
 	}
 
 	if mode == ModeStrict {
-		for i, p := range produced {
-			if matchedProduced[i] {
-				continue
+		// Greedy one-to-one assignment: each produced may only be claimed by one
+		// expectation so that N identical expected entries consume N distinct produced
+		// entries rather than all collapsing onto produced[0].
+		matched := make([]bool, len(produced))
+		for _, exp := range ex.ExpectedDiagnostics {
+			for i, p := range produced {
+				if !matched[i] && matchesExpected(exp, p) {
+					matched[i] = true
+					break
+				}
 			}
-			misses = append(misses, fmt.Sprintf(
-				"%s: unexpected diagnostic (file=%q severity=%q message=%q)",
-				ex.ExampleID, p.File, p.Severity, p.Message,
-			))
+		}
+		for i, p := range produced {
+			if !matched[i] {
+				misses = append(misses, fmt.Sprintf(
+					"%s: unexpected diagnostic (file=%q severity=%q message=%q)",
+					ex.ExampleID, p.File, p.Severity, p.Message,
+				))
+			}
 		}
 	}
 

--- a/cli/internal/validation/docs/verifier_test.go
+++ b/cli/internal/validation/docs/verifier_test.go
@@ -67,6 +67,37 @@ func TestMatchValid_ProducesDiagnostic_Fails(t *testing.T) {
 func TestMatchInvalid_StrictRejectsExtra(t *testing.T) {
 	ex := InvalidExample{ExampleID: "x", ExpectedDiagnostics: []ExpectedDiagnostic{{File: "a.yaml", Severity: "error", MessageContains: "boom"}}}
 	produced := []ProducedDiagnostic{{File: "a.yaml", Severity: "error", Message: "boom"}, {File: "a.yaml", Severity: "error", Message: "surprise extra"}}
-	assert.Empty(t, MatchInvalid(ex, produced, ModeSubset))   // subset passes
-	assert.Len(t, MatchInvalid(ex, produced, ModeStrict), 1)  // strict flags the extra
+	assert.Empty(t, MatchInvalid(ex, produced, ModeSubset))  // subset passes
+	assert.Len(t, MatchInvalid(ex, produced, ModeStrict), 1) // strict flags the extra
+}
+
+// TestMatchInvalid_TwoIdenticalExpectedTwoIdenticalProduced verifies the one-to-one
+// strict assignment: two identical expected entries consume two distinct produced entries,
+// so neither mode reports a miss.
+func TestMatchInvalid_TwoIdenticalExpectedTwoIdenticalProduced(t *testing.T) {
+	exp := ExpectedDiagnostic{File: "a.yaml", Severity: "error", MessageContains: "dup name"}
+	ex := InvalidExample{ExampleID: "dup2x2", ExpectedDiagnostics: []ExpectedDiagnostic{exp, exp}}
+	produced := []ProducedDiagnostic{
+		{File: "a.yaml", Severity: "error", Message: "dup name at /models/0"},
+		{File: "a.yaml", Severity: "error", Message: "dup name at /models/1"},
+	}
+
+	assert.Empty(t, MatchInvalid(ex, produced, ModeSubset))
+	assert.Empty(t, MatchInvalid(ex, produced, ModeStrict))
+}
+
+// TestMatchInvalid_ExtraProducedFlaggedInStrict ensures that when there are more produced
+// diagnostics than expected entries, the extra produced is flagged in strict mode.
+func TestMatchInvalid_ExtraProducedFlaggedInStrict(t *testing.T) {
+	exp := ExpectedDiagnostic{File: "a.yaml", Severity: "error", MessageContains: "dup name"}
+	ex := InvalidExample{ExampleID: "extra-produced", ExpectedDiagnostics: []ExpectedDiagnostic{exp}}
+	produced := []ProducedDiagnostic{
+		{File: "a.yaml", Severity: "error", Message: "dup name at /models/0"},
+		{File: "a.yaml", Severity: "error", Message: "dup name at /models/1"},
+	}
+
+	// Subset: single expectation matches produced[0], no miss.
+	assert.Empty(t, MatchInvalid(ex, produced, ModeSubset))
+	// Strict: produced[1] is unclaimed — one unexpected diagnostic.
+	assert.Len(t, MatchInvalid(ex, produced, ModeStrict), 1)
 }

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.24.0
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7
 	github.com/MakeNowJust/heredoc/v2 v2.0.1
+	github.com/alecthomas/participle/v2 v2.1.4
 	github.com/briandowns/spinner v1.23.2
 	github.com/charmbracelet/bubbles v0.21.0
 	github.com/charmbracelet/bubbletea v1.3.10
@@ -28,7 +29,6 @@ require (
 )
 
 require (
-	github.com/alecthomas/participle/v2 v2.1.4 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.12 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
@@ -65,7 +65,7 @@ require (
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
-	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/rogpeppe/go-internal v1.11.0 // indirect
 	github.com/sagikazarmark/locafero v0.11.0 // indirect


### PR DESCRIPTION
## 🔗 Ticket

Part of DEX-389 (subset) and DEX-372 (`--strict-verify`) — the **semantic** half — and DEX-273. These close via #609 when it lands on `main` (this PR is stacked beneath it).

> **Stacked on #609.** Base branch is the syntactic feature branch; merge this PR into that branch **before** #609 lands on `main`.

---

## Summary

Extends the verifier to **semantic** examples — run through the real engine with per-example resource-graph isolation. Closes the gap where semantic-phase examples were skipped + counted.

## Changes
- **Injected provider factory** for per-example isolation (`app.GenerateRuleCatalog` → `ruledoc.Build` → `verify`, no `app`↔`ruledoc` cycle); fresh provider per semantic example (providers are stateful).
- **`runSemantic`** mirrors `project.handleValidation`: parse → `ValidateSyntax` → load into the fresh provider (legacy/v1 branch) → `ResourceGraph` → `DetectCycles` → `ValidateSemantic` → match. Critical **syntax-before-load** ordering fix; parse/graph/cycle failures surface as named fixture errors.
- All 9 semantic fragments made self-contained + faithful.
- **Full `--strict-verify` coverage** incl. a one-to-one strict matcher fix (two identical diagnostics in one spec matched distinctly). **Default subset semantics byte-identical** (CI gate unchanged).

## Testing
`make test` · `make lint` · `make verify-rule-docs` · `--strict-verify` all exit 0. `runSemantic` unit tests (real per-call factory), nil-factory guard, real-corpus integration with semantic running. Whole branch passed adversarial review.

## Risk / Impact
Low–Medium. Net-new path; default subset gate unchanged. `dataGraph` flag on locally includes datagraph examples; CI (flag off) excludes them — consistent either way.

## Checklist
- [x] Ticket linked
- [x] Tests added/updated
- [x] No breaking changes (or documented)
