### PR TITLE
feat: add accounts CUD to API client

### DIFF
--- a/api/client/accounts.go
+++ b/api/client/accounts.go
@@ -11,12 +11,27 @@ type Account struct {
 	WorkspaceID string `json:"workspaceId"`
 	Name        string `json:"name"`
 	Definition  struct {
+		Name     string `json:"name"`
 		Type     string `json:"type"`
 		Category string `json:"category"`
 	} `json:"definition"`
 	Options   json.RawMessage `json:"options"`
 	CreatedAt *time.Time      `json:"createdAt,omitempty"`
 	UpdatedAt *time.Time      `json:"updatedAt,omitempty"`
+}
+
+type CreateAccountRequest struct {
+	AccountDefinitionName string          `json:"accountDefinitionName"`
+	Name                  string          `json:"name"`
+	Options               json.RawMessage `json:"options"`
+	Secret                json.RawMessage `json:"secret"`
+}
+
+// args: name, options and secret are all required; account definition name is immutable;
+type UpdateAccountRequest struct {
+	Name    string          `json:"name"`
+	Options json.RawMessage `json:"options"`
+	Secret  json.RawMessage `json:"secret"`
 }
 
 type accounts struct {
@@ -83,4 +98,26 @@ func (s *accounts) Get(ctx context.Context, id string) (*Account, error) {
 	}
 
 	return response, nil
+}
+
+func (s *accounts) Create(ctx context.Context, account *CreateAccountRequest) (*Account, error) {
+	response := &Account{}
+	if err := s.create(ctx, account, response); err != nil {
+		return nil, err
+	}
+
+	return response, nil
+}
+
+func (s *accounts) Update(ctx context.Context, id string, account *UpdateAccountRequest) (*Account, error) {
+	response := &Account{}
+	if err := s.update(ctx, id, account, response); err != nil {
+		return nil, err
+	}
+
+	return response, nil
+}
+
+func (s *accounts) Delete(ctx context.Context, id string) error {
+	return s.service.delete(ctx, id)
 }

--- a/api/client/accounts.go
+++ b/api/client/accounts.go
@@ -27,7 +27,9 @@ type CreateAccountRequest struct {
 	Secret                json.RawMessage `json:"secret"`
 }
 
-// args: name, options and secret are all required; account definition name is immutable;
+// All fields are required — PUT is a full-state replace, so a missing field means
+// "set to empty", not "leave unchanged". accountDefinitionName is immutable after
+// creation and intentionally absent.
 type UpdateAccountRequest struct {
 	Name    string          `json:"name"`
 	Options json.RawMessage `json:"options"`

--- a/api/client/accounts_test.go
+++ b/api/client/accounts_test.go
@@ -230,7 +230,7 @@ func TestClientAccountsCreate(t *testing.T) {
 		{
 			Validate: func(req *http.Request) bool {
 				return testutils.ValidateRequest(t, req, "POST", "https://api.rudderstack.com/v2/accounts", `{
-					"accountDefinitionName": "BigQuery",
+					"accountDefinitionName": "SOURCE_BIGQUERY",
 					"name": "some-name",
 					"options": { "key1": "val1" },
 					"secret": { "token": "shh" }
@@ -241,7 +241,7 @@ func TestClientAccountsCreate(t *testing.T) {
 				"id": "some-id",
 				"name": "some-name",
 				"definition": {
-					"name": "BigQuery",
+					"name": "SOURCE_BIGQUERY",
 					"type": "some-type",
 					"category": "some-category"
 				},
@@ -258,7 +258,7 @@ func TestClientAccountsCreate(t *testing.T) {
 	require.NoError(t, err)
 
 	account, err := c.Accounts.Create(ctx, &client.CreateAccountRequest{
-		AccountDefinitionName: "BigQuery",
+		AccountDefinitionName: "SOURCE_BIGQUERY",
 		Name:                  "some-name",
 		Options:               json.RawMessage([]byte(`{ "key1": "val1" }`)),
 		Secret:                json.RawMessage([]byte(`{ "token": "shh" }`)),
@@ -267,7 +267,7 @@ func TestClientAccountsCreate(t *testing.T) {
 	assert.NotNil(t, account)
 	assert.Equal(t, "some-id", account.ID)
 	assert.Equal(t, "some-name", account.Name)
-	assert.Equal(t, "BigQuery", account.Definition.Name)
+	assert.Equal(t, "SOURCE_BIGQUERY", account.Definition.Name)
 	assert.Equal(t, "some-type", account.Definition.Type)
 	assert.Equal(t, "some-category", account.Definition.Category)
 	assert.Equal(t, time.Date(2020, 1, 1, 1, 1, 1, 0, time.UTC), *account.CreatedAt)
@@ -293,7 +293,7 @@ func TestClientAccountsUpdate(t *testing.T) {
 				"id": "some-id",
 				"name": "new-name",
 				"definition": {
-					"name": "BigQuery",
+					"name": "SOURCE_BIGQUERY",
 					"type": "some-type",
 					"category": "some-category"
 				},
@@ -318,7 +318,7 @@ func TestClientAccountsUpdate(t *testing.T) {
 	assert.NotNil(t, account)
 	assert.Equal(t, "some-id", account.ID)
 	assert.Equal(t, "new-name", account.Name)
-	assert.Equal(t, "BigQuery", account.Definition.Name)
+	assert.Equal(t, "SOURCE_BIGQUERY", account.Definition.Name)
 	assert.Equal(t, "some-type", account.Definition.Type)
 	assert.Equal(t, "some-category", account.Definition.Category)
 	assert.Equal(t, time.Date(2020, 1, 1, 1, 1, 1, 0, time.UTC), *account.CreatedAt)

--- a/api/client/accounts_test.go
+++ b/api/client/accounts_test.go
@@ -2,6 +2,7 @@ package client_test
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"testing"
 	"time"
@@ -26,6 +27,7 @@ func TestClientAccountsList(t *testing.T) {
 					"id": "id-1",
 					"name": "name-1",
 					"definition": {
+						"name": "def-1",
 						"type": "type-1",
 						"category": "category-1"
 					}
@@ -75,6 +77,7 @@ func TestClientAccountsList(t *testing.T) {
 	assert.Len(t, page.Accounts, 2)
 	assert.Equal(t, "id-1", page.Accounts[0].ID)
 	assert.Equal(t, "name-1", page.Accounts[0].Name)
+	assert.Equal(t, "def-1", page.Accounts[0].Definition.Name)
 	assert.Equal(t, "type-1", page.Accounts[0].Definition.Type)
 	assert.Equal(t, "category-1", page.Accounts[0].Definition.Category)
 	assert.Equal(t, "id-2", page.Accounts[1].ID)
@@ -191,6 +194,7 @@ func TestClientAccountsGet(t *testing.T) {
 				"id": "some-id",
 				"name": "some-name",
 				"definition": {
+					"name": "some-definition-name",
 					"type": "some-type",
 					"category": "some-category"
 				},
@@ -210,10 +214,139 @@ func TestClientAccountsGet(t *testing.T) {
 	assert.NotNil(t, account)
 	assert.Equal(t, "some-id", account.ID)
 	assert.Equal(t, "some-name", account.Name)
+	assert.Equal(t, "some-definition-name", account.Definition.Name)
 	assert.Equal(t, "some-type", account.Definition.Type)
 	assert.Equal(t, "some-category", account.Definition.Category)
 	assert.Equal(t, time.Date(2020, 1, 1, 1, 1, 1, 0, time.UTC), *account.CreatedAt)
 	assert.Equal(t, time.Date(2020, 1, 2, 1, 1, 1, 0, time.UTC), *account.UpdatedAt)
+
+	httpClient.AssertNumberOfCalls()
+}
+
+func TestClientAccountsCreate(t *testing.T) {
+	ctx := context.Background()
+
+	calls := []testutils.Call{
+		{
+			Validate: func(req *http.Request) bool {
+				return testutils.ValidateRequest(t, req, "POST", "https://api.rudderstack.com/v2/accounts", `{
+					"accountDefinitionName": "BigQuery",
+					"name": "some-name",
+					"options": { "key1": "val1" },
+					"secret": { "token": "shh" }
+				}`)
+			},
+			ResponseStatus: 201,
+			ResponseBody: `{
+				"id": "some-id",
+				"name": "some-name",
+				"definition": {
+					"name": "BigQuery",
+					"type": "some-type",
+					"category": "some-category"
+				},
+				"options": { "key1": "val1" },
+				"createdAt": "2020-01-01T01:01:01Z",
+				"updatedAt": "2020-01-02T01:01:01Z"
+			}`,
+		},
+	}
+
+	httpClient := testutils.NewMockHTTPClient(t, calls...)
+
+	c, err := client.New("some-access-token", client.WithHTTPClient(httpClient))
+	require.NoError(t, err)
+
+	account, err := c.Accounts.Create(ctx, &client.CreateAccountRequest{
+		AccountDefinitionName: "BigQuery",
+		Name:                  "some-name",
+		Options:               json.RawMessage([]byte(`{ "key1": "val1" }`)),
+		Secret:                json.RawMessage([]byte(`{ "token": "shh" }`)),
+	})
+	require.NoError(t, err)
+	assert.NotNil(t, account)
+	assert.Equal(t, "some-id", account.ID)
+	assert.Equal(t, "some-name", account.Name)
+	assert.Equal(t, "BigQuery", account.Definition.Name)
+	assert.Equal(t, "some-type", account.Definition.Type)
+	assert.Equal(t, "some-category", account.Definition.Category)
+	assert.Equal(t, time.Date(2020, 1, 1, 1, 1, 1, 0, time.UTC), *account.CreatedAt)
+	assert.Equal(t, time.Date(2020, 1, 2, 1, 1, 1, 0, time.UTC), *account.UpdatedAt)
+
+	httpClient.AssertNumberOfCalls()
+}
+
+func TestClientAccountsUpdate(t *testing.T) {
+	ctx := context.Background()
+
+	calls := []testutils.Call{
+		{
+			Validate: func(req *http.Request) bool {
+				return testutils.ValidateRequest(t, req, "PUT", "https://api.rudderstack.com/v2/accounts/some-id", `{
+					"name": "new-name",
+					"options": { "key1": "val1" },
+					"secret": { "token": "shh" }
+				}`)
+			},
+			ResponseStatus: 200,
+			ResponseBody: `{
+				"id": "some-id",
+				"name": "new-name",
+				"definition": {
+					"name": "BigQuery",
+					"type": "some-type",
+					"category": "some-category"
+				},
+				"options": { "key1": "val1" },
+				"createdAt": "2020-01-01T01:01:01Z",
+				"updatedAt": "2020-01-02T01:01:01Z"
+			}`,
+		},
+	}
+
+	httpClient := testutils.NewMockHTTPClient(t, calls...)
+
+	c, err := client.New("some-access-token", client.WithHTTPClient(httpClient))
+	require.NoError(t, err)
+
+	account, err := c.Accounts.Update(ctx, "some-id", &client.UpdateAccountRequest{
+		Name:    "new-name",
+		Options: json.RawMessage([]byte(`{ "key1": "val1" }`)),
+		Secret:  json.RawMessage([]byte(`{ "token": "shh" }`)),
+	})
+	require.NoError(t, err)
+	assert.NotNil(t, account)
+	assert.Equal(t, "some-id", account.ID)
+	assert.Equal(t, "new-name", account.Name)
+	assert.Equal(t, "BigQuery", account.Definition.Name)
+	assert.Equal(t, "some-type", account.Definition.Type)
+	assert.Equal(t, "some-category", account.Definition.Category)
+	assert.Equal(t, time.Date(2020, 1, 1, 1, 1, 1, 0, time.UTC), *account.CreatedAt)
+	assert.Equal(t, time.Date(2020, 1, 2, 1, 1, 1, 0, time.UTC), *account.UpdatedAt)
+
+	httpClient.AssertNumberOfCalls()
+}
+
+func TestClientAccountsDelete(t *testing.T) {
+	ctx := context.Background()
+
+	calls := []testutils.Call{
+		{
+			Validate: func(req *http.Request) bool {
+				return testutils.ValidateRequest(t, req, "DELETE", "https://api.rudderstack.com/v2/accounts/some-id", "")
+			},
+			ResponseStatus: 204,
+			ResponseBody:   "",
+		},
+	}
+
+	httpClient := testutils.NewMockHTTPClient(t, calls...)
+
+	c, err := client.New("some-access-token", client.WithHTTPClient(httpClient))
+	require.NoError(t, err)
+
+	err = c.Accounts.Delete(ctx, "some-id")
+	require.NoError(t, err)
 
 	httpClient.AssertNumberOfCalls()
 }

--- a/cli/internal/providers/datagraph/handlers/datagraph/accounts_test.go
+++ b/cli/internal/providers/datagraph/handlers/datagraph/accounts_test.go
@@ -24,6 +24,7 @@ func TestAccountNameResolver_GetAccountName(t *testing.T) {
 			account: &client.Account{
 				Name:       "My Warehouse",
 				Definition: struct {
+					Name     string `json:"name"`
 					Type     string `json:"type"`
 					Category string `json:"category"`
 				}{Type: "SNOWFLAKE"},
@@ -39,6 +40,7 @@ func TestAccountNameResolver_GetAccountName(t *testing.T) {
 		resolver := NewAccountNameResolver(&mockAccountGetter{
 			account: &client.Account{
 				Definition: struct {
+					Name     string `json:"name"`
 					Type     string `json:"type"`
 					Category string `json:"category"`
 				}{Type: "SNOWFLAKE"},


### PR DESCRIPTION
## 🔗 Ticket

resolves [DEX-375](https://linear.app/rudderstack/issue/DEX-375/go-client-account-createupdatedelete)

---

## Summary

Extends the Go API client (`api/client/accounts.go`) with `Create`, `Update`, and `Delete` methods plus `CreateAccountRequest` / `UpdateAccountRequest` types, matching the public-API account contract delivered in rudder-control-plane (APL-408/409/410, PRs #2380 / #2379). Also adds the additive `definition.name` field to the shared `Account` struct so it is populated on Get/List/Create/Update responses.

---

## Changes

* Add `Name` to `Account.Definition` (`definition: { name, type, category }`) — additive per CONTRACT §3, shared across all account responses.
* Add `CreateAccountRequest` (§5.1): `accountDefinitionName`, `name`, `options`, `secret` (all required, no ExternalID).
* Add `UpdateAccountRequest` (§6.1): `name`, `options`, `secret` only — definition is immutable on update.
* Add `Create`, `Update(id, ...)`, and `Delete(id)` methods mirroring `sources.go`, delegating to the base `service` helpers.
* Update the datagraph account-name resolver test to include the new `Definition.Name` field (only affected downstream consumer).

---

## Testing

* Unit: new httptest-harness tests covering create (201), update (200, verifies PUT body omits `accountDefinitionName`), and delete (204); Get/List tests assert `Definition.Name` populates.
* `go test ./api/client/...` and datagraph packages pass; `make lint` clean (0 issues).

---

## Risk / Impact

Low — additive client changes; no behavioural change to existing apply cycle.

---

## Checklist

* [x] Ticket linked
* [x] Tests added/updated
* [x] No breaking changes (or documented)