### PR TITLE
feat(api): add account external-id client support

### DIFF
--- a/api/client/accounts.go
+++ b/api/client/accounts.go
@@ -1,8 +1,12 @@
 package client
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
 	"time"
 )
 
@@ -15,9 +19,10 @@ type Account struct {
 		Type     string `json:"type"`
 		Category string `json:"category"`
 	} `json:"definition"`
-	Options   json.RawMessage `json:"options"`
-	CreatedAt *time.Time      `json:"createdAt,omitempty"`
-	UpdatedAt *time.Time      `json:"updatedAt,omitempty"`
+	Options    json.RawMessage `json:"options"`
+	CreatedAt  *time.Time      `json:"createdAt,omitempty"`
+	UpdatedAt  *time.Time      `json:"updatedAt,omitempty"`
+	ExternalID string          `json:"externalId,omitempty"`
 }
 
 type CreateAccountRequest struct {
@@ -54,9 +59,35 @@ func (s *accounts) Next(ctx context.Context, paging Paging) (*AccountsPage, erro
 	return page, err
 }
 
-func (s *accounts) List(ctx context.Context) (*AccountsPage, error) {
+type ListAccountsOptions struct {
+	HasExternalID *bool
+}
+
+type ListAccountsOption func(*ListAccountsOptions)
+
+// WithHasExternalID filters the account list to managed (true) or
+// unmanaged/importable (false) accounts.
+func WithHasExternalID(v bool) ListAccountsOption {
+	return func(o *ListAccountsOptions) { o.HasExternalID = &v }
+}
+
+func (s *accounts) List(ctx context.Context, opts ...ListAccountsOption) (*AccountsPage, error) {
+	options := &ListAccountsOptions{}
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	path := s.basePath
+	query := url.Values{}
+	if options.HasExternalID != nil {
+		query.Add("hasExternalId", strconv.FormatBool(*options.HasExternalID))
+	}
+	if encoded := query.Encode(); encoded != "" {
+		path = fmt.Sprintf("%s?%s", path, encoded)
+	}
+
 	page := &AccountsPage{}
-	if err := s.list(ctx, page); err != nil {
+	if _, err := s.next(ctx, Paging{Next: path}, page); err != nil {
 		return nil, err
 	}
 
@@ -122,4 +153,18 @@ func (s *accounts) Update(ctx context.Context, id string, account *UpdateAccount
 
 func (s *accounts) Delete(ctx context.Context, id string) error {
 	return s.service.delete(ctx, id)
+}
+
+// SetExternalID assigns a caller-owned stable external id to a remote account.
+// PUT /v2/accounts/{id}/external-id  body: {"externalId": externalID}
+func (s *accounts) SetExternalID(ctx context.Context, id string, externalID string) error {
+	path := fmt.Sprintf("%s/%s/external-id", s.basePath, id)
+	data, err := json.Marshal(map[string]string{"externalId": externalID})
+	if err != nil {
+		return fmt.Errorf("marshalling external id: %w", err)
+	}
+	if _, err := s.client.Do(ctx, "PUT", path, bytes.NewReader(data)); err != nil {
+		return fmt.Errorf("setting external id: %w", err)
+	}
+	return nil
 }

--- a/api/client/accounts_externalid_test.go
+++ b/api/client/accounts_externalid_test.go
@@ -1,0 +1,89 @@
+package client_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/rudderlabs/rudder-iac/api/client"
+	"github.com/rudderlabs/rudder-iac/api/internal/testutils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAccountExternalIDMarshalsAsExternalId(t *testing.T) {
+	b, err := json.Marshal(client.Account{ExternalID: "ext-1"})
+	require.NoError(t, err)
+	assert.Contains(t, string(b), `"externalId":"ext-1"`)
+}
+
+func TestClientAccountsListWithHasExternalID(t *testing.T) {
+	ctx := context.Background()
+	calls := []testutils.Call{
+		{
+			Validate: func(req *http.Request) bool {
+				return testutils.ValidateRequest(t, req, "GET", "", "") &&
+					assert.Equal(t, "https://api.rudderstack.com/v2/accounts?hasExternalId=true", req.URL.String())
+			},
+			ResponseStatus: 200,
+			ResponseBody:   `{"data": [{"id": "id-1", "externalId": "ext-1"}], "paging": {"total": 1}}`,
+		},
+	}
+
+	httpClient := testutils.NewMockHTTPClient(t, calls...)
+	c, err := client.New("some-access-token", client.WithHTTPClient(httpClient))
+	require.NoError(t, err)
+
+	page, err := c.Accounts.List(ctx, client.WithHasExternalID(true))
+	require.NoError(t, err)
+	require.Len(t, page.Accounts, 1)
+	assert.Equal(t, "ext-1", page.Accounts[0].ExternalID)
+
+	httpClient.AssertNumberOfCalls()
+}
+
+func TestClientAccountsSetExternalID(t *testing.T) {
+	ctx := context.Background()
+	calls := []testutils.Call{
+		{
+			Validate: func(req *http.Request) bool {
+				return testutils.ValidateRequest(t, req, "PUT", "https://api.rudderstack.com/v2/accounts/some-id/external-id", `{"externalId":"ext-1"}`)
+			},
+			ResponseStatus: 200,
+			ResponseBody:   `{"id": "some-id", "externalId": "ext-1"}`,
+		},
+	}
+
+	httpClient := testutils.NewMockHTTPClient(t, calls...)
+	c, err := client.New("some-access-token", client.WithHTTPClient(httpClient))
+	require.NoError(t, err)
+
+	err = c.Accounts.SetExternalID(ctx, "some-id", "ext-1")
+	require.NoError(t, err)
+
+	httpClient.AssertNumberOfCalls()
+}
+
+func TestClientAccountsGetReturnsExternalID(t *testing.T) {
+	ctx := context.Background()
+	calls := []testutils.Call{
+		{
+			Validate: func(req *http.Request) bool {
+				return testutils.ValidateRequest(t, req, "GET", "https://api.rudderstack.com/v2/accounts/some-id", "")
+			},
+			ResponseStatus: 200,
+			ResponseBody:   `{"id": "some-id", "externalId": "ext-1"}`,
+		},
+	}
+
+	httpClient := testutils.NewMockHTTPClient(t, calls...)
+	c, err := client.New("some-access-token", client.WithHTTPClient(httpClient))
+	require.NoError(t, err)
+
+	account, err := c.Accounts.Get(ctx, "some-id")
+	require.NoError(t, err)
+	assert.Equal(t, "ext-1", account.ExternalID)
+
+	httpClient.AssertNumberOfCalls()
+}


### PR DESCRIPTION
## Summary

Adds the rudder-iac Go client surface for account **external-id state**, mirroring the proven RETL-sources pattern. Implements `CONTRACT-ACCT-STATE-V1` §5 (rudderlabs/rudder-specs#88).

- `Account.ExternalID` (`json:"externalId,omitempty"`)
- `SetExternalID(ctx, id, externalID)` → `PUT /v2/accounts/{id}/external-id`
- `WithHasExternalID(bool)` list option → `?hasExternalId=` on `List`

Additive only — no change to existing CUD method signatures (`List` gains a variadic option, backward-compatible).

## Tests (TDD)

`api/client/accounts_externalid_test.go` — httptest harness:
- `TestClientAccountsSetExternalID` — asserts PUT path/method/body
- `TestClientAccountsListWithHasExternalID` — asserts the `?hasExternalId=true` query
- `TestClientAccountsGetReturnsExternalID` / `TestAccountExternalIDMarshalsAsExternalId` — read + wire-shape

`go test ./api/client/` green; gofmt/vet clean; gocyclo/CRAP < 8 on touched funcs. Also verified live against a local mini stack (SetExternalID → List(hasExternalId=true) round-trip).

## Related

Backend counterparts: config-backend externalId route/column and rudder-api `/v2` proxy (separate PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)