### PR TITLE
feat(api): add GetAll pagination helper for destinations

### DIFF
--- a/api/client/destinations.go
+++ b/api/client/destinations.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"time"
 )
@@ -149,4 +150,23 @@ func (s *destinations) Update(ctx context.Context, destination *Destination) (*D
 
 func (s *destinations) Delete(ctx context.Context, id string) error {
 	return s.service.delete(ctx, id)
+}
+
+func (s *destinations) GetAll(ctx context.Context) ([]Destination, error) {
+	var all []Destination
+
+	page, err := s.List(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("listing destinations: %w", err)
+	}
+
+	for page != nil {
+		all = append(all, page.Destinations...)
+		page, err = s.Next(ctx, page.Paging)
+		if err != nil {
+			return nil, fmt.Errorf("fetching next destinations page: %w", err)
+		}
+	}
+
+	return all, nil
 }

--- a/api/client/destinations_test.go
+++ b/api/client/destinations_test.go
@@ -592,3 +592,154 @@ func TestClientDestinations_GetTransformation(t *testing.T) {
 		httpClient.AssertNumberOfCalls()
 	})
 }
+func TestClientDestinations_GetAll(t *testing.T) {
+	ctx := context.Background()
+
+	cases := []struct {
+		name          string
+		calls         []testutils.Call
+		want          []client.Destination
+		wantErrSubstr string
+	}{
+		{
+			name: "multi page",
+			calls: []testutils.Call{
+				{
+					Validate: func(req *http.Request) bool {
+						return testutils.ValidateRequest(t, req, "GET", "https://api.rudderstack.com/v2/destinations", "")
+					},
+					ResponseStatus: 200,
+					ResponseBody: `{
+						"destinations": [{
+							"id": "id-1",
+							"type": "type-1",
+							"name": "name-1",
+							"config": {"key":"val-1"}
+						},  {
+							"id": "id-2",
+							"type": "type-2",
+							"name": "name-2",
+							"config": {"key":"val-2"}
+						}],
+						"paging": {
+							"total": 3,
+							"next": "/destinations?page=2"
+						}
+					}`,
+				},
+				{
+					Validate: func(req *http.Request) bool {
+						return testutils.ValidateRequest(t, req, "GET", "https://api.rudderstack.com/v2/destinations?page=2", "")
+					},
+					ResponseStatus: 200,
+					ResponseBody: `{
+						"destinations": [{
+							"id": "id-3",
+							"type": "type-3",
+							"name": "name-3",
+							"config": {"key":"val-3"}
+						}],
+						"paging": {
+							"total": 3
+						}
+					}`,
+				},
+			},
+			want: []client.Destination{
+				{ID: "id-1", Type: "type-1", Name: "name-1", Config: []byte(`{"key":"val-1"}`)},
+				{ID: "id-2", Type: "type-2", Name: "name-2", Config: []byte(`{"key":"val-2"}`)},
+				{ID: "id-3", Type: "type-3", Name: "name-3", Config: []byte(`{"key":"val-3"}`)},
+			},
+		},
+		{
+			name: "single page",
+			calls: []testutils.Call{
+				{
+					Validate: func(req *http.Request) bool {
+						return testutils.ValidateRequest(t, req, "GET", "https://api.rudderstack.com/v2/destinations", "")
+					},
+					ResponseStatus: 200,
+					ResponseBody: `{
+						"destinations": [{
+							"id": "id-1",
+							"type": "type-1",
+							"name": "name-1",
+							"config": {"key":"val-1"}
+						}],
+						"paging": {
+							"total": 1
+						}
+					}`,
+				},
+			},
+			want: []client.Destination{
+				{ID: "id-1", Type: "type-1", Name: "name-1", Config: []byte(`{"key":"val-1"}`)},
+			},
+		},
+		{
+			name: "list error",
+			calls: []testutils.Call{
+				{
+					Validate: func(req *http.Request) bool {
+						return testutils.ValidateRequest(t, req, "GET", "https://api.rudderstack.com/v2/destinations", "")
+					},
+					ResponseStatus: 500,
+					ResponseBody:   `{"error":"Internal Server Error"}`,
+				},
+			},
+			wantErrSubstr: "listing destinations",
+		},
+		{
+			name: "next page error",
+			calls: []testutils.Call{
+				{
+					Validate: func(req *http.Request) bool {
+						return testutils.ValidateRequest(t, req, "GET", "https://api.rudderstack.com/v2/destinations", "")
+					},
+					ResponseStatus: 200,
+					ResponseBody: `{
+						"destinations": [{
+							"id": "id-1",
+							"type": "type-1",
+							"name": "name-1",
+							"config": {"key":"val-1"}
+						}],
+						"paging": {
+							"total": 2,
+							"next": "/destinations?page=2"
+						}
+					}`,
+				},
+				{
+					Validate: func(req *http.Request) bool {
+						return testutils.ValidateRequest(t, req, "GET", "https://api.rudderstack.com/v2/destinations?page=2", "")
+					},
+					ResponseStatus: 500,
+					ResponseBody:   `{"error":"Internal Server Error"}`,
+				},
+			},
+			wantErrSubstr: "fetching next destinations page",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			httpClient := testutils.NewMockHTTPClient(t, tc.calls...)
+
+			c, err := client.New("some-access-token", client.WithHTTPClient(httpClient))
+			require.NoError(t, err)
+
+			got, err := c.Destinations.GetAll(ctx)
+			if tc.wantErrSubstr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErrSubstr)
+				assert.Nil(t, got)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tc.want, got)
+			}
+
+			httpClient.AssertNumberOfCalls()
+		})
+	}
+}


### PR DESCRIPTION
## 🔗 Ticket

Resolves [RUD-2861](https://linear.app/rudderstack/issue/RUD-2861/destination-api-client-enhancements)

---

## Summary

Adds a `GetAll` pagination helper to the destinations API client so callers can fetch the complete destination list in one call. This completes the remaining RUD-2861 scope; `ExternalID` and `SetExternalID` are handled separately in #640.

---

## Changes

- Added `Destinations.GetAll(ctx)` that loops over existing `List`/`Next` methods until all pages are collected
- Wrapped list and pagination errors with actionable context
- Added table-driven unit tests covering multi-page, single-page, list error, and next-page error scenarios

---

## Testing

- `make lint` — 0 issues
- `go test ./api/client/...` — all pass

---

## Risk / Impact

Low
Notes: Pure API client addition; no provider or CLI wiring yet (RUD-2864).

---

## Checklist

- [x] Ticket linked
- [x] Tests added/updated
- [x] No breaking changes (or documented)

Made with [Cursor](https://cursor.com)