### PR TITLE
feat(typer): TS key remap via SerialName + runtime applyKeyMap (DAW-3732) [Option 1 of 2]

### DIFF
--- a/cli/internal/typer/generator/platforms/typescript/context.go
+++ b/cli/internal/typer/generator/platforms/typescript/context.go
@@ -10,6 +10,12 @@ type TSInterfaceProperty struct {
 	// JSON key has characters like spaces or `-` that aren't valid in
 	// identifier syntax). The template emits `"name"?: T` in that case.
 	QuotedName bool
+	// SerialName is the ORIGINAL tracking-plan key (e.g. "product_id") that this
+	// property maps to on the wire. Name may be camelCased (e.g. "productId")
+	// for an ergonomic interface, but the payload sent to the SDK must use
+	// SerialName so it matches the tracking plan. Mirrors Swift's SerialName
+	// field and Kotlin's put("first_name", ...) — see DAW-3732.
+	SerialName string
 }
 
 // TSInterface → export interface X { ... }
@@ -17,6 +23,33 @@ type TSInterface struct {
 	Name       string
 	Comment    string
 	Properties []TSInterfaceProperty
+}
+
+// TSKeyMapEntry is one camelCase→serial mapping inside a per-interface key map.
+//
+// When the wire key equals the interface field name (no camelCasing happened),
+// no entry is emitted — the runtime remap leaves such keys untouched.
+type TSKeyMapEntry struct {
+	// FieldName is the camelCase interface property name used as the object key
+	// at runtime (the left-hand side of the generated map literal).
+	FieldName string
+	// SerialName is the original tracking-plan key emitted on the wire.
+	SerialName string
+	// NestedMapName, when non-empty, is the name of another generated key map
+	// (e.g. "UserSignedUpContextKeyMap") whose value must be remapped
+	// recursively. This carries nested-object remapping the same way Swift's
+	// nested toProperties() does.
+	NestedMapName string
+}
+
+// TSKeyMap is a per-interface map from camelCase field names back to the
+// original tracking-plan keys, emitted as
+// `const <Name>: Record<string, KeyMapValue> = { ... }`. Only interfaces with
+// at least one renamed key (or a nested object that itself needs remapping)
+// produce a map — see collectKeyMaps.
+type TSKeyMap struct {
+	Name    string // e.g. "UserSignedUpKeyMap"
+	Entries []TSKeyMapEntry
 }
 
 // TSTypeAlias → export type Alias = Type;
@@ -74,6 +107,12 @@ type TSAnalyticsMethod struct {
 	SDKArguments    []TSSDKArgument
 	Overloads       []TSOverloadSignature
 	DispatcherBranches []TSDispatcherBranch
+	// PropsKeyMapName is the name of the key map applied to the props/traits
+	// object before the SDK call (e.g. "UserSignedUpKeyMap"). Empty when the
+	// event's interface needs no remapping — in that case props are forwarded
+	// verbatim. Currently wired for track methods (the canonical case); see the
+	// nested-object note in the PR body for the limitation on identify/group/page.
+	PropsKeyMapName string
 }
 
 // TSVariantGroup groups the case interfaces and union type alias for one
@@ -103,6 +142,13 @@ type TSContext struct {
 	// Interfaces holds top-level event interfaces (track props, identify traits).
 	Interfaces       []TSInterface
 	AnalyticsMethods []TSAnalyticsMethod
+	// KeyMaps holds the per-interface camelCase→serial-name maps emitted as
+	// `const <Interface>KeyMap` constants. Populated by collectKeyMaps after all
+	// interfaces are built. Only interfaces needing remap appear here.
+	KeyMaps []TSKeyMap
+	// UsesApplyKeyMap is true when at least one method remaps its props, so the
+	// generated file needs the shared applyKeyMap runtime helper.
+	UsesApplyKeyMap bool
 	// EventContext is the ruddertyper provenance map injected into every event's
 	// options.context. Values are pre-formatted TS literal expressions.
 	EventContext        map[string]string

--- a/cli/internal/typer/generator/platforms/typescript/generator.go
+++ b/cli/internal/typer/generator/platforms/typescript/generator.go
@@ -74,6 +74,12 @@ func (g *Generator) Generate(p *plan.TrackingPlan, opts core.GenerateOptions, pl
 		return nil, err
 	}
 
+	// Key maps are built once all interfaces exist so nested references can be
+	// resolved to a fixed point. wireTrackKeyMaps then points each track method
+	// at its map (mirrors Swift carrying SerialName through toProperties).
+	needsMap := collectKeyMaps(ctx)
+	wireTrackKeyMaps(ctx, needsMap)
+
 	file, err := GenerateFile(outputFileName, ctx)
 	if err != nil {
 		return nil, err
@@ -749,6 +755,7 @@ func buildInterfaceWithNested(name, comment string, schema *plan.ObjectSchema, c
 			Comment:    propSchema.Property.Description,
 			Optional:   !propSchema.Required,
 			QuotedName: quoted,
+			SerialName: propName,
 		})
 	}
 
@@ -829,6 +836,7 @@ func buildInterfaceFromSchema(name, comment string, schema *plan.ObjectSchema, n
 			Comment:    propSchema.Property.Description,
 			Optional:   !propSchema.Required,
 			QuotedName: quoted,
+			SerialName: propName,
 		})
 	}
 

--- a/cli/internal/typer/generator/platforms/typescript/keymap.go
+++ b/cli/internal/typer/generator/platforms/typescript/keymap.go
@@ -1,0 +1,219 @@
+package typescript
+
+import (
+	"sort"
+	"strings"
+)
+
+// keyMapSuffix is appended to an interface name to form its generated key-map
+// constant, e.g. "UserSignedUp" → "UserSignedUpKeyMap".
+const keyMapSuffix = "KeyMap"
+
+// collectKeyMaps walks every generated interface and emits a per-interface
+// camelCase→serial-name key map (TSKeyMap) for those that actually need one.
+//
+// An interface needs a map when at least one of its properties either:
+//   - renames its wire key (camelCase Name differs from SerialName), or
+//   - references another interface that itself needs a map (so the nested
+//     object's keys get remapped recursively — mirroring Swift's nested
+//     toProperties()).
+//
+// Maps are attached to ctx.KeyMaps (sorted by name for deterministic output)
+// and the set of interface names that have a map is returned so callers can
+// decide whether a method's props need remapping. This is the single source of
+// truth for "does interface X need remapping".
+func collectKeyMaps(ctx *TSContext) map[string]bool {
+	interfaces := allInterfaces(ctx)
+
+	// byName lets property-type resolution find a referenced interface. Names of
+	// interfaces that need a map is computed to a fixed point below, since a
+	// parent needs a map if a child does.
+	byName := make(map[string]*TSInterface, len(interfaces))
+	for i := range interfaces {
+		byName[interfaces[i].Name] = interfaces[i]
+	}
+
+	needsMap := make(map[string]bool)
+	// Fixed-point iteration: repeat until no interface flips to "needs map".
+	// Bounded by the number of interfaces (each pass can only add flags).
+	for {
+		changed := false
+		for name, iface := range byName {
+			if needsMap[name] {
+				continue
+			}
+			if interfaceNeedsMap(iface, needsMap) {
+				needsMap[name] = true
+				changed = true
+			}
+		}
+		if !changed {
+			break
+		}
+	}
+
+	maps := make([]TSKeyMap, 0, len(needsMap))
+	for _, iface := range interfaces {
+		if !needsMap[iface.Name] {
+			continue
+		}
+		maps = append(maps, buildKeyMap(iface, needsMap))
+	}
+
+	ctx.KeyMaps = orderKeyMaps(maps)
+	return needsMap
+}
+
+// orderKeyMaps returns the maps ordered so that every map appears after the
+// maps it references. TS `const` initializers run at module load, so a nested
+// reference to a map defined later would hit the temporal dead zone — emitting
+// dependencies first avoids that. Within a dependency tier the order is
+// alphabetical for deterministic output.
+func orderKeyMaps(maps []TSKeyMap) []TSKeyMap {
+	byName := make(map[string]TSKeyMap, len(maps))
+	names := make([]string, 0, len(maps))
+	for _, m := range maps {
+		byName[m.Name] = m
+		names = append(names, m.Name)
+	}
+	sort.Strings(names)
+
+	var (
+		ordered  []TSKeyMap
+		emitted  = make(map[string]bool)
+		visiting = make(map[string]bool)
+		visit    func(name string)
+	)
+	visit = func(name string) {
+		if emitted[name] || visiting[name] {
+			return // visiting guard also breaks any (unexpected) cycle
+		}
+		m, ok := byName[name]
+		if !ok {
+			return
+		}
+		visiting[name] = true
+		for _, e := range m.Entries {
+			if e.NestedMapName != "" {
+				visit(e.NestedMapName)
+			}
+		}
+		visiting[name] = false
+		emitted[name] = true
+		ordered = append(ordered, m)
+	}
+	for _, name := range names {
+		visit(name)
+	}
+	return ordered
+}
+
+// wireTrackKeyMaps points each track method at the key map for its typed props
+// interface, rewriting the props SDK argument to route through applyKeyMap so
+// the wire payload uses original plan keys. Methods whose interface needs no
+// remap (or whose props are an open Record, not a typed interface) are left
+// forwarding props verbatim.
+func wireTrackKeyMaps(ctx *TSContext, needsMap map[string]bool) {
+	for mi := range ctx.AnalyticsMethods {
+		m := &ctx.AnalyticsMethods[mi]
+		if m.SDKMethodName != "track" || len(m.MethodArguments) == 0 {
+			continue
+		}
+		ifaceName := m.MethodArguments[0].Type
+		if !needsMap[ifaceName] {
+			continue
+		}
+		mapName := ifaceName + keyMapSuffix
+		m.PropsKeyMapName = mapName
+		ctx.UsesApplyKeyMap = true
+		// The props SDK argument is the one referencing `props` — rewrite it to
+		// remap keys first. Other args (event name, options, callback) are
+		// untouched.
+		for ai := range m.SDKArguments {
+			if strings.HasPrefix(m.SDKArguments[ai].Value, "props ") {
+				m.SDKArguments[ai].Value = "applyKeyMap(props, " + mapName + ") as unknown as " + sdkApiObjectAlias
+			}
+		}
+	}
+}
+
+// allInterfaces returns pointers to every interface the generator produced,
+// across event, nested, custom, and variant-case buckets.
+func allInterfaces(ctx *TSContext) []*TSInterface {
+	var out []*TSInterface
+	for i := range ctx.CustomInterfaces {
+		out = append(out, &ctx.CustomInterfaces[i])
+	}
+	for i := range ctx.NestedInterfaces {
+		out = append(out, &ctx.NestedInterfaces[i])
+	}
+	for i := range ctx.Interfaces {
+		out = append(out, &ctx.Interfaces[i])
+	}
+	for gi := range ctx.VariantTypes {
+		for ci := range ctx.VariantTypes[gi].CaseInterfaces {
+			out = append(out, &ctx.VariantTypes[gi].CaseInterfaces[ci])
+		}
+	}
+	return out
+}
+
+// interfaceNeedsMap reports whether iface has any property that must be
+// remapped, given the current known set of interfaces that need a map.
+func interfaceNeedsMap(iface *TSInterface, needsMap map[string]bool) bool {
+	for _, p := range iface.Properties {
+		if p.Name != p.SerialName {
+			return true
+		}
+		if referencedInterfaceName(p.Type, needsMap) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// buildKeyMap constructs the TSKeyMap for an interface known to need one. Only
+// properties that rename or reference a nested map produce entries; identity
+// keys are omitted so applyKeyMap leaves them untouched.
+func buildKeyMap(iface *TSInterface, needsMap map[string]bool) TSKeyMap {
+	km := TSKeyMap{Name: iface.Name + keyMapSuffix}
+	for _, p := range iface.Properties {
+		nested := referencedInterfaceName(p.Type, needsMap)
+		if p.Name == p.SerialName && nested == "" {
+			continue
+		}
+		entry := TSKeyMapEntry{FieldName: p.Name, SerialName: p.SerialName}
+		if nested != "" {
+			entry.NestedMapName = nested + keyMapSuffix
+		}
+		km.Entries = append(km.Entries, entry)
+	}
+	return km
+}
+
+// referencedInterfaceName returns the name of a single interface referenced by
+// a TS type expression when that interface needs a map, else "". It strips
+// array/optional decorations (`Foo[]`, `Array<Foo>`, `Foo | null`) so a
+// property typed as `CustomTypeUserProfile[]` still resolves to
+// `CustomTypeUserProfile`.
+//
+// Union types with more than one interface member (e.g. discriminated-union
+// aliases) are intentionally NOT resolved here — remapping a union requires
+// per-branch dispatch on the discriminator, which this draft does not cover.
+// See the nested-object limitation in the PR body.
+func referencedInterfaceName(tsType string, needsMap map[string]bool) string {
+	t := strings.TrimSpace(tsType)
+	t = strings.TrimSuffix(t, "[]")
+	if strings.HasPrefix(t, "Array<") && strings.HasSuffix(t, ">") {
+		t = strings.TrimSuffix(strings.TrimPrefix(t, "Array<"), ">")
+	}
+	t = strings.TrimSpace(t)
+	// Bail on unions/generics — only a bare interface reference is safe to remap.
+	if strings.ContainsAny(t, "|<>") {
+		return ""
+	}
+	if needsMap[t] {
+		return t
+	}
+	return ""
+}

--- a/cli/internal/typer/generator/platforms/typescript/keymap_test.go
+++ b/cli/internal/typer/generator/platforms/typescript/keymap_test.go
@@ -1,0 +1,142 @@
+package typescript
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestCollectKeyMaps_OnlyRenamedInterfaces verifies that a map is emitted only
+// for interfaces with at least one camelCase→serial rename, and that
+// identity-keyed interfaces are skipped.
+func TestCollectKeyMaps_OnlyRenamedInterfaces(t *testing.T) {
+	ctx := &TSContext{
+		Interfaces: []TSInterface{
+			{
+				Name: "UserSignedUp",
+				Properties: []TSInterfaceProperty{
+					{Name: "productId", SerialName: "product_id", Type: "string"},
+					{Name: "email", SerialName: "email", Type: "string"},
+				},
+			},
+			{
+				// No renames → no map.
+				Name: "AllIdentity",
+				Properties: []TSInterfaceProperty{
+					{Name: "email", SerialName: "email", Type: "string"},
+				},
+			},
+		},
+	}
+
+	needsMap := collectKeyMaps(ctx)
+
+	assert.True(t, needsMap["UserSignedUp"])
+	assert.False(t, needsMap["AllIdentity"])
+
+	assert.Equal(t, []TSKeyMap{
+		{
+			Name: "UserSignedUpKeyMap",
+			Entries: []TSKeyMapEntry{
+				{FieldName: "productId", SerialName: "product_id"},
+			},
+		},
+	}, ctx.KeyMaps)
+}
+
+// TestCollectKeyMaps_NestedRecursion verifies a parent whose only "rename" is a
+// nested object still gets a map that references the child's map, and that the
+// child map is ordered before the parent (TS const TDZ safety).
+func TestCollectKeyMaps_NestedRecursion(t *testing.T) {
+	ctx := &TSContext{
+		Interfaces: []TSInterface{
+			{
+				Name: "Parent",
+				Properties: []TSInterfaceProperty{
+					// Identity key, but its type references a child that renames.
+					{Name: "child", SerialName: "child", Type: "Child"},
+				},
+			},
+		},
+		NestedInterfaces: []TSInterface{
+			{
+				Name: "Child",
+				Properties: []TSInterfaceProperty{
+					{Name: "firstName", SerialName: "first_name", Type: "string"},
+				},
+			},
+		},
+	}
+
+	needsMap := collectKeyMaps(ctx)
+
+	assert.True(t, needsMap["Parent"])
+	assert.True(t, needsMap["Child"])
+
+	// Child map must be emitted before Parent map so the nested reference is
+	// initialized first.
+	assert.Equal(t, []TSKeyMap{
+		{
+			Name: "ChildKeyMap",
+			Entries: []TSKeyMapEntry{
+				{FieldName: "firstName", SerialName: "first_name"},
+			},
+		},
+		{
+			Name: "ParentKeyMap",
+			Entries: []TSKeyMapEntry{
+				{FieldName: "child", SerialName: "child", NestedMapName: "ChildKeyMap"},
+			},
+		},
+	}, ctx.KeyMaps)
+}
+
+// TestReferencedInterfaceName_StripsDecorations checks array/optional handling
+// and that unions are not resolved (documented nested-object limitation).
+func TestReferencedInterfaceName_StripsDecorations(t *testing.T) {
+	needsMap := map[string]bool{"Profile": true}
+
+	assert.Equal(t, "Profile", referencedInterfaceName("Profile", needsMap))
+	assert.Equal(t, "Profile", referencedInterfaceName("Profile[]", needsMap))
+	assert.Equal(t, "Profile", referencedInterfaceName("Array<Profile>", needsMap))
+	// Unions/generics are not remapped.
+	assert.Equal(t, "", referencedInterfaceName("Profile | null", needsMap))
+	assert.Equal(t, "", referencedInterfaceName("Unknown", needsMap))
+}
+
+// TestWireTrackKeyMaps_RewritesPropsArg verifies the track props SDK argument
+// is routed through applyKeyMap only when the interface needs a map.
+func TestWireTrackKeyMaps_RewritesPropsArg(t *testing.T) {
+	ctx := &TSContext{
+		AnalyticsMethods: []TSAnalyticsMethod{
+			{
+				Name:            "trackUserSignedUp",
+				SDKMethodName:   "track",
+				MethodArguments: []TSMethodArgument{{Name: "props", Type: "UserSignedUp"}},
+				SDKArguments: []TSSDKArgument{
+					{Value: `"User Signed Up"`},
+					{Value: "props as unknown as SDKApiObject"},
+				},
+			},
+			{
+				Name:            "trackPlain",
+				SDKMethodName:   "track",
+				MethodArguments: []TSMethodArgument{{Name: "props", Type: "Plain"}},
+				SDKArguments: []TSSDKArgument{
+					{Value: `"Plain"`},
+					{Value: "props as unknown as SDKApiObject"},
+				},
+			},
+		},
+	}
+
+	wireTrackKeyMaps(ctx, map[string]bool{"UserSignedUp": true})
+
+	assert.True(t, ctx.UsesApplyKeyMap)
+	assert.Equal(t, "UserSignedUpKeyMap", ctx.AnalyticsMethods[0].PropsKeyMapName)
+	assert.Equal(t, "applyKeyMap(props, UserSignedUpKeyMap) as unknown as SDKApiObject", ctx.AnalyticsMethods[0].SDKArguments[1].Value)
+
+	// Interface without a map: props forwarded verbatim.
+	assert.Empty(t, ctx.AnalyticsMethods[1].PropsKeyMapName)
+	assert.Equal(t, "props as unknown as SDKApiObject", ctx.AnalyticsMethods[1].SDKArguments[1].Value)
+}

--- a/cli/internal/typer/generator/platforms/typescript/templates/RudderTyper.ts.tmpl
+++ b/cli/internal/typer/generator/platforms/typescript/templates/RudderTyper.ts.tmpl
@@ -67,6 +67,65 @@ import type {
 {{ end }}{{ template "interface.tmpl" $a -}}
 {{ end -}}
 {{ end }}
+{{- if .UsesApplyKeyMap }}
+
+// ===== Key Maps =====
+//
+// Interface fields are camelCased for ergonomics, but the tracking plan expects
+// the original keys on the wire. Each map below rebinds a camelCase field name
+// back to its original plan key; applyKeyMap applies them (recursively for
+// nested objects) just before the SDK call. See DAW-3732.
+
+type KeyMapValue = string | { key: string; map: KeyMap };
+type KeyMap = Record<string, KeyMapValue>;
+
+function applyKeyMap(input: unknown, map: KeyMap): unknown {
+    if (Array.isArray(input)) {
+        return input.map((item) => applyKeyMap(item, map));
+    }
+    if (input === null || typeof input !== "object") {
+        return input;
+    }
+    const out: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(input as Record<string, unknown>)) {
+        const entry = map[key];
+        if (entry === undefined) {
+            out[key] = value;
+        } else if (typeof entry === "string") {
+            out[key] = value;
+            // Rename after copying so an identity map is a no-op.
+            if (entry !== key) {
+                delete out[key];
+                out[entry] = value;
+            }
+        } else {
+            out[entry.key] = applyKeyMapNested(value, entry.map);
+        }
+    }
+    return out;
+}
+
+// applyKeyMapNested descends into a nested value (object or array of objects),
+// remapping each contained object's keys with the nested map.
+function applyKeyMapNested(value: unknown, map: KeyMap): unknown {
+    if (value === null || typeof value !== "object") {
+        return value;
+    }
+    return applyKeyMap(value, map);
+}
+{{- range .KeyMaps }}
+
+const {{ .Name }}: KeyMap = {
+{{- range .Entries }}
+{{- if .NestedMapName }}
+    {{ .FieldName }}: { key: {{ printf "%q" .SerialName }}, map: {{ .NestedMapName }} },
+{{- else }}
+    {{ .FieldName }}: {{ printf "%q" .SerialName }},
+{{- end }}
+{{- end }}
+};
+{{- end }}
+{{- end }}
 
 // ===== RudderTyper =====
 

--- a/cli/internal/typer/generator/platforms/typescript/testdata/RudderTyper.ts
+++ b/cli/internal/typer/generator/platforms/typescript/testdata/RudderTyper.ts
@@ -415,6 +415,171 @@ export interface EventWithNameCamelCase1 {
 }
 
 
+// ===== Key Maps =====
+//
+// Interface fields are camelCased for ergonomics, but the tracking plan expects
+// the original keys on the wire. Each map below rebinds a camelCase field name
+// back to its original plan key; applyKeyMap applies them (recursively for
+// nested objects) just before the SDK call. See DAW-3732.
+
+type KeyMapValue = string | { key: string; map: KeyMap };
+type KeyMap = Record<string, KeyMapValue>;
+
+function applyKeyMap(input: unknown, map: KeyMap): unknown {
+    if (Array.isArray(input)) {
+        return input.map((item) => applyKeyMap(item, map));
+    }
+    if (input === null || typeof input !== "object") {
+        return input;
+    }
+    const out: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(input as Record<string, unknown>)) {
+        const entry = map[key];
+        if (entry === undefined) {
+            out[key] = value;
+        } else if (typeof entry === "string") {
+            out[key] = value;
+            // Rename after copying so an identity map is a no-op.
+            if (entry !== key) {
+                delete out[key];
+                out[entry] = value;
+            }
+        } else {
+            out[entry.key] = applyKeyMapNested(value, entry.map);
+        }
+    }
+    return out;
+}
+
+// applyKeyMapNested descends into a nested value (object or array of objects),
+// remapping each contained object's keys with the nested map.
+function applyKeyMapNested(value: unknown, map: KeyMap): unknown {
+    if (value === null || typeof value !== "object") {
+        return value;
+    }
+    return applyKeyMap(value, map);
+}
+
+const CustomTypeAddressDetailsKeyMap: KeyMap = {
+    postalCode: "postal_code",
+};
+
+const CustomTypeFeatureConfigCaseBetaKeyMap: KeyMap = {
+    featureFlag: "feature_flag",
+};
+
+const CustomTypeFeatureConfigCaseFalseKeyMap: KeyMap = {
+    featureFlag: "feature_flag",
+    firstName: "first_name",
+};
+
+const CustomTypeFeatureConfigCaseTrueKeyMap: KeyMap = {
+    featureFlag: "feature_flag",
+};
+
+const CustomTypeFeatureConfigDefaultKeyMap: KeyMap = {
+    featureFlag: "feature_flag",
+};
+
+const CustomTypePageContextCaseHomeKeyMap: KeyMap = {
+    pageType: "page_type",
+};
+
+const CustomTypePageContextCaseProductKeyMap: KeyMap = {
+    pageType: "page_type",
+    productId: "product_id",
+};
+
+const CustomTypePageContextCaseSearchKeyMap: KeyMap = {
+    pageType: "page_type",
+};
+
+const CustomTypePageContextDefaultKeyMap: KeyMap = {
+    pageData: "page_data",
+    pageType: "page_type",
+};
+
+const CustomTypeUserProfileKeyMap: KeyMap = {
+    firstName: "first_name",
+    lastName: "last_name",
+};
+
+const EventWithVariantsCaseDesktopKeyMap: KeyMap = {
+    deviceType: "device_type",
+    firstName: "first_name",
+    lastName: "last_name",
+    pageContext: "page_context",
+    profile: { key: "profile", map: CustomTypeUserProfileKeyMap },
+};
+
+const EventWithVariantsCaseMobileKeyMap: KeyMap = {
+    deviceType: "device_type",
+    pageContext: "page_context",
+    profile: { key: "profile", map: CustomTypeUserProfileKeyMap },
+};
+
+const EventWithVariantsDefaultKeyMap: KeyMap = {
+    deviceType: "device_type",
+    pageContext: "page_context",
+    profile: { key: "profile", map: CustomTypeUserProfileKeyMap },
+    untypedField: "untyped_field",
+};
+
+const PagePropertiesKeyMap: KeyMap = {
+    profile: { key: "profile", map: CustomTypeUserProfileKeyMap },
+};
+
+const ProductPremiumClickedKeyMap: KeyMap = {
+    specialField: "special_field",
+    statusCode: "status_code",
+};
+
+const UserSignedUpContextNestedContextKeyMap: KeyMap = {
+    favoriteColors: "favorite_colors",
+    profile: { key: "profile", map: CustomTypeUserProfileKeyMap },
+};
+
+const UserSignedUpContextKeyMap: KeyMap = {
+    ipAddress: "ip_address",
+    nestedContext: { key: "nested_context", map: UserSignedUpContextNestedContextKeyMap },
+};
+
+const UserSignedUpKeyMap: KeyMap = {
+    arrayOfAny: "array_of_any",
+    arrayWithNullItems: "array_with_null_items",
+    context: { key: "context", map: UserSignedUpContextKeyMap },
+    customNullField: "custom_null_field",
+    deviceType: "device_type",
+    emailList: "email_list",
+    emptyObjectNoAdditionalProps: "empty_object_no_additional_props",
+    emptyObjectWithAdditionalProps: "empty_object_with_additional_props",
+    featureConfig: "feature_config",
+    mixedUnicode: "mixed_unicode",
+    mixedValue: "mixed_value",
+    multiTypeArray: "multi_type_array",
+    multiTypeField: "multi_type_field",
+    multiTypeWithNull: "multi_type_with_null",
+    nestedEmptyObject: "nested_empty_object",
+    nestedEmptyObjectNoAdditionalProps: "nested_empty_object_no_additional_props",
+    nullField: "null_field",
+    numberOrNull: "number_or_null",
+    objectProperty: "object_property",
+    phoneNumbers: "phone_numbers",
+    profile: { key: "profile", map: CustomTypeUserProfileKeyMap },
+    profileList: "profile_list",
+    propertyOfAny: "property_of_any",
+    stringOrNull: "string_or_null",
+    unicodeCustomType: "unicode_custom_type",
+    unicodeEnumField: "unicode_enum_field",
+    untypedArray: "untyped_array",
+    untypedField: "untyped_field",
+    userAccess: "user_access",
+};
+
+const VariableStringKeyMap: KeyMap = {
+    dollarField: "dollar_field",
+};
+
 // ===== RudderTyper =====
 
 /**
@@ -579,7 +744,7 @@ export class RudderTyper {
     ): void {
         this.analytics.track(
             "$Variable$String",
-            props as unknown as SDKApiObject,
+            applyKeyMap(props, VariableStringKeyMap) as unknown as SDKApiObject,
             this.withRudderTyperContext(options),
             callback,
         );
@@ -677,7 +842,7 @@ export class RudderTyper {
     ): void {
         this.analytics.track(
             "Product \"Premium\" Clicked",
-            props as unknown as SDKApiObject,
+            applyKeyMap(props, ProductPremiumClickedKeyMap) as unknown as SDKApiObject,
             this.withRudderTyperContext(options),
             callback,
         );
@@ -697,7 +862,7 @@ export class RudderTyper {
     ): void {
         this.analytics.track(
             "User Signed Up",
-            props as unknown as SDKApiObject,
+            applyKeyMap(props, UserSignedUpKeyMap) as unknown as SDKApiObject,
             this.withRudderTyperContext(options),
             callback,
         );

--- a/cli/internal/typer/generator/platforms/typescript/track_test.go
+++ b/cli/internal/typer/generator/platforms/typescript/track_test.go
@@ -292,13 +292,13 @@ func TestProcessCustomTypesIntoContext_VariantsEmitDiscriminatedUnion(t *testing
 	// Case interface has discriminator as literal + case-specific property
 	searchIface := group.CaseInterfaces[0]
 	require.Len(t, searchIface.Properties, 2)
-	assert.Equal(t, TSInterfaceProperty{Name: "pageType", Type: `"search"`, Comment: "", Optional: false}, searchIface.Properties[0])
-	assert.Equal(t, TSInterfaceProperty{Name: "query", Type: "string", Comment: "", Optional: false}, searchIface.Properties[1])
+	assert.Equal(t, TSInterfaceProperty{Name: "pageType", Type: `"search"`, Comment: "", Optional: false, SerialName: "page_type"}, searchIface.Properties[0])
+	assert.Equal(t, TSInterfaceProperty{Name: "query", Type: "string", Comment: "", Optional: false, SerialName: "query"}, searchIface.Properties[1])
 
 	// Default interface narrows the discriminator to values no named case covers
 	defaultIface := group.CaseInterfaces[1]
 	require.Len(t, defaultIface.Properties, 1)
-	assert.Equal(t, TSInterfaceProperty{Name: "pageType", Type: `Exclude<string, "search">`, Comment: "", Optional: false}, defaultIface.Properties[0])
+	assert.Equal(t, TSInterfaceProperty{Name: "pageType", Type: `Exclude<string, "search">`, Comment: "", Optional: false, SerialName: "page_type"}, defaultIface.Properties[0])
 }
 
 func TestProcessPropertyEnumsIntoContext(t *testing.T) {

--- a/cli/internal/typer/generator/platforms/typescript/typemapping_test.go
+++ b/cli/internal/typer/generator/platforms/typescript/typemapping_test.go
@@ -245,7 +245,7 @@ func TestBuildInterfaceWithNested_OptionalMultiType(t *testing.T) {
 	assert.Equal(t, &TSInterface{
 		Name: "Parent",
 		Properties: []TSInterfaceProperty{
-			{Name: "value", Type: "string | number", Optional: true},
+			{Name: "value", Type: "string | number", Optional: true, SerialName: "value"},
 		},
 	}, iface)
 }
@@ -284,7 +284,7 @@ func TestBuildInterfaceWithNested_MultiTypeInsideNestedObject(t *testing.T) {
 	assert.Equal(t, &TSInterface{
 		Name: "Parent",
 		Properties: []TSInterfaceProperty{
-			{Name: "details", Type: "ParentDetails"},
+			{Name: "details", Type: "ParentDetails", SerialName: "details"},
 		},
 	}, iface)
 
@@ -292,7 +292,7 @@ func TestBuildInterfaceWithNested_MultiTypeInsideNestedObject(t *testing.T) {
 		{
 			Name: "ParentDetails",
 			Properties: []TSInterfaceProperty{
-				{Name: "value", Type: "string | number"},
+				{Name: "value", Type: "string | number", SerialName: "value"},
 			},
 		},
 	}, ctx.NestedInterfaces)

--- a/cli/internal/typer/generator/platforms/typescript/variants.go
+++ b/cli/internal/typer/generator/platforms/typescript/variants.go
@@ -204,6 +204,7 @@ func buildVariantInterface(
 			Comment:    propSchema.Property.Description,
 			Optional:   optional,
 			QuotedName: quoted,
+			SerialName: propName,
 		})
 	}
 

--- a/cli/internal/typer/generator/platforms/typescript/variants_test.go
+++ b/cli/internal/typer/generator/platforms/typescript/variants_test.go
@@ -46,23 +46,23 @@ func TestBuildVariantGroup_StringDiscriminator(t *testing.T) {
 				Name:    "TestTypeCaseAlpha",
 				Comment: "The alpha case",
 				Properties: []TSInterfaceProperty{
-					{Name: "kind", Type: `"alpha"`},
-					{Name: "score", Type: "number"},
+					{Name: "kind", Type: `"alpha"`, SerialName: "kind"},
+					{Name: "score", Type: "number", SerialName: "score"},
 				},
 			},
 			{
 				Name:    "TestTypeCaseBeta",
 				Comment: "The beta case",
 				Properties: []TSInterfaceProperty{
-					{Name: "kind", Type: `"beta"`},
+					{Name: "kind", Type: `"beta"`, SerialName: "kind"},
 				},
 			},
 			{
 				Name:    "TestTypeDefault",
 				Comment: "Default case",
 				Properties: []TSInterfaceProperty{
-					{Name: "fallback", Type: "boolean", Optional: true},
-					{Name: "kind", Type: `Exclude<string, "alpha" | "beta">`},
+					{Name: "fallback", Type: "boolean", Optional: true, SerialName: "fallback"},
+					{Name: "kind", Type: `Exclude<string, "alpha" | "beta">`, SerialName: "kind"},
 				},
 			},
 		},
@@ -113,8 +113,8 @@ func TestBuildVariantGroup_BooleanDiscriminator(t *testing.T) {
 		Name:    "UserAccessCaseTrue",
 		Comment: "Active user",
 		Properties: []TSInterfaceProperty{
-			{Name: "active", Type: "true"},
-			{Name: "email", Type: "string"},
+			{Name: "active", Type: "true", SerialName: "active"},
+			{Name: "email", Type: "string", SerialName: "email"},
 		},
 	}, ifaceByName["UserAccessCaseTrue"])
 
@@ -122,8 +122,8 @@ func TestBuildVariantGroup_BooleanDiscriminator(t *testing.T) {
 		Name:    "UserAccessCaseFalse",
 		Comment: "Inactive user",
 		Properties: []TSInterfaceProperty{
-			{Name: "active", Type: "false"},
-			{Name: "reason", Type: "string", Optional: true},
+			{Name: "active", Type: "false", SerialName: "active"},
+			{Name: "reason", Type: "string", Optional: true, SerialName: "reason"},
 		},
 	}, ifaceByName["UserAccessCaseFalse"])
 
@@ -131,7 +131,7 @@ func TestBuildVariantGroup_BooleanDiscriminator(t *testing.T) {
 		Name:    "UserAccessDefault",
 		Comment: "Default case",
 		Properties: []TSInterfaceProperty{
-			{Name: "active", Type: "Exclude<boolean, true | false>"},
+			{Name: "active", Type: "Exclude<boolean, true | false>", SerialName: "active"},
 		},
 	}, ifaceByName["UserAccessDefault"], "default discriminator excludes covered values — both cases cover boolean exhaustively, so this resolves to never")
 
@@ -171,7 +171,7 @@ func TestBuildVariantGroup_MultipleMatchValues(t *testing.T) {
 		Name:    "ConfigCaseFast",
 		Comment: "Fast modes",
 		Properties: []TSInterfaceProperty{
-			{Name: "mode", Type: `"fast"`},
+			{Name: "mode", Type: `"fast"`, SerialName: "mode"},
 		},
 	}, ifaceByName["ConfigCaseFast"])
 
@@ -179,7 +179,7 @@ func TestBuildVariantGroup_MultipleMatchValues(t *testing.T) {
 		Name:    "ConfigCaseTurbo",
 		Comment: "Fast modes",
 		Properties: []TSInterfaceProperty{
-			{Name: "mode", Type: `"turbo"`},
+			{Name: "mode", Type: `"turbo"`, SerialName: "mode"},
 		},
 	}, ifaceByName["ConfigCaseTurbo"])
 
@@ -213,7 +213,7 @@ func TestBuildVariantGroup_NoDefaultSchema(t *testing.T) {
 		Name:    "FooDefault",
 		Comment: "Default case",
 		Properties: []TSInterfaceProperty{
-			{Name: "kind", Type: `Exclude<string, "a">`},
+			{Name: "kind", Type: `Exclude<string, "a">`, SerialName: "kind"},
 		},
 	}, ifaceByName["FooDefault"])
 }
@@ -246,8 +246,8 @@ func TestBuildVariantGroup_CasePropertyOverridesRequired(t *testing.T) {
 	assert.Equal(t, TSInterface{
 		Name: "ItemCaseSpecial",
 		Properties: []TSInterfaceProperty{
-			{Name: "kind", Type: `"special"`},
-			{Name: "label", Type: "string", Optional: false},
+			{Name: "kind", Type: `"special"`, SerialName: "kind"},
+			{Name: "label", Type: "string", Optional: false, SerialName: "label"},
 		},
 	}, ifaceByName["ItemCaseSpecial"], "case upgrades base optional → required via OR")
 }
@@ -289,14 +289,14 @@ func TestBuildVariantGroup_EnumDiscriminatorInDefault(t *testing.T) {
 		Name:    "EventDefault",
 		Comment: "Default case",
 		Properties: []TSInterfaceProperty{
-			{Name: "deviceType", Type: `Exclude<PropertyDeviceType, "mobile">`},
+			{Name: "deviceType", Type: `Exclude<PropertyDeviceType, "mobile">`, SerialName: "device_type"},
 		},
 	}, ifaceByName["EventDefault"], "default narrows the enum alias to values no named case covers")
 
 	assert.Equal(t, TSInterface{
 		Name: "EventCaseMobile",
 		Properties: []TSInterfaceProperty{
-			{Name: "deviceType", Type: `"mobile"`},
+			{Name: "deviceType", Type: `"mobile"`, SerialName: "device_type"},
 		},
 	}, ifaceByName["EventCaseMobile"], "named case uses literal")
 }


### PR DESCRIPTION
## 🔗 Ticket

Relates to [DAW-3732](https://linear.app/rudderstack/issue/DAW-3732)

---

## Summary

DAW-3732: RudderTyper v2's TypeScript generator camelCases tracking-plan property keys (`product_id` → `productId`) and then passes the `props` object **verbatim** to `analytics.track(...)`. The camelCased key therefore lands on the wire, violating the tracking plan. Swift and Kotlin already avoid this by carrying the ORIGINAL key alongside the ergonomic identifier and rebuilding the payload before the SDK call (Swift: `SerialName` + `toProperties()`; Kotlin: `put("first_name", firstName)`).

This PR is **Option 1 of 2 (draft, for comparison): SerialName + runtime remap, mirroring Swift/Kotlin.** It keeps the camelCase interface field names for ergonomics but remaps keys back to the original plan names at runtime, just before the SDK call.

---

## Changes

- **`SerialName` field** added to `TSInterfaceProperty` holding the original plan key. `Name` stays camelCase (no camelCasing reverted). Populated wherever properties are built: event interfaces (`buildInterfaceWithNested`), custom-type interfaces (`buildInterfaceFromSchema`), and variant case interfaces (`variants.go`).
- **Per-interface key maps** (`keymap.go`): `collectKeyMaps` emits a `const <Interface>KeyMap: KeyMap = { camelName: "serial_name", ... }` for every interface that has ≥1 renamed key **or** a nested object that itself needs remapping. Interfaces whose keys already match the wire produce no map.
- **Shared runtime helper** `applyKeyMap(obj, map)` emitted once per generated file, plus `applyKeyMapNested`. It rewrites keys recursively (objects and arrays of objects), mirroring Swift's nested `toProperties()`.
- **Track call site rewrite**: `props as unknown as SDKApiObject` → `applyKeyMap(props, <Interface>KeyMap) as unknown as SDKApiObject` for track methods whose typed interface needs a map. Methods with no remap keep passing `props` directly.
- **Topological ordering** of key-map constants so a nested reference is initialized before its parent (TS module-load `const` TDZ safety).
- Golden file `testdata/RudderTyper.ts` regenerated via `make typer-typescript-update-testdata`.

---

## Testing

- Unit tests: `go test ./internal/typer/...` passes.
- New `keymap_test.go` covers: only-renamed interfaces get a map, nested recursion + dependency ordering, type-decoration stripping (`Foo[]`, `Array<Foo>`), and the track-arg rewrite (remapped vs verbatim).
- Updated struct-equality expectations in `track_test.go`, `variants_test.go`, `typemapping_test.go` to include the new `SerialName` field (tests were not weakened — the exact original keys are asserted).
- `make lint`: 0 issues. `go build ./...` clean.
- Verified in the regenerated golden: interface fields stay camelCase (e.g. `productId`, `ipAddress`, `deviceType`); the deepest recursion chain `UserSignedUpKeyMap → UserSignedUpContextKeyMap → UserSignedUpContextNestedContextKeyMap → CustomTypeUserProfileKeyMap` is emitted bottom-up and applied at the `trackUserSignedUp` call site.

---

## Risk / Impact

Low / Medium.

- **Added runtime surface**: every generated file that has ≥1 remapped event now carries an `applyKeyMap`/`applyKeyMapNested` helper, a `KeyMap`/`KeyMapValue` type pair, and one `const …KeyMap` per interface needing remap. This is per-generated-file code the SDK user ships. It is dead-code-eliminable only if unreferenced; some variant-case maps are emitted but unused when their union isn't remapped (see below).
- **Nested-object handling status — full-recursive for interface references, shallow+documented for unions**: nested objects referenced by a single interface name (inline event nested objects, object custom types) ARE remapped recursively via nested key maps. **Discriminated-union props are NOT remapped**: a track method whose props type is a union alias (e.g. `EventWithVariants = A | B | Default`) still forwards `props` verbatim, because correct union remapping needs per-branch dispatch on the discriminator, which this draft intentionally does not implement. Likewise, `identify`/`group`/`page` traits/properties are left verbatim in this draft (the wiring currently targets track — the canonical case). These are the honest limitations of Option 1 as drafted.

---

## Checklist

- [x] Ticket linked
- [x] Tests added/updated
- [x] No breaking changes (or documented)

🤖 Generated with [Claude Code](https://claude.com/claude-code)