### PR TITLE
feat(typer): suffix TS track interfaces as Track{Event}Properties to match Kotlin/Swift

### DIFF
--- a/cli/internal/typer/generator/platforms/typescript/generator.go
+++ b/cli/internal/typer/generator/platforms/typescript/generator.go
@@ -124,13 +124,12 @@ func getOrRegisterEventInterfaceName(rule *plan.EventRule, nr *core.NameRegistry
 		name := FormatTypeName("Group", "Traits")
 		return nr.RegisterName(key, globalTypeScope, name)
 	case plan.EventTypeTrack:
-		// Track interfaces follow the spec convention: PascalCase event name
-		// only, no prefix or suffix. Per-event distinct names come from the
-		// event name itself.
-		name := FormatTypeName("", rule.Event.Name)
-		if name == "" {
+		// Mirror the mobile (Kotlin/Swift) convention: Track{EventName}Properties.
+		// Per-event distinct names come from the event name itself.
+		if rule.Event.Name == "" {
 			return "", fmt.Errorf("track event has empty name")
 		}
+		name := FormatTypeName("Track", rule.Event.Name+" Properties")
 		return nr.RegisterName(key, globalTypeScope, name)
 	case plan.EventTypePage:
 		// Page is a singleton in analytics-js: the SDK exposes one `page()`

--- a/cli/internal/typer/generator/platforms/typescript/testdata/RudderTyper.ts
+++ b/cli/internal/typer/generator/platforms/typescript/testdata/RudderTyper.ts
@@ -211,7 +211,7 @@ export type CustomTypeUserAccess = CustomTypeUserAccessCaseFalse | CustomTypeUse
 
 
 /** Desktop page view */
-export interface EventWithVariantsCaseDesktop {
+export interface TrackEventWithVariantsPropertiesCaseDesktop {
     /** Type of device */
     deviceType: "desktop";
     /** User's first name */
@@ -226,7 +226,7 @@ export interface EventWithVariantsCaseDesktop {
 
 
 /** Mobile device page view */
-export interface EventWithVariantsCaseMobile {
+export interface TrackEventWithVariantsPropertiesCaseMobile {
     /** Type of device */
     deviceType: "mobile";
     /** Page context information */
@@ -239,7 +239,7 @@ export interface EventWithVariantsCaseMobile {
 
 
 /** Default case */
-export interface EventWithVariantsDefault {
+export interface TrackEventWithVariantsPropertiesDefault {
     /** Type of device */
     deviceType: Exclude<PropertyDeviceType, "mobile" | "desktop">;
     /** Page context information */
@@ -252,13 +252,13 @@ export interface EventWithVariantsDefault {
 
 
 /** Example event to demonstrate variants */
-export type EventWithVariants = EventWithVariantsCaseDesktop | EventWithVariantsCaseMobile | EventWithVariantsDefault;
+export type TrackEventWithVariantsProperties = TrackEventWithVariantsPropertiesCaseDesktop | TrackEventWithVariantsPropertiesCaseMobile | TrackEventWithVariantsPropertiesDefault;
 
 
 // ===== Nested Object Types =====
 
 /** demonstrates multiple levels of nesting */
-export interface UserSignedUpContextNestedContext {
+export interface TrackUserSignedUpPropertiesContextNestedContext {
     /** Array of favorite colors using custom type */
     favoriteColors?: CustomTypeColor[];
     /** User profile data */
@@ -267,11 +267,11 @@ export interface UserSignedUpContextNestedContext {
 
 
 /** example of object property */
-export interface UserSignedUpContext {
+export interface TrackUserSignedUpPropertiesContext {
     /** IP address of the user */
     ipAddress: string;
     /** demonstrates multiple levels of nesting */
-    nestedContext: UserSignedUpContextNestedContext;
+    nestedContext: TrackUserSignedUpPropertiesContextNestedContext;
 }
 
 
@@ -303,21 +303,21 @@ export interface PageProperties {
 
 
 /** Event with dollar signs to test string interpolation escaping */
-export interface VariableString {
+export interface TrackVariableStringProperties {
     /** Field with $ for testing string interpolation: $variable and ${expression} */
     dollarField: PropertyDollarField;
 }
 
 
 /** Event with special characters that collide after sanitization */
-export interface EventWithNameCamelCase {
+export interface TrackEventWithNameCamelCaseProperties {
     /** User's email address */
     email?: CustomTypeEmail;
 }
 
 
 /** Triggered when user clicks on a "premium" product /\* important *\/ */
-export interface ProductPremiumClicked {
+export interface TrackProductPremiumClickedProperties {
     /** Field with special chars: "quotes", backslash\path, and /\* comment *\/ */
     specialField: string;
     /** HTTP status with special characters */
@@ -326,7 +326,7 @@ export interface ProductPremiumClicked {
 
 
 /** Triggered when a user signs up */
-export interface UserSignedUp {
+export interface TrackUserSignedUpProperties {
     /** User active status */
     active: CustomTypeActive;
     /** User's addresses */
@@ -340,7 +340,7 @@ export interface UserSignedUp {
     /** Array of user contacts */
     contacts?: CustomTypeEmail[];
     /** example of object property */
-    context?: UserSignedUpContext;
+    context?: TrackUserSignedUpPropertiesContext;
     /** Property using custom null type */
     customNullField?: CustomTypeNullType;
     /** Type of device */
@@ -409,7 +409,7 @@ export interface UserSignedUp {
 
 
 /** Event with camel case name */
-export interface EventWithNameCamelCase1 {
+export interface TrackEventWithNameCamelCaseProperties1 {
     /** User active status */
     active?: CustomTypeActive;
 }
@@ -573,7 +573,7 @@ export class RudderTyper {
      * @param callback - Optional callback fired after the call is dispatched
      */
     public trackVariableString(
-        props: VariableString,
+        props: TrackVariableStringProperties,
         options?: ApiOptions,
         callback?: ApiCallback,
     ): void {
@@ -593,7 +593,7 @@ export class RudderTyper {
      * @param callback - Optional callback fired after the call is dispatched
      */
     public trackEventWithNameCamelCase(
-        props: EventWithNameCamelCase,
+        props: TrackEventWithNameCamelCaseProperties,
         options?: ApiOptions,
         callback?: ApiCallback,
     ): void {
@@ -651,7 +651,7 @@ export class RudderTyper {
      * @param callback - Optional callback fired after the call is dispatched
      */
     public trackEventWithVariants(
-        props: EventWithVariants,
+        props: TrackEventWithVariantsProperties,
         options?: ApiOptions,
         callback?: ApiCallback,
     ): void {
@@ -671,7 +671,7 @@ export class RudderTyper {
      * @param callback - Optional callback fired after the call is dispatched
      */
     public trackProductPremiumClicked(
-        props: ProductPremiumClicked,
+        props: TrackProductPremiumClickedProperties,
         options?: ApiOptions,
         callback?: ApiCallback,
     ): void {
@@ -691,7 +691,7 @@ export class RudderTyper {
      * @param callback - Optional callback fired after the call is dispatched
      */
     public trackUserSignedUp(
-        props: UserSignedUp,
+        props: TrackUserSignedUpProperties,
         options?: ApiOptions,
         callback?: ApiCallback,
     ): void {
@@ -711,7 +711,7 @@ export class RudderTyper {
      * @param callback - Optional callback fired after the call is dispatched
      */
     public trackEventWithNameCamelCase1(
-        props: EventWithNameCamelCase1,
+        props: TrackEventWithNameCamelCaseProperties1,
         options?: ApiOptions,
         callback?: ApiCallback,
     ): void {

--- a/cli/internal/typer/generator/platforms/typescript/track_test.go
+++ b/cli/internal/typer/generator/platforms/typescript/track_test.go
@@ -39,7 +39,7 @@ func TestBuildTrackMethod_NonEmptySchema(t *testing.T) {
 		EventName:     "User Signed Up",
 		SDKMethodName: "track",
 		MethodArguments: []TSMethodArgument{
-			{Name: "props", Type: "UserSignedUp", Comment: "The properties to include with this event"},
+			{Name: "props", Type: "TrackUserSignedUpProperties", Comment: "The properties to include with this event"},
 		},
 		SDKArguments: []TSSDKArgument{
 			{Value: `"User Signed Up"`},
@@ -113,7 +113,7 @@ func TestBuildTrackMethod_EventNameWithSpecialChars(t *testing.T) {
 		EventName:     `Product "Premium" Clicked`,
 		SDKMethodName: "track",
 		MethodArguments: []TSMethodArgument{
-			{Name: "props", Type: "ProductPremiumClicked", Comment: "The properties to include with this event"},
+			{Name: "props", Type: "TrackProductPremiumClickedProperties", Comment: "The properties to include with this event"},
 		},
 		SDKArguments: []TSSDKArgument{
 			{Value: `"Product \"Premium\" Clicked"`},
@@ -160,14 +160,14 @@ func TestProcessEventRules_EmitsVariants(t *testing.T) {
 	assert.Equal(t, "trackPlainEvent", ctx.AnalyticsMethods[1].Name)
 
 	assert.Len(t, ctx.Interfaces, 1, "plain event still gets an interface")
-	assert.Equal(t, "PlainEvent", ctx.Interfaces[0].Name)
+	assert.Equal(t, "TrackPlainEventProperties", ctx.Interfaces[0].Name)
 
 	require.Len(t, ctx.VariantTypes, 1)
 	group := ctx.VariantTypes[0]
-	assert.Equal(t, "HasVariants", group.UnionAlias.Alias)
+	assert.Equal(t, "TrackHasVariantsProperties", group.UnionAlias.Alias)
 	require.Len(t, group.CaseInterfaces, 2, "one named case + default")
-	assert.Equal(t, "HasVariantsCaseAlpha", group.CaseInterfaces[0].Name)
-	assert.Equal(t, "HasVariantsDefault", group.CaseInterfaces[1].Name)
+	assert.Equal(t, "TrackHasVariantsPropertiesCaseAlpha", group.CaseInterfaces[0].Name)
+	assert.Equal(t, "TrackHasVariantsPropertiesDefault", group.CaseInterfaces[1].Name)
 }
 
 func TestProcessEventRules_SkipsUnsupportedEventTypes(t *testing.T) {
@@ -375,13 +375,13 @@ func TestBuildEventInterface_HoistsNestedSchemas(t *testing.T) {
 	require.Len(t, ctx.NestedInterfaces, 2, "two nested levels → two hoisted interfaces")
 
 	// Deepest-first: location (level 2) appears before context (level 1).
-	assert.Equal(t, "OrderPlacedContextLocation", ctx.NestedInterfaces[0].Name)
-	assert.Equal(t, "OrderPlacedContext", ctx.NestedInterfaces[1].Name)
+	assert.Equal(t, "TrackOrderPlacedPropertiesContextLocation", ctx.NestedInterfaces[0].Name)
+	assert.Equal(t, "TrackOrderPlacedPropertiesContext", ctx.NestedInterfaces[1].Name)
 
 	// Parent interface references the nested name, not the open record type.
 	parent := ctx.Interfaces[0]
 	require.Len(t, parent.Properties, 1)
-	assert.Equal(t, "OrderPlacedContext", parent.Properties[0].Type)
+	assert.Equal(t, "TrackOrderPlacedPropertiesContext", parent.Properties[0].Type)
 
 	// Level-1 interface references the level-2 interface by name.
 	level1 := ctx.NestedInterfaces[1]
@@ -392,7 +392,7 @@ func TestBuildEventInterface_HoistsNestedSchemas(t *testing.T) {
 			break
 		}
 	}
-	assert.Equal(t, "OrderPlacedContextLocation", locationProp.Type)
+	assert.Equal(t, "TrackOrderPlacedPropertiesContextLocation", locationProp.Type)
 }
 
 func TestEmptyObjectType_RespectsAdditionalProperties(t *testing.T) {


### PR DESCRIPTION
## 🔗 Ticket

No Linear ticket — change originated from review discussion on the docs PR [rudder-hugo#2118](https://github.com/rudderlabs/rudder-hugo/pull/2118), which surfaced that TypeScript `track` interfaces dropped the `Properties` suffix used by Kotlin/Swift.

---

## Summary

Align the generated TypeScript `track` event interface names with the mobile (Kotlin/Swift) convention. Previously TS emitted a bare PascalCase event name (e.g. `UserSignedUp`); it now emits `Track{EventName}Properties` (e.g. `TrackUserSignedUpProperties`), matching Kotlin's `Track{EventName}Properties` and Swift's struct naming. `identify`/`group`/`page` are unchanged — they are singletons in analytics-js (`IdentifyTraits`, `GroupTraits`, `PageProperties`) and already carry the prefix/suffix.

---

## Changes

- `getOrRegisterEventInterfaceName` (typescript generator): the `track` case now registers `FormatTypeName("Track", eventName+" Properties")` instead of the bare event name. The empty-name guard moves ahead of formatting since the prefixed/suffixed name is never empty.
- The rename propagates automatically through the single registry key to: the interface declaration, the method `props:` parameter type, hoisted nested interfaces (e.g. `TrackUserSignedUpPropertiesContext`), and variant union/case names (e.g. `TrackEventWithVariantsProperties`, `…CaseDesktop`).
- Regenerated the golden file `testdata/RudderTyper.ts` and updated affected assertions in `track_test.go`.

---

## Testing

- `make test` — all unit tests pass.
- `make lint` — 0 issues.
- Golden file regenerated via `make typer-typescript-update-testdata` and reviewed; only `track`-derived names changed, `identify`/`group`/`page` untouched.
- Not applicable: apply-cycle E2E (this is the typer code generator, no apply-cycle impact). Method names (`trackUserSignedUp`, etc.) are unchanged, so the validator fixture's call sites are unaffected.

---

## Risk / Impact

Medium

- This changes generated TypeScript output. Users who regenerate will see `track` property interfaces (and their nested/variant types) renamed to `Track{EventName}Properties`.
- Call sites are typically unaffected — the `track*` methods take object literals, and method names don't change. Only code that explicitly references a `track` property interface *by type name* needs updating after regeneration.
- Docs follow-up: the `track` row in the RudderTyper v2 command reference (rudder-hugo#2118) should be updated to show `Track{EventName}Properties` for TypeScript.

---

## Checklist

- [ ] Ticket linked (no Linear ticket; origin noted above)
- [x] Tests added/updated
- [x] No breaking changes (or documented) — breaking change to generated TS interface names, documented above
