### PR TITLE
feat(datagraph): add pii_mask to column-metadata CLI and client

### DIFF
--- a/api/client/datagraph/column_metadata.go
+++ b/api/client/datagraph/column_metadata.go
@@ -11,20 +11,22 @@ import (
 // DisplayName / Description are pointers so a nil value serializes as JSON `null`
 // (an explicit clear, per the declarative apply contract) rather than being
 // omitted — hence no `omitempty`. A non-nil value sets the field. At least one
-// of the two is non-nil; an empty string is invalid (use null to clear).
+// of displayName, description, or piiMask must be set on the wire.
 type ColumnMetadataEntry struct {
 	Name        string  `json:"name"`
 	DisplayName *string `json:"displayName"`
 	Description *string `json:"description"`
+	PiiMask     *bool   `json:"piiMask,omitempty"`
 }
 
 // ColumnMetadataRow is a single column-metadata row returned by the API.
 // displayName / description are omitted by the server when unset, so they
-// unmarshal to the empty string.
+// unmarshal to the empty string. piiMask is always present.
 type ColumnMetadataRow struct {
 	Name        string `json:"name"`
 	DisplayName string `json:"displayName,omitempty"`
 	Description string `json:"description,omitempty"`
+	PiiMask     bool   `json:"piiMask"`
 }
 
 // ColumnMetadataListResponse is the response from both List and BatchUpsert.

--- a/api/client/datagraph/column_metadata_test.go
+++ b/api/client/datagraph/column_metadata_test.go
@@ -350,3 +350,48 @@ func TestBatchUpsertColumnMetadata_ServerError(t *testing.T) {
 
 	httpClient.AssertNumberOfCalls()
 }
+
+// TestBatchUpsertColumnMetadata_PiiMask covers PII-only and mixed entries on
+// the wire, plus response decoding when displayName is omitted on alias-less rows.
+func TestBatchUpsertColumnMetadata_PiiMask(t *testing.T) {
+	httpClient := testutils.NewMockHTTPClient(t, testutils.Call{
+		Validate: func(req *http.Request) bool {
+			expected := `{"columns":[` +
+				`{"name":"email_address","displayName":"Email","description":null,"piiMask":true},` +
+				`{"name":"ssn","displayName":null,"description":null,"piiMask":true}` +
+				`]}`
+			return testutils.ValidateRequest(t, req, "PATCH", "https://api.rudderstack.com/v2/data-graphs/dg-123/models/em-456/column-metadata", expected)
+		},
+		ResponseStatus: 200,
+		ResponseBody: `{
+			"columns": [
+				{"name": "email_address", "displayName": "Email", "piiMask": true, "updatedAt": "2024-01-15T12:00:00Z"},
+				{"name": "ssn", "piiMask": true, "updatedAt": "2024-01-15T13:00:00Z"}
+			]
+		}`,
+	})
+
+	store := newTestStore(t, httpClient)
+
+	result, err := store.BatchUpsertColumnMetadata(
+		context.Background(),
+		"dg-123",
+		"em-456",
+		datagraph.BatchUpsertColumnMetadataRequest{
+			Columns: []datagraph.ColumnMetadataEntry{
+				{Name: "email_address", DisplayName: stringPtr("Email"), PiiMask: boolPtr(true)},
+				{Name: "ssn", DisplayName: nil, PiiMask: boolPtr(true)},
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, &datagraph.ColumnMetadataListResponse{
+		Columns: []datagraph.ColumnMetadataRow{
+			{Name: "email_address", DisplayName: "Email", PiiMask: true},
+			{Name: "ssn", PiiMask: true},
+		},
+	}, result)
+
+	httpClient.AssertNumberOfCalls()
+}

--- a/cli/internal/cmd/datagraph/validate/column_validation_test.go
+++ b/cli/internal/cmd/datagraph/validate/column_validation_test.go
@@ -174,7 +174,7 @@ spec:
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "syntax validation failed")
 
-	assert.Contains(t, out, "at least one of 'display_name' or 'description'")
+	assert.Contains(t, out, "at least one of 'display_name', 'description', or 'pii_mask'")
 	assert.Contains(t, out, "Found 1 error(s)")
 }
 

--- a/cli/internal/providers/datagraph/handlers/model/handler.go
+++ b/cli/internal/providers/datagraph/handlers/model/handler.go
@@ -267,6 +267,7 @@ func columnsFromRemote(rows []dgClient.ColumnMetadataRow) []map[string]any {
 			"name":         row.Name,
 			"display_name": row.DisplayName,
 			"description":  row.Description,
+			"pii_mask":     row.PiiMask,
 		}
 	}
 	return out
@@ -392,9 +393,10 @@ func (h *HandlerImpl) applyColumnMetadata(
 		name, _ := col["name"].(string)
 		displayName, _ := col["display_name"].(string)
 		description, _ := col["description"].(string)
+		piiMask, _ := col["pii_mask"].(bool)
 		// Declarative mapping: a field present in yaml is set; a field absent
-		// (empty here) is cleared by sending JSON null (nil pointer). The local
-		// validator guarantees at least one is non-empty.
+		// (empty here) is cleared by sending JSON null (nil pointer). pii_mask
+		// defaults to false when omitted from yaml.
 		entry := dgClient.ColumnMetadataEntry{Name: name}
 		if displayName != "" {
 			dn := displayName
@@ -404,6 +406,7 @@ func (h *HandlerImpl) applyColumnMetadata(
 			desc := description
 			entry.Description = &desc
 		}
+		entry.PiiMask = &piiMask
 		entries = append(entries, entry)
 		if name != "" {
 			localNames[name] = struct{}{}

--- a/cli/internal/providers/datagraph/handlers/model/handler_test.go
+++ b/cli/internal/providers/datagraph/handlers/model/handler_test.go
@@ -20,6 +20,8 @@ import (
 
 func strptr(s string) *string { return &s }
 
+func boolptr(b bool) *bool { return &b }
+
 func TestMapRemoteToState(t *testing.T) {
 	mockClient := &testutils.MockDataGraphClient{}
 	h := &HandlerImpl{client: mockClient}
@@ -756,8 +758,8 @@ func TestCreate_BatchUpsertColumnMetadata(t *testing.T) {
 		assert.Equal(t, "em-456", gotModelID)
 		assert.Equal(t, dgClient.BatchUpsertColumnMetadataRequest{
 			Columns: []dgClient.ColumnMetadataEntry{
-				{Name: "id", DisplayName: strptr("User ID")},
-				{Name: "email_address", DisplayName: strptr("Email")},
+				{Name: "id", DisplayName: strptr("User ID"), PiiMask: boolptr(false)},
+				{Name: "email_address", DisplayName: strptr("Email"), PiiMask: boolptr(false)},
 			},
 		}, gotReq)
 	})
@@ -847,7 +849,7 @@ func TestUpdate_BatchUpsertColumnMetadata(t *testing.T) {
 		assert.Equal(t, "dg-remote-123", gotDgID)
 		assert.Equal(t, "em-456", gotModelID)
 		assert.Equal(t, dgClient.BatchUpsertColumnMetadataRequest{
-			Columns: []dgClient.ColumnMetadataEntry{{Name: "id", DisplayName: strptr("Customer ID")}},
+			Columns: []dgClient.ColumnMetadataEntry{{Name: "id", DisplayName: strptr("Customer ID"), PiiMask: boolptr(false)}},
 		}, gotReq)
 	})
 
@@ -933,7 +935,7 @@ func TestUpdate_BatchUpsertColumnMetadata(t *testing.T) {
 
 		assert.Equal(t, 1, upsertCalls)
 		assert.Equal(t, dgClient.BatchUpsertColumnMetadataRequest{
-			Columns:       []dgClient.ColumnMetadataEntry{{Name: "id", DisplayName: strptr("User ID")}},
+			Columns:       []dgClient.ColumnMetadataEntry{{Name: "id", DisplayName: strptr("User ID"), PiiMask: boolptr(false)}},
 			DeleteColumns: []string{"email"},
 		}, gotReq)
 	})
@@ -970,8 +972,8 @@ func TestUpdate_BatchUpsertColumnMetadata(t *testing.T) {
 
 		assert.Equal(t, dgClient.BatchUpsertColumnMetadataRequest{
 			Columns: []dgClient.ColumnMetadataEntry{
-				{Name: "id", DisplayName: strptr("User ID")},
-				{Name: "phone", DisplayName: strptr("Phone")},
+				{Name: "id", DisplayName: strptr("User ID"), PiiMask: boolptr(false)},
+				{Name: "phone", DisplayName: strptr("Phone"), PiiMask: boolptr(false)},
 			},
 			// Sorted alphabetically for deterministic wire payload.
 			DeleteColumns: []string{"email", "legacy_field"},
@@ -1080,8 +1082,8 @@ func TestMapRemoteToState_PopulatesColumns(t *testing.T) {
 		resource, _, err := h.MapRemoteToState(remote, urnResolver)
 		require.NoError(t, err)
 		assert.Equal(t, []map[string]any{
-			{"name": "email", "display_name": "Email", "description": ""},
-			{"name": "id", "display_name": "User ID", "description": ""},
+			{"name": "email", "display_name": "Email", "description": "", "pii_mask": false},
+			{"name": "id", "display_name": "User ID", "description": "", "pii_mask": false},
 		}, resource.Columns)
 	})
 
@@ -1300,8 +1302,8 @@ func TestRoundTrip_ColumnsIdempotent(t *testing.T) {
 	// the test would flag a (legitimate) diff on column ordering rather than the
 	// idempotency bug under test.
 	localResource.Columns = []map[string]any{
-		{"name": "email", "display_name": "Email", "description": ""},
-		{"name": "id", "display_name": "User ID", "description": ""},
+		{"name": "email", "display_name": "Email", "description": "", "pii_mask": false},
+		{"name": "id", "display_name": "User ID", "description": "", "pii_mask": false},
 	}
 
 	// 3. Round-trip equality at the diff layer: identical Columns => no diff.
@@ -1312,4 +1314,34 @@ func TestRoundTrip_ColumnsIdempotent(t *testing.T) {
 	diffs := differ.CompareData(remoteMap, localMap)
 	assert.NotContains(t, diffs, "columns",
 		"second-apply idempotency: remote-derived Columns must match local yaml Columns so the syncer skips the BatchUpsert call")
+}
+
+func TestCreate_BatchUpsertColumnMetadata_PiiMask(t *testing.T) {
+	var gotReq dgClient.BatchUpsertColumnMetadataRequest
+
+	mockClient := &testutils.MockDataGraphClient{
+		CreateModelFunc: func(_ context.Context, req *dgClient.CreateModelRequest) (*dgClient.Model, error) {
+			return &dgClient.Model{ID: "em-456", ExternalID: req.ExternalID, Type: req.Type}, nil
+		},
+		BatchUpsertColumnMetadataFunc: func(_ context.Context, _, _ string, req dgClient.BatchUpsertColumnMetadataRequest) (*dgClient.ColumnMetadataListResponse, error) {
+			gotReq = req
+			return &dgClient.ColumnMetadataListResponse{}, nil
+		},
+	}
+
+	h := &HandlerImpl{client: mockClient}
+	data := buildModelResource(t, []map[string]any{
+		{"name": "email_address", "display_name": "Email", "pii_mask": true},
+		{"name": "ssn", "pii_mask": true},
+	})
+
+	_, err := h.Create(context.Background(), data)
+	require.NoError(t, err)
+
+	assert.Equal(t, dgClient.BatchUpsertColumnMetadataRequest{
+		Columns: []dgClient.ColumnMetadataEntry{
+			{Name: "email_address", DisplayName: strptr("Email"), PiiMask: boolptr(true)},
+			{Name: "ssn", PiiMask: boolptr(true)},
+		},
+	}, gotReq)
 }

--- a/cli/internal/providers/datagraph/model/datagraph.go
+++ b/cli/internal/providers/datagraph/model/datagraph.go
@@ -41,12 +41,13 @@ type ModelSpec struct {
 // ColumnMetadataYAML is one entry in a model's `columns:` block. Constraints
 // match the rudder-api column-metadata contract: length-bounded, trimmed, no
 // control characters, and (for display_name) case-insensitively unique within a
-// model. Each entry must set at least one of display_name / description — that
-// cross-field rule is enforced by the spec validator, not struct tags.
+// model. Each entry must set at least one of display_name, description, or
+// pii_mask — that cross-field rule is enforced by the spec validator, not struct tags.
 type ColumnMetadataYAML struct {
 	Name        string `json:"name" yaml:"name" mapstructure:"name" validate:"required,max=255"`
 	DisplayName string `json:"display_name,omitempty" yaml:"display_name,omitempty" mapstructure:"display_name" validate:"omitempty,max=255"`
 	Description string `json:"description,omitempty" yaml:"description,omitempty" mapstructure:"description" validate:"omitempty,max=255"`
+	PiiMask     *bool  `json:"pii_mask,omitempty" yaml:"pii_mask,omitempty" mapstructure:"pii_mask"`
 }
 
 // RelationshipSpec represents configuration for relationships from YAML

--- a/cli/internal/providers/datagraph/provider.go
+++ b/cli/internal/providers/datagraph/provider.go
@@ -262,10 +262,15 @@ func columnsFromSpec(specColumns []dgModel.ColumnMetadataYAML) []map[string]any 
 	})
 	out := make([]map[string]any, len(sorted))
 	for i, c := range sorted {
+		piiMask := false
+		if c.PiiMask != nil {
+			piiMask = *c.PiiMask
+		}
 		out[i] = map[string]any{
 			"name":         c.Name,
 			"display_name": c.DisplayName,
 			"description":  c.Description,
+			"pii_mask":     piiMask,
 		}
 	}
 	return out
@@ -560,6 +565,10 @@ func columnsForExport(rows []dgClient.ColumnMetadataRow) []dgModel.ColumnMetadat
 			Name:        row.Name,
 			DisplayName: row.DisplayName,
 			Description: row.Description,
+		}
+		if row.PiiMask {
+			piiMask := true
+			out[i].PiiMask = &piiMask
 		}
 	}
 	return out

--- a/cli/internal/providers/datagraph/provider_export_test.go
+++ b/cli/internal/providers/datagraph/provider_export_test.go
@@ -400,7 +400,7 @@ func TestFormatForExport_IncludesColumnsBlock(t *testing.T) {
 						PrimaryID:   "user_id",
 					},
 					Columns: []dgClient.ColumnMetadataRow{
-						{Name: "email", DisplayName: "Email"},
+						{Name: "email", DisplayName: "Email", PiiMask: true},
 						{Name: "user_id", DisplayName: "User ID"},
 					},
 				},
@@ -439,8 +439,9 @@ func TestFormatForExport_IncludesColumnsBlock(t *testing.T) {
 	}
 
 	// User has column metadata — the block is emitted in remote order.
+	piiMask := true
 	assert.Equal(t, []dgModel.ColumnMetadataYAML{
-		{Name: "email", DisplayName: "Email"},
+		{Name: "email", DisplayName: "Email", PiiMask: &piiMask},
 		{Name: "user_id", DisplayName: "User ID"},
 	}, byID["user"].Columns)
 

--- a/cli/internal/providers/datagraph/provider_test.go
+++ b/cli/internal/providers/datagraph/provider_test.go
@@ -427,8 +427,8 @@ func TestLoadSpec_ColumnsOrderIdempotent(t *testing.T) {
 	// the shape directly here keeps the test self-contained and decoupled
 	// from the unexported handler client field.
 	remoteShapeColumns := []map[string]any{
-		{"name": "email", "display_name": "Email", "description": ""},
-		{"name": "user_id", "display_name": "User ID", "description": ""},
+		{"name": "email", "display_name": "Email", "description": "", "pii_mask": false},
+		{"name": "user_id", "display_name": "User ID", "description": "", "pii_mask": false},
 	}
 	remoteShape := *localModel
 	remoteShape.Columns = remoteShapeColumns

--- a/cli/internal/providers/datagraph/rules/datagraph_columns_valid_test.go
+++ b/cli/internal/providers/datagraph/rules/datagraph_columns_valid_test.go
@@ -118,6 +118,44 @@ func TestDataGraphSpecSyntaxValid_ColumnsValid(t *testing.T) {
 			},
 		},
 		{
+			name: "column with pii_mask only (no display_name)",
+			spec: dgModel.DataGraphSpec{
+				ID:        "my-dg",
+				AccountID: "wh-123",
+				Models: []dgModel.ModelSpec{
+					{
+						ID:          "user",
+						DisplayName: "User",
+						Type:        "entity",
+						Table:       "db.schema.users",
+						PrimaryID:   "id",
+						Columns: []dgModel.ColumnMetadataYAML{
+							{Name: "ssn", PiiMask: boolPtr(true)},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "column with display_name and pii_mask",
+			spec: dgModel.DataGraphSpec{
+				ID:        "my-dg",
+				AccountID: "wh-123",
+				Models: []dgModel.ModelSpec{
+					{
+						ID:          "user",
+						DisplayName: "User",
+						Type:        "entity",
+						Table:       "db.schema.users",
+						PrimaryID:   "id",
+						Columns: []dgModel.ColumnMetadataYAML{
+							{Name: "email_address", DisplayName: "Email", PiiMask: boolPtr(true)},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "two description-only columns do not collide (no description uniqueness)",
 			spec: dgModel.DataGraphSpec{
 				ID:        "my-dg",
@@ -255,7 +293,7 @@ func TestDataGraphSpecSyntaxValid_ColumnsInvalid(t *testing.T) {
 			expectedMsgSubstrings: []string{"'name' is required"},
 		},
 		{
-			name: "column with neither display_name nor description",
+			name: "column with neither display_name, description, nor pii_mask",
 			spec: dgModel.DataGraphSpec{
 				ID:        "my-dg",
 				AccountID: "wh-123",
@@ -264,7 +302,7 @@ func TestDataGraphSpecSyntaxValid_ColumnsInvalid(t *testing.T) {
 				},
 			},
 			expectedRefs:          []string{"/models/0/columns/0"},
-			expectedMsgSubstrings: []string{"at least one of 'display_name' or 'description'"},
+			expectedMsgSubstrings: []string{"at least one of 'display_name', 'description', or 'pii_mask'"},
 		},
 		{
 			name: "column missing name (with description set)",
@@ -633,4 +671,40 @@ func TestModelSpec_ColumnsMapstructure(t *testing.T) {
 		},
 	}
 	assert.Equal(t, expected, decoded)
+}
+
+func boolPtr(b bool) *bool { return &b }
+
+func TestModelSpec_ColumnsYAMLRoundTrip_PiiMask(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`id: user
+display_name: User
+type: entity
+table: db.schema.users
+primary_id: id
+columns:
+  - name: email_address
+    display_name: Email
+    pii_mask: true
+  - name: ssn
+    pii_mask: true
+`)
+
+	var parsed dgModel.ModelSpec
+	require.NoError(t, yaml.Unmarshal(input, &parsed))
+
+	piiTrue := true
+	expected := dgModel.ModelSpec{
+		ID:          "user",
+		DisplayName: "User",
+		Type:        "entity",
+		Table:       "db.schema.users",
+		PrimaryID:   "id",
+		Columns: []dgModel.ColumnMetadataYAML{
+			{Name: "email_address", DisplayName: "Email", PiiMask: &piiTrue},
+			{Name: "ssn", PiiMask: &piiTrue},
+		},
+	}
+	assert.Equal(t, expected, parsed)
 }

--- a/cli/internal/providers/datagraph/rules/datagraph_spec_valid.go
+++ b/cli/internal/providers/datagraph/rules/datagraph_spec_valid.go
@@ -99,10 +99,10 @@ var validateDataGraphSpec = func(_ string, _ string, _ map[string]any, spec dgMo
 
 // validateModelColumns enforces the per-column constraints that can't be
 // expressed via struct tags: trimmed values, no control characters in
-// display_name / description, the "at least one of display_name or description"
-// rule, in-model uniqueness of `name`, and case-insensitive uniqueness of
-// `display_name` (description has no uniqueness rule). max=255 is handled
-// upstream by struct-tag validation.
+// display_name / description, the "at least one of display_name, description,
+// or pii_mask" rule, in-model uniqueness of `name`, and case-insensitive
+// uniqueness of `display_name` (description has no uniqueness rule). max=255 is
+// handled upstream by struct-tag validation.
 func validateModelColumns(modelIdx int, columns []dgModel.ColumnMetadataYAML) []rules.ValidationResult {
 	if len(columns) == 0 {
 		return nil
@@ -126,10 +126,11 @@ func validateModelColumns(modelIdx int, columns []dgModel.ColumnMetadataYAML) []
 			})
 		}
 
-		if col.DisplayName == "" && col.Description == "" {
+		piiMask := col.PiiMask != nil && *col.PiiMask
+		if col.DisplayName == "" && col.Description == "" && !piiMask {
 			results = append(results, rules.ValidationResult{
 				Reference: base,
-				Message:   "each column must set at least one of 'display_name' or 'description'",
+				Message:   "each column must set at least one of 'display_name', 'description', or 'pii_mask'",
 			})
 		}
 


### PR DESCRIPTION
## Specs
https://github.com/rudderlabs/rudder-specs/pull/64

## Summary
- Adds `pii_mask` to the data-graph yaml `columns:` block, API client types, and declarative apply/import/validate flow so CLI-managed column metadata matches the rudder-api `piiMask` contract.
- Each column entry may now set `display_name`, `description`, and/or `pii_mask`; alias-less PII-only rows (`pii_mask: true` with no alias) are supported end-to-end.

## Tests run

| Layer | Scenario | Command / setup | Expected | Result |
|-------|----------|-----------------|----------|--------|
| **Unit — API client** | `TestBatchUpsertColumnMetadata_PiiMask` | `go test ./api/client/datagraph/...` | Wire body carries `piiMask:true` for alias + alias-less entries; response decodes `piiMask` and omitted `displayName` on PII-only rows | Pass |
| **Unit — handler** | `TestCreate_BatchUpsertColumnMetadata_PiiMask` | `go test ./cli/internal/providers/datagraph/handlers/model/...` | Declarative apply maps yaml `pii_mask` → `PiiMask` on PATCH entries | Pass |
| **Unit — rules** | `TestDataGraphSpecSyntaxValid_ColumnsValid` (PII cases) | `go test ./cli/internal/providers/datagraph/rules/...` | `pii_mask`-only and `display_name` + `pii_mask` entries validate locally | Pass |
| **Unit — rules** | `TestDataGraphSpecSyntaxValid_ColumnsInvalid` (name-only) | same | Entry with only `name` rejected | Pass |
| **Unit — rules** | `TestModelSpec_ColumnsYAMLRoundTrip_PiiMask` | same | Yaml `pii_mask: true` round-trips through struct tags | Pass |
| **Unit — export** | `TestFormatForExport_IncludesColumnsBlock` | `go test ./cli/internal/providers/datagraph/...` | Import yaml emits `pii_mask: true` when server row has `piiMask` | Pass |
| **Unit — all datagraph** | Full provider + client suite | `go test ./api/client/datagraph/... ./cli/internal/providers/datagraph/...` | All packages green | Pass |
| **E2E — rudder-api (A8)** | PATCH alias + PII-only rows | mini stack + rudder-api worktree on `:15555` | 200; `piiMask` on every list row; alias-less row omits `displayName` | Pass |
| **E2E — rudder-api (A8)** | LIST after PATCH | curl `GET .../column-metadata` | `piiMask` always present | Pass |
| **E2E — rudder-api (A8)** | Entry with neither `displayName` nor `piiMask` | curl `PATCH` with `{"columns":[{"name":"email"}]}` | 400 (public Zod schema) | Pass |
| **E2E — rudder-api (A8)** | `piiMask`-only entry | curl `PATCH` with `{"columns":[{"name":"country","piiMask":true}]}` | 200 | Pass |
| **E2E — CLI (C9)** | `validate` | `rudder-cli validate -l <fixture>` | Passes for PII-only + alias+PII yaml | Pass |
| **E2E — CLI (C9)** | First `apply` | `rudder-cli apply --confirm=false` via stub proxy `:15556 → :15555` | PATCH carries `piiMask:true`; model updated | Pass |
| **E2E — CLI (C9)** | Re-apply idempotency | second `apply` | `No changes to apply` | Pass |
| **E2E — CLI (C9)** | `import workspace` | `rudder-cli import workspace` | Yaml reproduces `pii_mask: true` and alias-less PII column | Pass |
| **E2E — CLI (C9)** | Local validate (name-only) | `validate` on invalid fixture | Error: must set `display_name`, `description`, or `pii_mask` | Pass |
| **E2E — CLI (C9)** | Declarative removal | Drop PII-only column from yaml + `apply` | Server row removed (`country` gone, `email` kept) | Pass |

Companion PR for the public API layer: https://github.com/rudderlabs/rudder-control-plane/pull/2378

## Linear Ticket

https://linear.app/rudderstack/issue/PRO-5737/audiences-column-pii-mask-data-graph-metadata