### PR TITLE
feat(varsubst): require .vars.yaml or .vars.yml suffix for all var files

### DIFF
--- a/cli/internal/app/options_test.go
+++ b/cli/internal/app/options_test.go
@@ -27,7 +27,7 @@ func setExperimental(t *testing.T, enabled bool) {
 
 func writeVarFile(t *testing.T, content string) string {
 	t.Helper()
-	path := filepath.Join(t.TempDir(), "vars.yaml")
+	path := filepath.Join(t.TempDir(), "config.vars.yaml")
 	require.NoError(t, os.WriteFile(path, []byte(content), 0644))
 	return path
 }
@@ -60,12 +60,23 @@ func TestNewProjectOptions(t *testing.T) {
 
 	t.Run("missing var file surfaces ErrVarFileNotFound", func(t *testing.T) {
 		setExperimental(t, true)
-		path := filepath.Join(t.TempDir(), "missing.yaml")
+		path := filepath.Join(t.TempDir(), "missing.vars.yaml")
 
 		opts, err := NewProjectOptions(config.GetConfig(), []string{path})
 		require.Error(t, err)
 		assert.Nil(t, opts)
 		assert.ErrorIs(t, err, resolver.ErrVarFileNotFound)
+	})
+
+	t.Run("var file without .vars.yaml suffix surfaces ErrVarFileInvalidName", func(t *testing.T) {
+		setExperimental(t, true)
+		path := filepath.Join(t.TempDir(), "plain.yaml")
+		require.NoError(t, os.WriteFile(path, []byte("FOO: bar"), 0644))
+
+		opts, err := NewProjectOptions(config.GetConfig(), []string{path})
+		require.Error(t, err)
+		assert.Nil(t, opts)
+		assert.ErrorIs(t, err, resolver.ErrVarFileInvalidName)
 	})
 
 	t.Run("invalid var file surfaces ErrVarFileParseFailed", func(t *testing.T) {
@@ -105,8 +116,8 @@ func TestBuildSubstitutor_ResolverChain(t *testing.T) {
 
 	t.Run("later var file wins over earlier var file", func(t *testing.T) {
 		dir := t.TempDir()
-		path1 := filepath.Join(dir, "first.yaml")
-		path2 := filepath.Join(dir, "second.yaml")
+		path1 := filepath.Join(dir, "first.vars.yaml")
+		path2 := filepath.Join(dir, "second.vars.yaml")
 		require.NoError(t, os.WriteFile(path1, []byte("X: first"), 0644))
 		require.NoError(t, os.WriteFile(path2, []byte("X: second"), 0644))
 

--- a/cli/internal/cmd/project/apply/apply.go
+++ b/cli/internal/cmd/project/apply/apply.go
@@ -131,7 +131,7 @@ func NewCmdApply() *cobra.Command {
 	cmd.Flags().StringVarP(&location, "location", "l", ".", "Path to the directory containing the project files or a specific file")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Only show the changes without applying them")
 	cmd.Flags().BoolVar(&confirm, "confirm", true, "Confirm changes before applying them")
-	cmd.Flags().StringArrayVar(&varFiles, "var-file", nil, "Path to a YAML file with variables for substitution (repeatable; later files take priority)")
+	cmd.Flags().StringArrayVar(&varFiles, "var-file", nil, "Path to a variable file ending in .vars.yaml or .vars.yml (repeatable; later files take priority)")
 
 	return cmd
 }

--- a/cli/internal/cmd/project/migrate/migrate.go
+++ b/cli/internal/cmd/project/migrate/migrate.go
@@ -75,7 +75,7 @@ func NewCmdMigrate() *cobra.Command {
 
 	cmd.Flags().StringVarP(&location, "location", "l", ".", "Path to the directory containing the project files or a specific file")
 	cmd.Flags().BoolVar(&confirm, "confirm", true, "Confirm migration before proceeding")
-	cmd.Flags().StringArrayVar(&varFiles, "var-file", nil, "Path to a YAML file with variables for substitution (repeatable; later files take priority)")
+	cmd.Flags().StringArrayVar(&varFiles, "var-file", nil, "Path to a variable file ending in .vars.yaml or .vars.yml (repeatable; later files take priority)")
 
 	return cmd
 }

--- a/cli/internal/cmd/project/validate/validate.go
+++ b/cli/internal/cmd/project/validate/validate.go
@@ -79,6 +79,6 @@ func NewCmdValidate() *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&location, "location", "l", ".", "Path to the directory containing the project files or a specific file")
-	cmd.Flags().StringArrayVar(&varFiles, "var-file", nil, "Path to a YAML file with variables for substitution (repeatable; later files take priority)")
+	cmd.Flags().StringArrayVar(&varFiles, "var-file", nil, "Path to a variable file ending in .vars.yaml or .vars.yml (repeatable; later files take priority)")
 	return cmd
 }

--- a/cli/internal/varsubst/README.md
+++ b/cli/internal/varsubst/README.md
@@ -184,11 +184,12 @@ Rules for variable files:
   rejected (`DB: { HOST: x }` or `HOSTS: [a, b]` cause an error).
 - **No null/empty values.** `KEY:` or `KEY: null` is rejected. To set an empty value, use
   explicit empty quotes: `KEY: ""`.
-- **Inside the project directory, the file must be named `<name>.vars.yaml`** (or
-  `<name>.vars.yml`). The project loader treats every other YAML file in the project
-  directory as a resource spec — a stray `staging.yaml` var file would fail loading with a
-  spec parse error. The `.vars.yaml` suffix tells the loader to skip the file. Var files
-  kept *outside* the project directory can be named anything.
+- **The file must be named `<name>.vars.yaml`** (or `<name>.vars.yml`) — always, whether it
+  lives inside or outside the project directory. `--var-file` rejects any other path with a
+  `variable file must use the .vars.yaml or .vars.yml suffix` error. Inside the project
+  directory the suffix does double duty: the loader skips `.vars.yaml`/`.vars.yml` files
+  rather than treating them as resource specs, so a stray `staging.yaml` var file would fail
+  loading with a spec parse error.
 - Comments (`#`) and blank lines are fine.
 - Paths are resolved relative to your current working directory.
 
@@ -262,6 +263,7 @@ error[project/var-substitution]: undefined variable "DB_PASSWORD"
 | `undefined variable` | `{{ .VAR }}` not found in env vars or var files, and no default given. |
 | `invalid variable syntax` | Malformed token, e.g. missing dot (`{{ VAR }}`) or an invalid name (`{{ .1A }}`). |
 | `variable file not found` | A `--var-file` path does not exist. |
+| `variable file must use the .vars.yaml or .vars.yml suffix` | A `--var-file` path does not end in `.vars.yaml`/`.vars.yml`. |
 | `failed to parse variable file` | The file is invalid YAML, has nested values, or has a null/empty value. |
 
 When any spec has a substitution error, nothing is applied — the original specs are left

--- a/cli/internal/varsubst/resolver/errors.go
+++ b/cli/internal/varsubst/resolver/errors.go
@@ -10,4 +10,10 @@ var (
 	// as a flat YAML map of scalar values (e.g. invalid YAML, nested map/array,
 	// or a nil value).
 	ErrVarFileParseFailed = errors.New("variable file parse failed")
+
+	// ErrVarFileInvalidName is returned when a variable file path does not end in
+	// the required .vars.yaml or .vars.yml suffix. The suffix is mandatory for
+	// every var file, including those passed via --var-file from outside the
+	// project directory.
+	ErrVarFileInvalidName = errors.New("variable file must use the .vars.yaml or .vars.yml suffix")
 )

--- a/cli/internal/varsubst/resolver/file_resolver.go
+++ b/cli/internal/varsubst/resolver/file_resolver.go
@@ -3,12 +3,26 @@ package resolver
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
 
+const (
+	// VarFileSuffixYAML and VarFileSuffixYML are the suffixes a variable file must
+	// end in. The requirement holds for every var file, whether it lives inside
+	// the project directory or is passed via --var-file from elsewhere.
+	VarFileSuffixYAML = ".vars.yaml"
+	VarFileSuffixYML  = ".vars.yml"
+)
+
 type fileResolver struct {
 	vars map[string]string
+}
+
+// hasVarFileSuffix reports whether path ends in one of the required var-file suffixes.
+func hasVarFileSuffix(path string) bool {
+	return strings.HasSuffix(path, VarFileSuffixYAML) || strings.HasSuffix(path, VarFileSuffixYML)
 }
 
 // NewFileResolver loads variables from a flat YAML file whose top-level keys
@@ -18,7 +32,14 @@ type fileResolver struct {
 // explicit null (`KEY: null`) returns ErrVarFileParseFailed — setting null
 // values is not supported. To represent an empty value, use empty quotes:
 // `KEY: ""`.
+//
+// The path must end in .vars.yaml or .vars.yml; otherwise ErrVarFileInvalidName
+// is returned. This is checked before the file is read.
 func NewFileResolver(path string) (Resolver, error) {
+	if !hasVarFileSuffix(path) {
+		return nil, fmt.Errorf("%w: %s", ErrVarFileInvalidName, path)
+	}
+
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/cli/internal/varsubst/resolver/file_resolver_test.go
+++ b/cli/internal/varsubst/resolver/file_resolver_test.go
@@ -11,7 +11,7 @@ import (
 
 func writeVarFile(t *testing.T, content string) string {
 	t.Helper()
-	path := filepath.Join(t.TempDir(), "vars.yaml")
+	path := filepath.Join(t.TempDir(), "config.vars.yaml")
 	require.NoError(t, os.WriteFile(path, []byte(content), 0644))
 	return path
 }
@@ -71,7 +71,7 @@ func TestNewFileResolver(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var path string
 			if tt.noFile {
-				path = filepath.Join(t.TempDir(), "nonexistent.yaml")
+				path = filepath.Join(t.TempDir(), "nonexistent.vars.yaml")
 			} else {
 				path = writeVarFile(t, tt.content)
 			}
@@ -82,6 +82,37 @@ func TestNewFileResolver(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 			}
+		})
+	}
+}
+
+func TestNewFileResolver_NameSuffix(t *testing.T) {
+	tests := []struct {
+		name     string
+		fileName string
+		wantErr  error
+	}{
+		{name: ".vars.yaml accepted", fileName: "config.vars.yaml"},
+		{name: ".vars.yml accepted", fileName: "config.vars.yml"},
+		{name: "plain .yaml rejected", fileName: "config.yaml", wantErr: ErrVarFileInvalidName},
+		{name: "plain .yml rejected", fileName: "config.yml", wantErr: ErrVarFileInvalidName},
+		{name: "bare vars.yaml (no dot) rejected", fileName: "vars.yaml", wantErr: ErrVarFileInvalidName},
+		{name: "no extension rejected", fileName: "config", wantErr: ErrVarFileInvalidName},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// The file content and existence are valid; only the name varies, so a
+			// failure can only come from the suffix check.
+			path := filepath.Join(t.TempDir(), tt.fileName)
+			require.NoError(t, os.WriteFile(path, []byte("FOO: bar"), 0644))
+
+			_, err := NewFileResolver(path)
+			if tt.wantErr != nil {
+				assert.ErrorIs(t, err, tt.wantErr)
+				return
+			}
+			assert.NoError(t, err)
 		})
 	}
 }


### PR DESCRIPTION
> **Stacked on #623 (DEX-428).** Base is the `feature/dex-428-…` branch so the diff shows only the suffix change; retarget to `main` once #623 merges.

## 🔗 Ticket

Resolves [DEX-429](https://linear.app/rudderstack/issue/DEX-429)

---

## Summary

Make the `.vars.yaml` / `.vars.yml` suffix a hard requirement for **every** variable file — not just those inside the project directory. Previously the suffix was only enforced implicitly for in-project files (the loader skips them); var files passed via `--var-file` from outside the project could be named anything. Now `--var-file` rejects any path that doesn't end in `.vars.yaml` or `.vars.yml`.

---

## Changes

- `resolver.NewFileResolver` validates the path suffix **before** reading the file and returns a new sentinel `ErrVarFileInvalidName` when it doesn't end in `.vars.yaml`/`.vars.yml` (suffix constants `VarFileSuffixYAML`/`VarFileSuffixYML`).
- Updated the `--var-file` help text on `apply`, `validate`, and `migrate` to state the requirement.
- Documented the rule in the varsubst README (the "Variable files" rules + the error table) and removed the now-stale "outside the project directory can be named anything" note.
- Added unit tests for the suffix rule (`resolver` + `app/options`) and updated existing fixtures to compliant names.

---

## Testing

- `make build`, `make lint` (0 issues), and unit tests for `varsubst/resolver`, `app`, and the project commands pass.
- Verified with the built binary: `validate --var-file plain.yaml` is rejected with `variable file must use the .vars.yaml or .vars.yml suffix`; `--var-file config.vars.yaml` is accepted.

---

## Risk / Impact

**Low.** The check only applies to `--var-file` inputs, which are consumed only when variable substitution (an experimental, off-by-default feature) is enabled. Existing compliant var files — e.g. the import-scaffolded `secrets.vars.yaml` — are unaffected.

---

## Checklist

- [x] Ticket linked
- [x] Tests added/updated
- [x] No breaking changes (stricter validation, gated behind the experimental var-substitution feature)
