### PR TITLE
feat(syncer): make the apply-cycle diff secret-aware (DEX-408)

### DIFF
--- a/cli/internal/project/importer/importer.go
+++ b/cli/internal/project/importer/importer.go
@@ -55,7 +55,9 @@ func WorkspaceImport(
 	}
 
 	diff := differ.ComputeDiff(sourceGraph, targetGraph, differ.DiffOptions{})
-	if diff.HasDiff() {
+	// HasNonSecretDiff (not HasDiff) so resources that only re-apply an unknown
+	// secret — which is expected on every run — do not permanently block imports.
+	if diff.HasNonSecretDiff() {
 		return fmt.Errorf("%w", ErrProjectNotSynced)
 	}
 

--- a/cli/internal/providers/datagraph/handlers/model/handler_test.go
+++ b/cli/internal/providers/datagraph/handlers/model/handler_test.go
@@ -1028,21 +1028,21 @@ func TestModelResource_ColumnsParticipateInDiff(t *testing.T) {
 			{"name": "id", "display_name": "User ID"},
 			{"name": "email_address", "display_name": "Email"},
 		}
-		diffs := differ.CompareData(mkResource(cols), mkResource(cols))
+		diffs, _ := differ.CompareData(mkResource(cols), mkResource(cols))
 		assert.Empty(t, diffs)
 	})
 
 	t.Run("different columns surface as a diff", func(t *testing.T) {
 		a := []map[string]any{{"name": "id", "display_name": "User ID"}}
 		b := []map[string]any{{"name": "id", "display_name": "Customer ID"}}
-		diffs := differ.CompareData(mkResource(a), mkResource(b))
+		diffs, _ := differ.CompareData(mkResource(a), mkResource(b))
 		assert.Contains(t, diffs, "columns")
 	})
 
 	t.Run("columns added in target surface as a diff", func(t *testing.T) {
 		empty := mkResource(nil)
 		populated := mkResource([]map[string]any{{"name": "id", "display_name": "User ID"}})
-		diffs := differ.CompareData(empty, populated)
+		diffs, _ := differ.CompareData(empty, populated)
 		assert.Contains(t, diffs, "columns")
 	})
 }
@@ -1309,7 +1309,7 @@ func TestRoundTrip_ColumnsIdempotent(t *testing.T) {
 	require.NoError(t, mapstructure.Decode(localResource, &localMap))
 	require.NoError(t, mapstructure.Decode(remoteResource, &remoteMap))
 
-	diffs := differ.CompareData(remoteMap, localMap)
+	diffs, _ := differ.CompareData(remoteMap, localMap)
 	assert.NotContains(t, diffs, "columns",
 		"second-apply idempotency: remote-derived Columns must match local yaml Columns so the syncer skips the BatchUpsert call")
 }

--- a/cli/internal/providers/datagraph/provider_test.go
+++ b/cli/internal/providers/datagraph/provider_test.go
@@ -439,7 +439,7 @@ func TestLoadSpec_ColumnsOrderIdempotent(t *testing.T) {
 	require.NoError(t, mapstructure.Decode(localModel, &localMap))
 	require.NoError(t, mapstructure.Decode(&remoteShape, &remoteMap))
 
-	diffs := differ.CompareData(remoteMap, localMap)
+	diffs, _ := differ.CompareData(remoteMap, localMap)
 	assert.NotContains(t, diffs, "columns",
 		"yaml-order-reversed columns must sort to the same canonical order as the server's sorted response so the differ short-circuits")
 }

--- a/cli/internal/resources/references.go
+++ b/cli/internal/resources/references.go
@@ -83,9 +83,17 @@ func collectReferencesByReflection(v any) []*PropertyRef {
 			return refs
 		}
 
-		// Recursively collect references from the fields of the struct
+		// Recursively collect references from the exported fields of the struct.
+		// Unexported fields can't be read via Interface() (it panics), so we skip
+		// them — this is what lets opaque value types like secret.String, whose
+		// state is unexported, sit in a RawData struct without crashing graph
+		// construction. PropertyRefs are always declared on exported fields, so in
+		// practice nothing reachable is lost. Mirrors DereferenceByReflection.
 		for i := 0; i < val.NumField(); i++ {
 			field := val.Field(i)
+			if !field.CanInterface() {
+				continue
+			}
 			refs = append(refs, collectReferencesByReflection(field.Interface())...)
 		}
 		return refs

--- a/cli/internal/resources/references_test.go
+++ b/cli/internal/resources/references_test.go
@@ -209,3 +209,29 @@ type ExampleStruct struct {
 	}
 	ArrayField []any
 }
+
+// opaqueValue mimics secret.String: a struct whose entire state is unexported.
+// Reflecting into its fields via Interface() panics, so collectReferencesByReflection
+// must skip unexported fields rather than descend into them.
+type opaqueValue struct {
+	hidden string
+}
+
+func TestCollectReferencesByReflection_SkipsUnexportedFields(t *testing.T) {
+	type host struct {
+		Ref    *PropertyRef
+		Secret opaqueValue // exported field, but its inner state is unexported
+		hidden opaqueValue // unexported field
+	}
+
+	in := host{
+		Ref:    &PropertyRef{URN: "test:urn", Property: "id"},
+		Secret: opaqueValue{hidden: "x"},
+		hidden: opaqueValue{hidden: "y"},
+	}
+
+	assert.NotPanics(t, func() {
+		refs := collectReferencesByReflection(in)
+		assert.Equal(t, []*PropertyRef{{URN: "test:urn", Property: "id"}}, refs)
+	})
+}

--- a/cli/internal/secret/secret.go
+++ b/cli/internal/secret/secret.go
@@ -1,6 +1,6 @@
 // Package secret provides String, a self-redacting value type for sensitive
 // data (API tokens, passwords, credentials). Every standard Go surface that
-// prints, formats, logs, or serializes a String returns a redacted form
+// prints, formats, logs, or serializes a String returns a masked form
 // automatically; the real value escapes only through the explicit, greppable
 // Reveal() accessor. Sensitivity becomes a property of the field's type, so a
 // secret is masked once and stays masked at every surface it flows through.
@@ -16,8 +16,8 @@ import (
 )
 
 const (
-	redactedPlaceholder = "(remote-redacted)"
-	shortMask           = "***"
+	unknownPlaceholder = "(unknown)"
+	shortMask          = "***"
 	// hintThreshold is the minimum number of characters before masked() reveals
 	// the last four as a spot-check hint; below it the value is fully masked so the
 	// hint never exposes a meaningful fraction of a short secret.
@@ -29,37 +29,53 @@ const (
 // only be obtained through Reveal().
 type String struct {
 	v string
-	// redacted marks a value that arrived already masked from a remote API,
-	// i.e. we never held the real value. It lets callers distinguish "no secret"
-	// from "a secret we cannot see".
-	redacted bool
+	// unknown marks a secret whose real value we do not hold — typically because it
+	// came from a remote API that never returns secrets. It lets callers distinguish
+	// "no secret" from "a secret we cannot see", and it drives the always-re-apply
+	// diff rule below.
+	unknown bool
 }
 
 // New wraps a real, known value. The spec loader and provider spec-to-args
 // conversion use it.
 func New(v string) String { return String{v: v} }
 
-// NewRedacted marks a value the remote API returned as a placeholder rather than
-// the real secret.
-func NewRedacted() String { return String{redacted: true} }
+// NewUnknown marks a secret whose real value we never hold. This is what
+// MapRemoteToState constructs for a secret field, since backend APIs do not
+// return secret values. An unknown secret always diffs (see Diff), so its
+// resource is re-applied on every run.
+func NewUnknown() String { return String{unknown: true} }
 
 // Reveal returns the real value. This is the only escape hatch and every call
 // site is greppable, so revelations can be audited.
 func (s String) Reveal() string { return s.v }
 
-// IsZero reports whether there is no secret to send: an empty value that is not a
-// remote-redacted placeholder. Providers use it to decide whether to include the
-// field in an outgoing request. New("") equals the zero value, so an empty secret
-// is treated the same as "unset".
-func (s String) IsZero() bool { return s.v == "" && !s.redacted }
+// IsZero reports whether there is no secret to send: an empty value that is not an
+// unknown placeholder. Providers use it to decide whether to include the field in
+// an outgoing request. New("") equals the zero value, so an empty secret is treated
+// the same as "unset".
+func (s String) IsZero() bool { return s.v == "" && !s.unknown }
 
-// IsRedacted reports whether the value came from a remote API as a placeholder.
-func (s String) IsRedacted() bool { return s.redacted }
+// IsUnknown reports whether the value is a placeholder whose real value we do not
+// hold (e.g. it came from a remote API that does not return secrets).
+func (s String) IsUnknown() bool { return s.unknown }
 
-// masked is the single redacted representation used by every formatting surface.
+// Diff reports whether a and b differ for plan purposes — true means the secret
+// must be (re-)applied. An unknown secret always differs, even from another
+// unknown: backend APIs never return secrets, so we can never confirm the remote
+// matches the local value and must re-apply every run. Two known secrets differ
+// only when their real values differ.
+func (a String) Diff(b String) bool {
+	if a.unknown || b.unknown {
+		return true
+	}
+	return a.v != b.v
+}
+
+// masked is the single masked representation used by every formatting surface.
 func (s String) masked() string {
-	if s.redacted {
-		return redactedPlaceholder
+	if s.unknown {
+		return unknownPlaceholder
 	}
 	// Count and slice by rune so multi-byte values are measured by character and
 	// the hint never splits a rune.
@@ -92,14 +108,14 @@ func (s String) MarshalJSON() ([]byte, error) { return json.Marshal(s.masked()) 
 // MarshalYAML redacts any direct YAML serialization of a String.
 func (s String) MarshalYAML() (any, error) { return s.masked(), nil }
 
-// UnmarshalYAML reads a bare string from a spec, producing a non-redacted value.
+// UnmarshalYAML reads a bare string from a spec, producing a known value.
 func (s *String) UnmarshalYAML(node *yaml.Node) error {
 	var raw string
 	if err := node.Decode(&raw); err != nil {
 		return fmt.Errorf("decoding secret: %w", err)
 	}
 	s.v = raw
-	s.redacted = false
+	s.unknown = false
 	return nil
 }
 
@@ -110,6 +126,6 @@ func (s *String) UnmarshalJSON(b []byte) error {
 		return fmt.Errorf("decoding secret: %w", err)
 	}
 	s.v = raw
-	s.redacted = false
+	s.unknown = false
 	return nil
 }

--- a/cli/internal/secret/secret.go
+++ b/cli/internal/secret/secret.go
@@ -18,9 +18,10 @@ import (
 const (
 	unknownPlaceholder = "(unknown)"
 	shortMask          = "***"
-	// hintThreshold is the minimum number of characters before masked() reveals
-	// the last four as a spot-check hint; below it the value is fully masked so the
-	// hint never exposes a meaningful fraction of a short secret.
+	// hintThreshold is the minimum length, in runes, at which masked() reveals the
+	// last four runes as a spot-check hint; shorter values are masked whole ("***").
+	// At exactly this length the tail is half the value, so 8 is the shortest secret
+	// for which leaking a 4-rune tail is treated as acceptable.
 	hintThreshold = 8
 )
 
@@ -48,6 +49,9 @@ func NewUnknown() String { return String{unknown: true} }
 
 // Reveal returns the real value. This is the only escape hatch and every call
 // site is greppable, so revelations can be audited.
+//
+// On an unknown secret there is no real value to reveal, so this returns "".
+// we may later harden Reveal to error rather than silently return "" for an unknown secret.
 func (s String) Reveal() string { return s.v }
 
 // IsZero reports whether there is no secret to send: an empty value that is not an

--- a/cli/internal/secret/secret_test.go
+++ b/cli/internal/secret/secret_test.go
@@ -27,7 +27,7 @@ func TestString_Masking(t *testing.T) {
 		{"exactly eight shows last four", New("abcd1234"), "****1234"},
 		{"short value is fully masked", New("hunter2"), "***"},
 		{"empty value is masked", New(""), "***"},
-		{"remote redacted", NewRedacted(), "(remote-redacted)"},
+		{"unknown secret", NewUnknown(), "(unknown)"},
 		// Masking counts characters, not bytes: the hint is the last four whole
 		// runes and the threshold counts runes, so multi-byte values are not split.
 		{"multibyte value shows last four runes", New("1234café"), "****café"},
@@ -75,7 +75,7 @@ func TestString_RedactingSurfaces(t *testing.T) {
 		wantMasked string
 	}{
 		{"real value", New(realSecret), realSecret, maskedSecret},
-		{"remote redacted", NewRedacted(), "", "(remote-redacted)"},
+		{"unknown secret", NewUnknown(), "", "(unknown)"},
 	}
 
 	for _, in := range inputs {
@@ -98,14 +98,14 @@ func TestReveal(t *testing.T) {
 	_ = fmt.Sprintf("%v %s %q %#v", s, s, s, s)
 	assert.Equal(t, realSecret, s.Reveal())
 
-	assert.Equal(t, "", NewRedacted().Reveal())
+	assert.Equal(t, "", NewUnknown().Reveal())
 }
 
 func TestUnmarshalYAML(t *testing.T) {
 	var s String
 	require.NoError(t, yaml.Unmarshal([]byte("sk_live_abcd1234\n"), &s))
 	assert.Equal(t, New("sk_live_abcd1234"), s)
-	assert.False(t, s.IsRedacted())
+	assert.False(t, s.IsUnknown())
 }
 
 func TestUnmarshalYAML_InStruct(t *testing.T) {
@@ -122,7 +122,7 @@ func TestUnmarshalJSON(t *testing.T) {
 	var s String
 	require.NoError(t, json.Unmarshal([]byte(`"sk_live_abcd1234"`), &s))
 	assert.Equal(t, New("sk_live_abcd1234"), s)
-	assert.False(t, s.IsRedacted())
+	assert.False(t, s.IsUnknown())
 }
 
 // TestMarshalJSON_InStruct_Redacts mirrors the export path, which json.Marshals a
@@ -150,19 +150,40 @@ func TestLogValue_Integration(t *testing.T) {
 func TestEquality(t *testing.T) {
 	assert.True(t, New("a") == New("a"))
 	assert.False(t, New("a") == New("b"))
-	assert.False(t, New("a") == NewRedacted())
-	assert.True(t, NewRedacted() == NewRedacted())
+	assert.False(t, New("a") == NewUnknown())
+	assert.True(t, NewUnknown() == NewUnknown())
 }
 
 func TestIsZero(t *testing.T) {
 	assert.True(t, String{}.IsZero())
 	assert.True(t, New("").IsZero())
 	assert.False(t, New("x").IsZero())
-	assert.False(t, NewRedacted().IsZero())
+	assert.False(t, NewUnknown().IsZero())
 }
 
-func TestIsRedacted(t *testing.T) {
-	assert.False(t, New("x").IsRedacted())
-	assert.False(t, New("").IsRedacted())
-	assert.True(t, NewRedacted().IsRedacted())
+func TestIsUnknown(t *testing.T) {
+	assert.False(t, New("x").IsUnknown())
+	assert.False(t, New("").IsUnknown())
+	assert.True(t, NewUnknown().IsUnknown())
+}
+
+func TestDiff(t *testing.T) {
+	tests := []struct {
+		name string
+		a, b String
+		want bool
+	}{
+		{"equal values do not diff", New("hunter2"), New("hunter2"), false},
+		{"different values diff", New("hunter2"), New("hunter3"), true},
+		{"local value vs unknown remote always diffs", New("hunter2"), NewUnknown(), true},
+		{"unknown remote vs local value always diffs", NewUnknown(), New("hunter2"), true},
+		{"both unknown always diff", NewUnknown(), NewUnknown(), true},
+		{"empty equals empty", New(""), New(""), false},
+		{"empty vs set diffs", New(""), New("hunter2"), true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.a.Diff(tt.b))
+		})
+	}
 }

--- a/cli/internal/syncer/differ/diff.go
+++ b/cli/internal/syncer/differ/diff.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/go-viper/mapstructure/v2"
 	"github.com/rudderlabs/rudder-iac/cli/internal/resources"
+	"github.com/rudderlabs/rudder-iac/cli/internal/secret"
 	"github.com/samber/lo"
 )
 
@@ -33,15 +34,48 @@ func (d *Diff) HasDiff() bool {
 		len(d.RemovedResources) > 0
 }
 
+// HasNonSecretDiff reports whether the plan contains any change a user actually made,
+// ignoring resources that update only because they carry an unknown secret (which
+// re-applies every run by design). Used by the import "project not synced" guard so
+// the presence of secrets does not permanently block imports.
+func (d *Diff) HasNonSecretDiff() bool {
+	if len(d.NewResources) > 0 ||
+		len(d.ImportableResources) > 0 ||
+		len(d.RemovedResources) > 0 {
+		return true
+	}
+	for _, rd := range d.UpdatedResources {
+		if !rd.IsSecretOnly() {
+			return true
+		}
+	}
+	return false
+}
+
 type ResourceDiff struct {
 	URN   string
 	Diffs map[string]PropertyDiff
+	// SecretOnly is true when every property diff is secret-driven, so the
+	// resource is "always re-applied" rather than genuine drift. It is computed
+	// once while the diffs are built (see compareData) and cached here.
+	SecretOnly bool
+}
+
+// IsSecretOnly reports whether this resource updates only because of unknown
+// secrets. The verdict is precomputed in ComputeDiff, so this is O(1).
+func (rd ResourceDiff) IsSecretOnly() bool {
+	return rd.SecretOnly
 }
 
 type PropertyDiff struct {
 	Property    string
 	SourceValue any
 	TargetValue any
+	// SecretOnly is true when this diff exists only because of an unknown secret, so
+	// the reporter can render it distinctly and classify the resource as always
+	// re-applied. It propagates up: a containing map diff is SecretOnly only when every
+	// child diff is.
+	SecretOnly bool
 }
 
 type DiffOptions struct {
@@ -86,10 +120,11 @@ func ComputeDiff(source *resources.Graph, target *resources.Graph, options DiffO
 				tData = r.Data()
 			}
 
-			// Check if resource is updated or unmodified
-			propertyDiffs := CompareData(sData, tData)
+			// Check if resource is updated or unmodified. secretOnly is computed
+			// while the diffs are built and cached on the ResourceDiff.
+			propertyDiffs, secretOnly := CompareData(sData, tData)
 			if len(propertyDiffs) > 0 {
-				updatedResources[urn] = ResourceDiff{URN: urn, Diffs: propertyDiffs}
+				updatedResources[urn] = ResourceDiff{URN: urn, Diffs: propertyDiffs, SecretOnly: secretOnly}
 			} else {
 				unmodifiedResources = append(unmodifiedResources, urn)
 			}
@@ -113,9 +148,23 @@ func ComputeDiff(source *resources.Graph, target *resources.Graph, options DiffO
 	}
 }
 
-// compareData compares the data of two resources and returns the differences
-func CompareData(r1, r2 resources.ResourceData) map[string]PropertyDiff {
+// CompareData compares the data of two resources and returns the differences and
+// whether the whole set is secret-only.
+// The secret-only verdict is computed as the diffs are built rather than by
+// re-looping afterwards; callers propagate it up a nested map and cache it on a
+// ResourceDiff (see ComputeDiff) so IsSecretOnly stays O(1).
+func CompareData(r1, r2 resources.ResourceData) (map[string]PropertyDiff, bool) {
 	diffs := make(map[string]PropertyDiff)
+
+	// record is the single, once-per-key write path into diffs, so the running
+	// count of secret diffs stays in lockstep with the map size.
+	secretDiffs := 0
+	record := func(key string, d PropertyDiff) {
+		diffs[key] = d
+		if d.SecretOnly {
+			secretDiffs++
+		}
+	}
 
 	// Helper function to compare values recursively
 	var compareValues func(key string, v1, v2 any)
@@ -131,14 +180,14 @@ func CompareData(r1, r2 resources.ResourceData) map[string]PropertyDiff {
 		}
 
 		if reflect.TypeOf(v1) != reflect.TypeOf(v2) {
-			diffs[key] = PropertyDiff{Property: key, SourceValue: v1, TargetValue: v2}
+			record(key, PropertyDiff{Property: key, SourceValue: v1, TargetValue: v2})
 			return
 		}
 
 		// If v1 and v2 are pointers, compare the dereferenced values
 		if reflect.TypeOf(v1).Kind() == reflect.Pointer {
 			if isNil(v1) || isNil(v2) {
-				diffs[key] = PropertyDiff{Property: key, SourceValue: v1, TargetValue: v2}
+				record(key, PropertyDiff{Property: key, SourceValue: v1, TargetValue: v2})
 				return
 			}
 			compareValues(key, reflect.ValueOf(v1).Elem().Interface(), reflect.ValueOf(v2).Elem().Interface())
@@ -150,34 +199,50 @@ func CompareData(r1, r2 resources.ResourceData) map[string]PropertyDiff {
 		case *resources.PropertyRef:
 			v2Typed := v2.(*resources.PropertyRef)
 			if !comparePropertyRefs(v1Typed, v2Typed) {
-				diffs[key] = PropertyDiff{Property: key, SourceValue: v1, TargetValue: v2}
+				record(key, PropertyDiff{Property: key, SourceValue: v1, TargetValue: v2})
 			}
 		case resources.PropertyRef:
 			v2Typed := v2.(resources.PropertyRef)
 			if !comparePropertyRefs(&v1Typed, &v2Typed) {
-				diffs[key] = PropertyDiff{Property: key, SourceValue: v1, TargetValue: v2}
+				record(key, PropertyDiff{Property: key, SourceValue: v1, TargetValue: v2})
+			}
+
+		// A secret owns the "how do we compare?" decision in its own type: an
+		// unknown secret always diffs (we can't read the remote, so we re-apply),
+		// otherwise known values are compared. The diff is flagged Secret so the
+		// reporter renders it distinctly and the resource is classified as always
+		// re-applied. SourceValue/TargetValue stay secret.String so they mask. A
+		// *secret.String (the form that survives RawData's struct→map decode, like
+		// *PropertyRef) is dereferenced to this case by the pointer branch above.
+		case secret.String:
+			v2Typed := v2.(secret.String)
+			if v1Typed.Diff(v2Typed) {
+				record(key, PropertyDiff{Property: key, SourceValue: v1, TargetValue: v2, SecretOnly: true})
 			}
 
 		case []map[string]any:
 			v2Typed := v2.([]map[string]any)
 			if !reflect.DeepEqual(v1Typed, v2Typed) {
-				diffs[key] = PropertyDiff{Property: key, SourceValue: v1, TargetValue: v2}
+				record(key, PropertyDiff{Property: key, SourceValue: v1, TargetValue: v2})
 			}
 
 		case map[string]any:
 			v2Typed := v2.(map[string]any)
-			subDiffs := CompareData(v1Typed, v2Typed)
+			subDiffs, subSecretOnly := CompareData(v1Typed, v2Typed)
 			if len(subDiffs) > 0 {
-				diffs[key] = PropertyDiff{Property: key, SourceValue: v1, TargetValue: v2}
+				// A nested map is secret-only (always re-applied) only when every
+				// child diff is itself secret-driven; one real sibling change makes
+				// the whole map a real diff.
+				record(key, PropertyDiff{Property: key, SourceValue: v1, TargetValue: v2, SecretOnly: subSecretOnly})
 			}
 		case []any:
 			v2Typed := v2.([]any)
 			if !reflect.DeepEqual(v1Typed, v2Typed) {
-				diffs[key] = PropertyDiff{Property: key, SourceValue: v1, TargetValue: v2}
+				record(key, PropertyDiff{Property: key, SourceValue: v1, TargetValue: v2})
 			}
 		default:
 			if v1 != v2 {
-				diffs[key] = PropertyDiff{Property: key, SourceValue: v1, TargetValue: v2}
+				record(key, PropertyDiff{Property: key, SourceValue: v1, TargetValue: v2})
 			}
 		}
 	}
@@ -185,7 +250,7 @@ func CompareData(r1, r2 resources.ResourceData) map[string]PropertyDiff {
 	// Iterate over properties in r1 to find differences
 	for key, value1 := range r1 {
 		if value2, exists := r2[key]; !exists {
-			diffs[key] = PropertyDiff{Property: key, SourceValue: value1, TargetValue: nil}
+			record(key, PropertyDiff{Property: key, SourceValue: value1, TargetValue: nil})
 		} else {
 			compareValues(key, value1, value2)
 		}
@@ -194,11 +259,13 @@ func CompareData(r1, r2 resources.ResourceData) map[string]PropertyDiff {
 	// Iterate over properties in r2 to find properties that are not in r1
 	for key, value2 := range r2 {
 		if _, exists := r1[key]; !exists {
-			diffs[key] = PropertyDiff{Property: key, SourceValue: nil, TargetValue: value2}
+			record(key, PropertyDiff{Property: key, SourceValue: nil, TargetValue: value2})
 		}
 	}
 
-	return diffs
+	// secretDiffs == len(diffs) means every recorded diff is secret-driven; the
+	// > 0 guard keeps an empty diff set from counting as secret-only.
+	return diffs, secretDiffs > 0 && secretDiffs == len(diffs)
 }
 
 // rewrite []any ->  map[string]any if possible

--- a/cli/internal/syncer/differ/diff.go
+++ b/cli/internal/syncer/differ/diff.go
@@ -220,6 +220,11 @@ func CompareData(r1, r2 resources.ResourceData) (map[string]PropertyDiff, bool) 
 				record(key, PropertyDiff{Property: key, SourceValue: v1, TargetValue: v2, SecretOnly: true})
 			}
 
+		// TODO: a secret.String nested inside a slice (same for []any below) is
+		// compared whole via reflect.DeepEqual, so it bypasses the secret case
+		// above — it still re-applies every run but isn't flagged SecretOnly, so it
+		// renders as a normal masked update rather than under "always re-applied".
+		// No value leaks (Format masks). Extend secret-awareness to slices.
 		case []map[string]any:
 			v2Typed := v2.([]map[string]any)
 			if !reflect.DeepEqual(v1Typed, v2Typed) {

--- a/cli/internal/syncer/differ/diff_test.go
+++ b/cli/internal/syncer/differ/diff_test.go
@@ -1,6 +1,7 @@
 package differ_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/go-viper/mapstructure/v2"
@@ -125,16 +126,39 @@ func TestCompareData_Secret(t *testing.T) {
 		assert.False(t, secretOnly)
 	})
 
-	t.Run("secret inside a slice diffs via DeepEqual but is not classified secret-only", func(t *testing.T) {
-		// Slices fall back to reflect.DeepEqual, so an unknown remote still produces
-		// a diff (it re-applies) but the diff is not tagged Secret.
-		diffs, secretOnly := differ.CompareData(
-			resources.ResourceData{"creds": []map[string]any{{"token": secret.New("hunter2")}}},
-			resources.ResourceData{"creds": []map[string]any{{"token": secret.NewUnknown()}}},
-		)
-		require.Contains(t, diffs, "creds")
-		assert.False(t, diffs["creds"].SecretOnly)
-		assert.False(t, secretOnly)
+	t.Run("secret inside a slice re-applies every run, not classified secret-only, never leaks", func(t *testing.T) {
+		// Slices fall back to reflect.DeepEqual, so a secret nested inside one
+		// bypasses the secret case: an unknown remote never equals local, so it
+		// diffs (re-applies) on every run, but the diff is not flagged Secret.
+		// Format still masks, so the real value never leaks through the render path.
+		slices := map[string]struct{ local, remote any }{
+			"[]map[string]any": {
+				local:  []map[string]any{{"token": secret.New("hunter2")}},
+				remote: []map[string]any{{"token": secret.NewUnknown()}},
+			},
+			"[]any": {
+				local:  []any{map[string]any{"token": secret.New("hunter2")}},
+				remote: []any{map[string]any{"token": secret.NewUnknown()}},
+			},
+		}
+		for name, tc := range slices {
+			t.Run(name, func(t *testing.T) {
+				// Two independent compares against the always-unknown remote both
+				// diff: the resource re-applies on every run.
+				for run := 1; run <= 2; run++ {
+					diffs, secretOnly := differ.CompareData(
+						resources.ResourceData{"creds": tc.remote},
+						resources.ResourceData{"creds": tc.local},
+					)
+					require.Contains(t, diffs, "creds", "unknown remote must diff on run %d (re-applied every run)", run)
+					assert.False(t, diffs["creds"].SecretOnly, "slice-nested secret is not classified secret-only")
+					assert.False(t, secretOnly)
+
+					rendered := fmt.Sprintf("%v -> %v", diffs["creds"].SourceValue, diffs["creds"].TargetValue)
+					assert.NotContains(t, rendered, "hunter2", "real secret value leaked through render path: %s", rendered)
+				}
+			})
+		}
 	})
 
 	t.Run("pointer flavor mirrors value flavor", func(t *testing.T) {

--- a/cli/internal/syncer/differ/diff_test.go
+++ b/cli/internal/syncer/differ/diff_test.go
@@ -3,9 +3,12 @@ package differ_test
 import (
 	"testing"
 
+	"github.com/go-viper/mapstructure/v2"
 	"github.com/rudderlabs/rudder-iac/cli/internal/resources"
+	"github.com/rudderlabs/rudder-iac/cli/internal/secret"
 	"github.com/rudderlabs/rudder-iac/cli/internal/syncer/differ"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCompareData(t *testing.T) {
@@ -21,7 +24,7 @@ func TestCompareData(t *testing.T) {
 		"key4": "value4",
 	}
 
-	diffs := differ.CompareData(data1, data2)
+	diffs, _ := differ.CompareData(data1, data2)
 
 	assert.Len(t, diffs, 3)
 
@@ -66,3 +69,191 @@ func TestComputeDiff(t *testing.T) {
 	assert.Contains(t, diff.RemovedResources, "some-type:r2")
 	assert.Contains(t, diff.UnmodifiedResources, "some-type:r0")
 }
+
+// TestCompareData_Secret covers the secret-aware rules on the Data() path, where
+// the concrete secret.String value lives directly in the resource map. It also
+// asserts the secret-only verdict CompareData returns alongside the diffs.
+func TestCompareData_Secret(t *testing.T) {
+	t.Run("equal known secrets do not diff", func(t *testing.T) {
+		diffs, secretOnly := differ.CompareData(
+			resources.ResourceData{"token": secret.New("hunter2")},
+			resources.ResourceData{"token": secret.New("hunter2")},
+		)
+		assert.Empty(t, diffs)
+		assert.False(t, secretOnly)
+	})
+
+	t.Run("different known secrets diff, flagged Secret, keep both values for masking", func(t *testing.T) {
+		diffs, secretOnly := differ.CompareData(
+			resources.ResourceData{"token": secret.New("hunter2")},
+			resources.ResourceData{"token": secret.New("hunter3")},
+		)
+		assert.Equal(t, map[string]differ.PropertyDiff{
+			"token": {Property: "token", SourceValue: secret.New("hunter2"), TargetValue: secret.New("hunter3"), SecretOnly: true},
+		}, diffs)
+		assert.True(t, secretOnly)
+	})
+
+	t.Run("unknown remote always diffs and is flagged Secret", func(t *testing.T) {
+		diffs, secretOnly := differ.CompareData(
+			resources.ResourceData{"token": secret.New("hunter2")},
+			resources.ResourceData{"token": secret.NewUnknown()},
+		)
+		assert.Equal(t, map[string]differ.PropertyDiff{
+			"token": {Property: "token", SourceValue: secret.New("hunter2"), TargetValue: secret.NewUnknown(), SecretOnly: true},
+		}, diffs)
+		assert.True(t, secretOnly)
+	})
+
+	t.Run("secret nested in a map alone makes the map diff secret-only", func(t *testing.T) {
+		diffs, secretOnly := differ.CompareData(
+			resources.ResourceData{"config": map[string]any{"token": secret.New("hunter2")}},
+			resources.ResourceData{"config": map[string]any{"token": secret.NewUnknown()}},
+		)
+		require.Contains(t, diffs, "config")
+		assert.True(t, diffs["config"].SecretOnly)
+		assert.True(t, secretOnly)
+	})
+
+	t.Run("secret nested in a map with a real sibling is a real diff", func(t *testing.T) {
+		diffs, secretOnly := differ.CompareData(
+			resources.ResourceData{"config": map[string]any{"token": secret.New("hunter2"), "name": "a"}},
+			resources.ResourceData{"config": map[string]any{"token": secret.NewUnknown(), "name": "b"}},
+		)
+		require.Contains(t, diffs, "config")
+		assert.False(t, diffs["config"].SecretOnly)
+		assert.False(t, secretOnly)
+	})
+
+	t.Run("secret inside a slice diffs via DeepEqual but is not classified secret-only", func(t *testing.T) {
+		// Slices fall back to reflect.DeepEqual, so an unknown remote still produces
+		// a diff (it re-applies) but the diff is not tagged Secret.
+		diffs, secretOnly := differ.CompareData(
+			resources.ResourceData{"creds": []map[string]any{{"token": secret.New("hunter2")}}},
+			resources.ResourceData{"creds": []map[string]any{{"token": secret.NewUnknown()}}},
+		)
+		require.Contains(t, diffs, "creds")
+		assert.False(t, diffs["creds"].SecretOnly)
+		assert.False(t, secretOnly)
+	})
+
+	t.Run("pointer flavor mirrors value flavor", func(t *testing.T) {
+		local, remote := secret.New("hunter2"), secret.New("hunter3")
+		diffs, secretOnly := differ.CompareData(
+			resources.ResourceData{"token": &local},
+			resources.ResourceData{"token": &remote},
+		)
+		// The pointer branch dereferences to the secret.String case, which records
+		// the dereferenced values and the Secret flag.
+		assert.Equal(t, map[string]differ.PropertyDiff{
+			"token": {Property: "token", SourceValue: secret.New("hunter2"), TargetValue: secret.New("hunter3"), SecretOnly: true},
+		}, diffs)
+		assert.True(t, secretOnly)
+
+		same := secret.New("hunter2")
+		equal, secretOnly := differ.CompareData(
+			resources.ResourceData{"token": &local},
+			resources.ResourceData{"token": &same},
+		)
+		assert.Empty(t, equal)
+		assert.False(t, secretOnly)
+	})
+}
+
+// TestDiff_HasNonsecretDiff locks the import guard's discriminator. ResourceDiff.SecretOnly
+// is precomputed by ComputeDiff; here we set it directly to exercise the guard logic.
+// (That ComputeDiff sets it correctly is covered by TestComputeDiff_Secret.)
+func TestDiff_HasNonsecretDiff(t *testing.T) {
+	secretOnly := &differ.Diff{UpdatedResources: map[string]differ.ResourceDiff{
+		"some-type:r0": {URN: "some-type:r0", SecretOnly: true,
+			Diffs: map[string]differ.PropertyDiff{"token": {SecretOnly: true}}},
+	}}
+	assert.True(t, secretOnly.HasDiff(), "a secret-only resource is still a diff (it re-applies)")
+	assert.False(t, secretOnly.HasNonSecretDiff(), "but it is not real drift")
+
+	mixed := &differ.Diff{UpdatedResources: map[string]differ.ResourceDiff{
+		"some-type:r0": {URN: "some-type:r0", SecretOnly: false,
+			Diffs: map[string]differ.PropertyDiff{"token": {SecretOnly: true}, "name": {}}},
+	}}
+	assert.True(t, mixed.HasNonSecretDiff())
+
+	assert.True(t, (&differ.Diff{NewResources: []string{"x"}}).HasNonSecretDiff())
+	assert.True(t, (&differ.Diff{RemovedResources: []string{"x"}}).HasNonSecretDiff())
+}
+
+// secretRawData is a typed RawData struct that adopts a secret. The field is a
+// *secret.String, mirroring *PropertyRef: a pointer is the form that survives the
+// struct→map decode the differ relies on (see TestSecret_SurvivesStructToMap).
+type secretRawData struct {
+	Name  string
+	Token *secret.String
+}
+
+// TestSecret_SurvivesStructToMap locks down the decode-preservation contract: the
+// struct→map step the differ performs on RawData must not flatten the concrete
+// secret type, otherwise the secret-aware rules can never fire.
+func TestSecret_SurvivesStructToMap(t *testing.T) {
+	t.Run("pointer secret is preserved as concrete type", func(t *testing.T) {
+		tok := secret.New("hunter2")
+		var out map[string]any
+		require.NoError(t, mapstructure.Decode(secretRawData{Name: "main", Token: &tok}, &out))
+
+		got, ok := out["Token"].(*secret.String)
+		require.True(t, ok, "expected *secret.String, got %T", out["Token"])
+		assert.Equal(t, "hunter2", got.Reveal())
+	})
+
+	// A value secret.String has no exported fields, so mapstructure decomposes it
+	// into an empty map rather than preserving it. This is why adopters use a
+	// *secret.String on the RawData path, exactly as PropertyRef uses a pointer.
+	t.Run("value secret does not survive, justifying the pointer contract", func(t *testing.T) {
+		type valueRawData struct {
+			Token secret.String
+		}
+		var out map[string]any
+		require.NoError(t, mapstructure.Decode(valueRawData{Token: secret.New("hunter2")}, &out))
+
+		_, ok := out["Token"].(secret.String)
+		assert.False(t, ok, "value secret.String unexpectedly survived as a concrete type")
+	})
+}
+
+// TestComputeDiff_Secret exercises the full RawData path end to end: typed structs
+// carrying a *secret.String are decoded to maps and compared by the differ.
+func TestComputeDiff_Secret(t *testing.T) {
+	rawWith := func(s secret.String) *secretRawData {
+		return &secretRawData{Name: "main", Token: &s}
+	}
+	resWith := func(id string, s secret.String) *resources.Resource {
+		return resources.NewResource(id, "some-type", resources.ResourceData{}, []string{}, resources.WithRawData(rawWith(s)))
+	}
+
+	t.Run("unknown remote forces an always-re-applied, secret-only update", func(t *testing.T) {
+		local := resources.NewGraph()
+		remote := resources.NewGraph()
+		local.AddResource(resWith("r0", secret.New("hunter2")))
+		remote.AddResource(resWith("r0", secret.NewUnknown()))
+
+		diff := differ.ComputeDiff(local, remote, differ.DiffOptions{})
+		require.Contains(t, diff.UpdatedResources, "some-type:r0")
+		assert.True(t, diff.UpdatedResources["some-type:r0"].IsSecretOnly())
+		assert.False(t, diff.HasNonSecretDiff(), "a secret-only update is not real drift")
+		assert.NotContains(t, diff.UnmodifiedResources, "some-type:r0")
+	})
+
+	t.Run("real field change alongside a secret is a real diff", func(t *testing.T) {
+		local := resources.NewGraph()
+		remote := resources.NewGraph()
+		local.AddResource(resources.NewResource("r0", "some-type", resources.ResourceData{}, []string{},
+			resources.WithRawData(&secretRawData{Name: "local", Token: ptr(secret.New("hunter2"))})))
+		remote.AddResource(resources.NewResource("r0", "some-type", resources.ResourceData{}, []string{},
+			resources.WithRawData(&secretRawData{Name: "remote", Token: ptr(secret.NewUnknown())})))
+
+		diff := differ.ComputeDiff(local, remote, differ.DiffOptions{})
+		require.Contains(t, diff.UpdatedResources, "some-type:r0")
+		assert.False(t, diff.UpdatedResources["some-type:r0"].IsSecretOnly())
+		assert.True(t, diff.HasNonSecretDiff())
+	})
+}
+
+func ptr(s secret.String) *secret.String { return &s }

--- a/cli/internal/syncer/reporters/plan.go
+++ b/cli/internal/syncer/reporters/plan.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/rudderlabs/rudder-iac/cli/internal/config"
 	"github.com/rudderlabs/rudder-iac/cli/internal/resources"
+	"github.com/rudderlabs/rudder-iac/cli/internal/secret"
 	"github.com/rudderlabs/rudder-iac/cli/internal/syncer/differ"
 	"github.com/rudderlabs/rudder-iac/cli/internal/syncer/planner"
 	"github.com/rudderlabs/rudder-iac/cli/internal/ui"
@@ -46,28 +47,7 @@ func renderDiff(diff *differ.Diff) string {
 	}
 
 	if len(diff.UpdatedResources) > 0 {
-		urns := []string{}
-		for _, r := range diff.UpdatedResources {
-			urns = append(urns, r.URN)
-		}
-		sort.Strings(urns)
-		listResources(b, "Updated resources", urns, func(urn string) string {
-			r := diff.UpdatedResources[urn]
-			details := ""
-			diffKeys := []string{}
-			for k := range r.Diffs {
-				diffKeys = append(diffKeys, k)
-			}
-			sort.Strings(diffKeys)
-			for _, k := range diffKeys {
-				d := r.Diffs[k]
-				diffLines := renderPropertyDiff(d)
-				for _, line := range diffLines {
-					details += line
-				}
-			}
-			return details
-		})
+		renderUpdatedResources(b, diff)
 	}
 
 	if len(diff.RemovedResources) > 0 {
@@ -75,6 +55,46 @@ func renderDiff(diff *differ.Diff) string {
 	}
 
 	return b.String()
+}
+
+// renderUpdatedResources lists updated resources, splitting off the secret-only
+// ones — which re-apply every run because their remote value can't be read — into
+// their own section so they don't read as user-made drift. This is the only place
+// the section layout is secret-aware; the per-line rendering stays generic.
+func renderUpdatedResources(b *strings.Builder, diff *differ.Diff) {
+	var updated, secretOnly []string
+	for _, r := range diff.UpdatedResources {
+		if r.IsSecretOnly() {
+			secretOnly = append(secretOnly, r.URN)
+		} else {
+			updated = append(updated, r.URN)
+		}
+	}
+
+	detail := func(urn string) string {
+		r := diff.UpdatedResources[urn]
+		details := ""
+		diffKeys := make([]string, 0, len(r.Diffs))
+		for k := range r.Diffs {
+			diffKeys = append(diffKeys, k)
+		}
+		sort.Strings(diffKeys)
+		for _, k := range diffKeys {
+			for _, line := range renderPropertyDiff(r.Diffs[k]) {
+				details += line
+			}
+		}
+		return details
+	}
+
+	if len(updated) > 0 {
+		sort.Strings(updated)
+		listResources(b, "Updated resources", updated, detail)
+	}
+	if len(secretOnly) > 0 {
+		sort.Strings(secretOnly)
+		listResources(b, "Always re-applied (secret values can't be read back)", secretOnly, detail)
+	}
 }
 
 func listResources(b *strings.Builder, label string, resources []string, detailFn func(string) string) {
@@ -95,9 +115,25 @@ func renderPropertyRef(ref *resources.PropertyRef) string {
 	return ui.Color(ref.URN, ui.ColorGreen)
 }
 
+// renderSecret masks a secret value wherever it surfaces in a diff (e.g. nested in
+// a map that also has real changes). It is the secret analogue of renderPropertyRef:
+// the type-specific rendering lives here, dispatched from printable.
+func renderSecret(s *secret.String) string {
+	if s == nil {
+		return ui.Color("<nil>", ui.ColorBlue)
+	}
+	return ui.Color(s.String(), ui.ColorWhite)
+}
+
 func printable(val any) string {
 	if val == nil {
 		return ui.Color("<nil>", ui.ColorBlue)
+	}
+	if s, ok := val.(secret.String); ok {
+		return renderSecret(&s)
+	}
+	if s, ok := val.(*secret.String); ok {
+		return renderSecret(s)
 	}
 	if ref, ok := val.(*resources.PropertyRef); ok {
 		return renderPropertyRef(ref)
@@ -119,6 +155,13 @@ func printable(val any) string {
 
 // renderPropertyDiff renders a single property diff, either as a flat diff or expanded nested diff
 func renderPropertyDiff(diff differ.PropertyDiff) []string {
+	// A secret-only diff has no meaningful old => new — the remote value is unknown
+	// — so it is rendered by the dedicated secret helper and never enters the
+	// generic value/nested-diff path below.
+	if diff.SecretOnly {
+		return []string{renderSecretDiff(diff.Property)}
+	}
+
 	// If nested diff printing is disabled, use old behavior
 	useNestedDiffPrinting := config.GetConfig().ExperimentalFlags.NestedDiffs
 	if !useNestedDiffPrinting {
@@ -174,5 +217,17 @@ func formattedLine(property string, pair ValuePair) string {
 		printable(pair.Source),
 		ui.Color("=>", ui.ColorYellow),
 		printable(pair.Target),
+	)
+}
+
+// renderSecretDiff renders a property whose only change is a secret. The remote
+// value is unknown, so there is no old => new to show — it will be re-applied every
+// run. Mirrors renderPropertyRef: secret-specific rendering lives here, not in the
+// generic line formatter.
+func renderSecretDiff(property string) string {
+	return fmt.Sprintf(
+		"    - %s: %s\n",
+		ui.Color(property, ui.ColorWhite),
+		ui.Color("(secret, always re-applied)", ui.ColorYellow),
 	)
 }

--- a/cli/internal/syncer/reporters/plan_test.go
+++ b/cli/internal/syncer/reporters/plan_test.go
@@ -2,9 +2,11 @@ package reporters
 
 import (
 	"bytes"
+	"strings"
 	"testing"
 
 	"github.com/rudderlabs/rudder-iac/cli/internal/resources"
+	"github.com/rudderlabs/rudder-iac/cli/internal/secret"
 	"github.com/rudderlabs/rudder-iac/cli/internal/syncer/differ"
 	"github.com/rudderlabs/rudder-iac/cli/internal/syncer/planner"
 	"github.com/spf13/viper"
@@ -261,6 +263,95 @@ func TestPrintablePropertyRef(t *testing.T) {
 		assert.Contains(t, result, urn)
 		assert.NotContains(t, result, "{")
 	})
+}
+
+func TestPrintableSecret(t *testing.T) {
+	const real = "sk_live_abcd1234"
+	const masked = "****1234"
+
+	t.Run("value secret is masked", func(t *testing.T) {
+		result := printable(secret.New(real))
+		assert.Contains(t, result, masked)
+		assert.NotContains(t, result, real)
+	})
+
+	t.Run("pointer secret is masked", func(t *testing.T) {
+		s := secret.New(real)
+		result := printable(&s)
+		assert.Contains(t, result, masked)
+		assert.NotContains(t, result, real)
+	})
+
+	t.Run("unknown secret renders placeholder", func(t *testing.T) {
+		assert.Contains(t, printable(secret.NewUnknown()), "(unknown)")
+	})
+
+	t.Run("nil pointer secret renders nil", func(t *testing.T) {
+		assert.Contains(t, printable((*secret.String)(nil)), "<nil>")
+	})
+}
+
+// TestRenderPropertyDiff_Secret proves a secret diff renders as "always re-applied"
+// (no meaningful old => new) and never leaks the real value.
+func TestRenderPropertyDiff_Secret(t *testing.T) {
+	const real = "sk_live_old_1111"
+
+	t.Run("flat secret diff renders the always-re-applied annotation", func(t *testing.T) {
+		lines := renderPropertyDiff(differ.PropertyDiff{
+			Property:    "token",
+			SourceValue: secret.New(real),
+			TargetValue: secret.NewUnknown(),
+			SecretOnly:  true,
+		})
+		out := strings.Join(lines, "")
+		assert.Contains(t, out, "token")
+		assert.Contains(t, out, "(secret, always re-applied)")
+		assert.NotContains(t, out, "=>")
+		assert.NotContains(t, out, real)
+	})
+
+	// When a sibling field changes, the property diff is not secret-only, so the
+	// nested renderer renders the real change normally and the secret leaf through
+	// the generic path, where printable masks it. The "(secret, always re-applied)"
+	// line is reserved for secret-only property diffs; a secret leaked here must
+	// still never show its real value.
+	t.Run("nested diff masks a secret leaf without leaking the value", func(t *testing.T) {
+		enableNestedDiffs(t)
+		localSecret, unknown := secret.New(real), secret.NewUnknown()
+		lines := renderPropertyDiff(differ.PropertyDiff{
+			Property:    "config",
+			SourceValue: map[string]any{"token": &localSecret, "name": "a"},
+			TargetValue: map[string]any{"token": &unknown, "name": "b"},
+		})
+		out := strings.Join(lines, "")
+		assert.Contains(t, out, "config.name")
+		assert.Contains(t, out, "config.token")
+		assert.Contains(t, out, "(unknown)")
+		assert.NotContains(t, out, real)
+	})
+}
+
+// TestRenderDiff_SecretSections proves secret-only resources are listed in their own
+// "Always re-applied" section, separate from real updates, with no value leak.
+func TestRenderDiff_SecretSections(t *testing.T) {
+	diff := &differ.Diff{
+		UpdatedResources: map[string]differ.ResourceDiff{
+			"type:real": {URN: "type:real", Diffs: map[string]differ.PropertyDiff{
+				"name": {Property: "name", SourceValue: "a", TargetValue: "b"},
+			}},
+			"type:secret": {URN: "type:secret", SecretOnly: true, Diffs: map[string]differ.PropertyDiff{
+				"token": {Property: "token", SourceValue: secret.New("sk_live_x"), TargetValue: secret.NewUnknown(), SecretOnly: true},
+			}},
+		},
+	}
+
+	out := renderDiff(diff)
+	assert.Contains(t, out, "Updated resources")
+	assert.Contains(t, out, "type:real")
+	assert.Contains(t, out, "Always re-applied (secret values can't be read back)")
+	assert.Contains(t, out, "type:secret")
+	assert.Contains(t, out, "(secret, always re-applied)")
+	assert.NotContains(t, out, "sk_live_x")
 }
 
 func enableNestedDiffs(t *testing.T) {


### PR DESCRIPTION
## 🔗 Ticket

Resolves [DEX-408](https://linear.app/rudderstack/issue/DEX-408/make-the-apply-cycle-diff-secret-aware)

> ⚠️ **Stacked on #608 (DEX-407).** Base is the DEX-407 branch so the diff shows only DEX-408's work; rebase onto `main` once #608 merges.

---

## Summary

Makes the apply-cycle diff secret-aware.

**Deliberate deviation from the ticket:** the ticket asked to treat a masked/placeholder remote secret as *converged* (no diff). Because the backend never returns secret values, the remote side is *always* a placeholder, so converging would mean a changed secret could never be applied. We therefore made an **unknown** secret *always diff* (re-applied every run), surfaced in a separate "always re-applied" section and excluded from the import "not synced" check. In effect this folds the deferred DEX-412 escape-hatch into the default behaviour, and renames the "redacted" concept to "unknown".

---

## Changes

- **`secret` package:** rename redacted→unknown (`NewUnknown`, `IsUnknown`, `(unknown)` placeholder); `Diff` returns true whenever either side is unknown.
- **Differ:** secret-aware comparison; `PropertyDiff`/`ResourceDiff.SecretOnly` classification (computed once during the existing build pass) and `Diff.HasNonSecretDiff()`; `*secret.String` survives the `RawData` struct→map decode like `*PropertyRef`.
- **Reporter:** secret-only resources listed in a separate "Always re-applied (secret values can't be read back)" section, rendered via dedicated helpers (`renderSecret` / `renderSecretDiff` / `renderUpdatedResources`); the generic diff-rendering algorithm stays type-agnostic.
- **Importer:** "project not synced" guard uses `HasNonSecretDiff()` so always-re-applied secrets don't permanently block imports.
- **Fix:** `collectReferencesByReflection` skips unexported fields (was panicking on `secret.String` carried in a `RawData` struct).

---

## Testing

Unit tests, `make lint` (clean), and full `make test` (passing):

- **secret package:** every redacting surface + the flipped `Diff`.
- **differ:** secret comparison, `SecretOnly` propagation through nested maps, struct→map pointer survival, `HasNonSecretDiff`.
- **reporter:** separate section, annotation line, and masking (no real value ever printed).

No E2E added: no provider wires `secret.String` in production yet (adoption is DEX-409); this lands the framework + policy.

---

## Risk / Impact

**Low.** Inert until a provider adopts `secret.String` (DEX-409). The cross-cutting changes are the differ's `CompareData` signature (now also returns a secret-only bool — internal only, all callers updated) and the `references.go` reflection guard; both are covered by tests, and diff behaviour for non-secret data is unchanged.

---

## Checklist

- [x] Ticket linked
- [x] Tests added/updated
- [x] No breaking changes (or documented) — `CompareData` signature change is internal; all in-repo callers updated
