### PR TITLE
feat(api): add destination transformation connect/disconnect/get client

### DIFF
--- a/api/client/destinations.go
+++ b/api/client/destinations.go
@@ -1,8 +1,10 @@
 package client
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"strings"
 	"time"
 )
 
@@ -32,6 +34,64 @@ type destinations struct {
 type DestinationsPage struct {
 	APIPage
 	Destinations []Destination `json:"destinations"`
+}
+
+type DestinationTransformation struct {
+	DestinationID    string    `json:"destinationId"`
+	TransformationID string    `json:"transformationId"`
+	CreatedAt        time.Time `json:"createdAt"`
+	UpdatedAt        time.Time `json:"updatedAt"`
+}
+
+func (s *destinations) transformationPath(destinationID string) string {
+	return strings.Join([]string{s.basePath, destinationID, "transformation"}, "/")
+}
+
+func (s *destinations) ConnectTransformation(ctx context.Context, destinationID, transformationID string) (*DestinationTransformation, error) {
+	body, err := json.Marshal(map[string]string{"transformationId": transformationID})
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := s.client.Do(ctx, "PUT", s.transformationPath(destinationID), bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+
+	result := &DestinationTransformation{}
+	if err = json.Unmarshal(res, result); err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+func (s *destinations) DisconnectTransformation(ctx context.Context, destinationID string) (*DestinationTransformation, error) {
+	res, err := s.client.Do(ctx, "DELETE", s.transformationPath(destinationID), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	result := &DestinationTransformation{}
+	if err = json.Unmarshal(res, result); err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+func (s *destinations) GetTransformation(ctx context.Context, destinationID string) (*DestinationTransformation, error) {
+	res, err := s.client.Do(ctx, "GET", s.transformationPath(destinationID), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	result := &DestinationTransformation{}
+	if err = json.Unmarshal(res, result); err != nil {
+		return nil, err
+	}
+
+	return result, nil
 }
 
 func (s *destinations) Next(ctx context.Context, paging Paging) (*DestinationsPage, error) {

--- a/api/client/destinations_test.go
+++ b/api/client/destinations_test.go
@@ -3,6 +3,7 @@ package client_test
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"testing"
 	"time"
@@ -385,4 +386,209 @@ func TestClientDestinationsUpdateOmitsEmptyVersion(t *testing.T) {
 	assert.Equal(t, "some-id", destination.ID)
 
 	httpClient.AssertNumberOfCalls()
+}
+
+func TestClientDestinations_ConnectTransformation(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := context.Background()
+
+		httpClient := testutils.NewMockHTTPClient(t, testutils.Call{
+			Validate: func(req *http.Request) bool {
+				return testutils.ValidateRequest(t, req, "PUT", "https://api.rudderstack.com/v2/destinations/some-destination-id/transformation", `{
+					"transformationId": "some-transformation-id"
+				}`)
+			},
+			ResponseStatus: 200,
+			ResponseBody: `{
+				"destinationId": "some-destination-id",
+				"transformationId": "some-transformation-id",
+				"createdAt": "2020-01-01T01:01:01Z",
+				"updatedAt": "2020-01-02T01:01:01Z"
+			}`,
+		})
+
+		c, err := client.New("some-access-token", client.WithHTTPClient(httpClient))
+		require.NoError(t, err)
+
+		result, err := c.Destinations.ConnectTransformation(ctx, "some-destination-id", "some-transformation-id")
+		require.NoError(t, err)
+		assert.Equal(t, &client.DestinationTransformation{
+			DestinationID:    "some-destination-id",
+			TransformationID: "some-transformation-id",
+			CreatedAt:        time.Date(2020, 1, 1, 1, 1, 1, 0, time.UTC),
+			UpdatedAt:        time.Date(2020, 1, 2, 1, 1, 1, 0, time.UTC),
+		}, result)
+
+		httpClient.AssertNumberOfCalls()
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := context.Background()
+
+		httpClient := testutils.NewMockHTTPClient(t, testutils.Call{
+			Validate: func(req *http.Request) bool {
+				return testutils.ValidateRequest(t, req, "PUT", "https://api.rudderstack.com/v2/destinations/some-destination-id/transformation", `{
+					"transformationId": "some-transformation-id"
+				}`)
+			},
+			ResponseStatus: 404,
+			ResponseBody:   `{"message": "not found"}`,
+		})
+
+		c, err := client.New("some-access-token", client.WithHTTPClient(httpClient))
+		require.NoError(t, err)
+
+		_, err = c.Destinations.ConnectTransformation(ctx, "some-destination-id", "some-transformation-id")
+		require.Error(t, err)
+
+		var apiErr *client.APIError
+		require.True(t, errors.As(err, &apiErr))
+		assert.Equal(t, 404, apiErr.HTTPStatusCode)
+
+		httpClient.AssertNumberOfCalls()
+	})
+}
+
+func TestClientDestinations_DisconnectTransformation(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := context.Background()
+
+		httpClient := testutils.NewMockHTTPClient(t, testutils.Call{
+			Validate: func(req *http.Request) bool {
+				return testutils.ValidateRequest(
+					t,
+					req,
+					"DELETE",
+					"https://api.rudderstack.com/v2/destinations/some-destination-id/transformation",
+					"",
+				)
+			},
+			ResponseStatus: 200,
+			ResponseBody: `{
+				"destinationId": "some-destination-id",
+				"transformationId": "some-transformation-id",
+				"createdAt": "2020-01-01T01:01:01Z",
+				"updatedAt": "2020-01-02T01:01:01Z"
+			}`,
+		})
+
+		c, err := client.New("some-access-token", client.WithHTTPClient(httpClient))
+		require.NoError(t, err)
+
+		result, err := c.Destinations.DisconnectTransformation(ctx, "some-destination-id")
+		require.NoError(t, err)
+		assert.Equal(t, &client.DestinationTransformation{
+			DestinationID:    "some-destination-id",
+			TransformationID: "some-transformation-id",
+			CreatedAt:        time.Date(2020, 1, 1, 1, 1, 1, 0, time.UTC),
+			UpdatedAt:        time.Date(2020, 1, 2, 1, 1, 1, 0, time.UTC),
+		}, result)
+
+		httpClient.AssertNumberOfCalls()
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := context.Background()
+
+		httpClient := testutils.NewMockHTTPClient(t, testutils.Call{
+			Validate: func(req *http.Request) bool {
+				return testutils.ValidateRequest(
+					t,
+					req,
+					"DELETE",
+					"https://api.rudderstack.com/v2/destinations/some-destination-id/transformation",
+					"",
+				)
+			},
+			ResponseStatus: 404,
+			ResponseBody:   `{"message": "not found"}`,
+		})
+
+		c, err := client.New("some-access-token", client.WithHTTPClient(httpClient))
+		require.NoError(t, err)
+
+		_, err = c.Destinations.DisconnectTransformation(ctx, "some-destination-id")
+		require.Error(t, err)
+
+		var apiErr *client.APIError
+		require.True(t, errors.As(err, &apiErr))
+		assert.Equal(t, 404, apiErr.HTTPStatusCode)
+
+		httpClient.AssertNumberOfCalls()
+	})
+}
+
+func TestClientDestinations_GetTransformation(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := context.Background()
+
+		httpClient := testutils.NewMockHTTPClient(t, testutils.Call{
+			Validate: func(req *http.Request) bool {
+				return testutils.ValidateRequest(
+					t,
+					req,
+					"GET",
+					"https://api.rudderstack.com/v2/destinations/some-destination-id/transformation",
+					"",
+				)
+			},
+			ResponseStatus: 200,
+			ResponseBody: `{
+				"destinationId": "some-destination-id",
+				"transformationId": "some-transformation-id",
+				"createdAt": "2020-01-01T01:01:01Z",
+				"updatedAt": "2020-01-02T01:01:01Z"
+			}`,
+		})
+
+		c, err := client.New("some-access-token", client.WithHTTPClient(httpClient))
+		require.NoError(t, err)
+
+		result, err := c.Destinations.GetTransformation(ctx, "some-destination-id")
+		require.NoError(t, err)
+		assert.Equal(t, &client.DestinationTransformation{
+			DestinationID:    "some-destination-id",
+			TransformationID: "some-transformation-id",
+			CreatedAt:        time.Date(2020, 1, 1, 1, 1, 1, 0, time.UTC),
+			UpdatedAt:        time.Date(2020, 1, 2, 1, 1, 1, 0, time.UTC),
+		}, result)
+
+		httpClient.AssertNumberOfCalls()
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := context.Background()
+
+		httpClient := testutils.NewMockHTTPClient(t, testutils.Call{
+			Validate: func(req *http.Request) bool {
+				return testutils.ValidateRequest(t, req, "GET", "https://api.rudderstack.com/v2/destinations/some-destination-id/transformation", "")
+			},
+			ResponseStatus: 404,
+			ResponseBody:   `{"message": "not found"}`,
+		})
+
+		c, err := client.New("some-access-token", client.WithHTTPClient(httpClient))
+		require.NoError(t, err)
+
+		_, err = c.Destinations.GetTransformation(ctx, "some-destination-id")
+		require.Error(t, err)
+
+		var apiErr *client.APIError
+		require.True(t, errors.As(err, &apiErr))
+		assert.Equal(t, 404, apiErr.HTTPStatusCode)
+
+		httpClient.AssertNumberOfCalls()
+	})
 }


### PR DESCRIPTION
## 🔗 Ticket

Resolves [RUD-2862](https://linear.app/rudderstack/issue/RUD-2862/transformation-connectdisconnect-api-client)

---

## Summary

Adds API client methods for linking, unlinking, and reading the transformation connected to a destination. Uses the destination-centric v2 public API contract from [rudder-control-plane#2413](https://github.com/rudderlabs/rudder-control-plane/pull/2413). These methods unblock RUD-2864 destination handler lifecycle work.

---

## Changes

- Add `DestinationTransformation` model to `api/client/destinations.go`
- Add `ConnectTransformation` (`PUT /v2/destinations/:id/transformation`)
- Add `DisconnectTransformation` (`DELETE /v2/destinations/:id/transformation`)
- Add `GetTransformation` (`GET /v2/destinations/:id/transformation`)
- Add unit tests with parallel success/not-found subtests

---

## Testing

- `go test ./api/client -run 'TestClientDestinations_(Connect|Disconnect|Get)Transformation' -count=1 -v`
- `make lint`

---

## Risk / Impact

Low — additive API client methods only; no CLI provider or apply-cycle changes.

---

## Checklist

- [x] Ticket linked
- [x] Tests added/updated
- [x] No breaking changes (or documented)

Made with [Cursor](https://cursor.com)