### PR TITLE
chore: scope manifest-inline-conflict to (workspace_id, urn) with remote_id check and merge manifest workspaces

### DIFF
--- a/cli/internal/project/importmanifest/provider.go
+++ b/cli/internal/project/importmanifest/provider.go
@@ -7,6 +7,8 @@ package importmanifest
 import (
 	"fmt"
 
+	"github.com/samber/lo"
+
 	manifestdocs "github.com/rudderlabs/rudder-iac/cli/internal/project/importmanifest/docs"
 	"github.com/rudderlabs/rudder-iac/cli/internal/project/importmanifest/manifestspec"
 	mrules "github.com/rudderlabs/rudder-iac/cli/internal/project/importmanifest/rules"
@@ -23,6 +25,8 @@ import (
 const KindImportManifest = manifestspec.KindImportManifest
 
 type Provider struct {
+	// entries holds one merged entry per workspace, unifying a workspace split
+	// across multiple manifest files.
 	entries []specs.WorkspaceImportMetadata
 }
 
@@ -44,15 +48,27 @@ func (p *Provider) SupportedMatchPatterns() []rules.MatchPattern {
 	}
 }
 
-// LoadSpec appends the spec's workspace entries to provider state. Appending is
-// safe because cross-file URN collisions are caught by validation before this
-// runs — no merge step needed.
+// LoadSpec merges the spec's workspace entries into provider state, keeping one
+// entry per workspace so a workspace split across multiple manifest files is
+// unified. Validation guarantees no duplicate (workspace_id, urn), so appending
+// resources needs no deduplication.
 func (p *Provider) LoadSpec(path string, s *specs.Spec) error {
 	workspaces, err := parseWorkspaces(s)
 	if err != nil {
 		return fmt.Errorf("parsing import-manifest %s: %w", path, err)
 	}
-	p.entries = append(p.entries, workspaces...)
+
+	for _, ws := range workspaces {
+		_, i, found := lo.FindIndexOf(p.entries, func(e specs.WorkspaceImportMetadata) bool {
+			return e.WorkspaceID == ws.WorkspaceID
+		})
+
+		if found {
+			p.entries[i].Resources = append(p.entries[i].Resources, ws.Resources...)
+			continue
+		}
+		p.entries = append(p.entries, ws)
+	}
 	return nil
 }
 
@@ -105,4 +121,10 @@ func (p *Provider) SemanticRules() []rules.Rule {
 func (p *Provider) RuleDocEntries() []docs.RuleDocEntry {
 	entries, _ := docs.LoadRuleDocEntries(manifestdocs.FragmentsFS, ".")
 	return entries
+}
+
+// ImportManifest returns the merged workspace entries, one per workspace. The
+// slice is empty when no manifest specs were loaded.
+func (p *Provider) ImportManifest() []specs.WorkspaceImportMetadata {
+	return p.entries
 }

--- a/cli/internal/project/importmanifest/provider_test.go
+++ b/cli/internal/project/importmanifest/provider_test.go
@@ -141,3 +141,53 @@ func TestProvider_RuleSets(t *testing.T) {
 	}
 	assert.Equal(t, []string{"import-manifest/orphaned-urn"}, semanticIDs)
 }
+
+func TestProvider_ImportManifest(t *testing.T) {
+	t.Parallel()
+
+	wsB := specs.WorkspaceImportMetadata{
+		WorkspaceID: "ws-b",
+		Resources:   []specs.ImportIds{{URN: "event:login", RemoteID: "rem-b"}},
+	}
+
+	t.Run("empty when no specs loaded", func(t *testing.T) {
+		p := New()
+		assert.Empty(t, p.ImportManifest())
+	})
+
+	t.Run("returns one entry per workspace", func(t *testing.T) {
+		p := New()
+		require.NoError(t, p.LoadSpec("a.yaml", manifestSpec("ws-a",
+			specs.ImportIds{URN: "event:login", RemoteID: "rem-a"})))
+		require.NoError(t, p.LoadSpec("b.yaml", manifestSpec("ws-b",
+			specs.ImportIds{URN: "event:login", RemoteID: "rem-b"})))
+
+		assert.Equal(t, []specs.WorkspaceImportMetadata{
+			{WorkspaceID: "ws-a", Resources: []specs.ImportIds{{URN: "event:login", RemoteID: "rem-a"}}},
+			wsB,
+		}, p.ImportManifest())
+	})
+
+	t.Run("merges resources of a workspace split across files", func(t *testing.T) {
+		p := New()
+		// ws-a is declared in two files, each contributing a different URN;
+		// ws-b is interleaved to confirm ordering is preserved.
+		require.NoError(t, p.LoadSpec("a1.yaml", manifestSpec("ws-a",
+			specs.ImportIds{URN: "event:login", RemoteID: "rem-a"})))
+		require.NoError(t, p.LoadSpec("b.yaml", manifestSpec("ws-b",
+			specs.ImportIds{URN: "event:login", RemoteID: "rem-b"})))
+		require.NoError(t, p.LoadSpec("a2.yaml", manifestSpec("ws-a",
+			specs.ImportIds{URN: "event:signup", RemoteID: "rem-c"})))
+
+		assert.Equal(t, []specs.WorkspaceImportMetadata{
+			{
+				WorkspaceID: "ws-a",
+				Resources: []specs.ImportIds{
+					{URN: "event:login", RemoteID: "rem-a"},
+					{URN: "event:signup", RemoteID: "rem-c"},
+				},
+			},
+			wsB,
+		}, p.ImportManifest())
+	})
+}

--- a/cli/internal/project/project.go
+++ b/cli/internal/project/project.go
@@ -349,10 +349,11 @@ func BuildRegistry(provider, manifestProvider ProjectProvider) (rules.Registry, 
 		prules.NewMetadataSyntaxValidRule(provider.ParseSpec, resourcePatterns),
 		prules.NewDuplicateURNRule(provider.ParseSpec, resourcePatterns),
 
-		// Cross-source: a URN must not appear in both an import-manifest and an
-		// inline metadata.import block. Applies to the union (both kinds), and
-		// needs both providers' ParseSpec.
-		prules.NewManifestInlineConflictRule(manifestProvider.ParseSpec, provider.ParseSpec, activePatterns),
+		// Cross-source: a (workspace_id, urn) must not appear in both an
+		// import-manifest and an inline metadata.import block with differing
+		// remote_ids. Applies to the union (both kinds); needs the resource
+		// ParseSpec to resolve inline local_id entries.
+		prules.NewManifestInlineConflictRule(provider.ParseSpec, activePatterns),
 	}
 	syntactic = append(syntactic, provider.SyntacticRules()...)
 	syntactic = append(syntactic, manifestProvider.SyntacticRules()...)

--- a/cli/internal/project/rules/manifest_inline_conflict.go
+++ b/cli/internal/project/rules/manifest_inline_conflict.go
@@ -3,36 +3,36 @@ package rules
 import (
 	"fmt"
 
+	"github.com/samber/lo"
+
 	"github.com/rudderlabs/rudder-iac/cli/internal/project/importmanifest/manifestspec"
 	"github.com/rudderlabs/rudder-iac/cli/internal/project/specs"
 	"github.com/rudderlabs/rudder-iac/cli/internal/resources"
 	"github.com/rudderlabs/rudder-iac/cli/internal/validation/rules"
 )
 
-// manifestInlineConflictRule flags a URN declared in BOTH an import-manifest and
-// a legacy inline metadata.import block. Inline metadata is the single-source
-// legacy format being migrated away from, so any overlap with a manifest is a
-// migration ambiguity — an operator must remove one. Reported at both locations.
+// manifestInlineConflictRule flags a (workspace_id, urn) declared in BOTH an
+// import-manifest and a legacy inline metadata.import block with DIFFERING
+// remote_ids. Inline metadata is the single-source legacy format being migrated
+// away from, so an overlap that disagrees on the remote target is a migration
+// ambiguity — an operator must remove one. Reported at both locations.
 //
-// It is workspace-AGNOSTIC: it keys on URN alone (unlike the manifest
-// duplicate-urn rule), because an overlap is a conflict regardless of which
-// workspace each side names.
+// It is workspace-SCOPED (like the manifest duplicate-urn rule): the same urn
+// under different workspaces maps to a different remote per workspace, so it is
+// legal. An overlap that agrees on remote_id names the same import target and is
+// harmless, so it is not flagged either.
 type manifestInlineConflictRule struct {
-	manifestParseSpec ParseSpecFunc        // manifest URN extraction
 	resourceParseSpec ParseSpecFunc        // resolves inline local_id via LegacyResourceType
 	patterns          []rules.MatchPattern // union of manifest + resource patterns
 }
 
-// NewManifestInlineConflictRule needs both providers' info: the manifest
-// ParseSpec (manifest URNs), the resource ParseSpec (to resolve inline local_id
-// entries), and the active patterns (manifest + resource) it applies to.
+// NewManifestInlineConflictRule needs the resource ParseSpec (to resolve inline
+// local_id entries) and the active patterns (manifest + resource) it applies to.
 func NewManifestInlineConflictRule(
-	manifestParseSpec ParseSpecFunc,
 	resourceParseSpec ParseSpecFunc,
 	patterns []rules.MatchPattern,
 ) rules.Rule {
 	return &manifestInlineConflictRule{
-		manifestParseSpec: manifestParseSpec,
 		resourceParseSpec: resourceParseSpec,
 		patterns:          patterns,
 	}
@@ -41,7 +41,7 @@ func NewManifestInlineConflictRule(
 func (r *manifestInlineConflictRule) ID() string               { return "project/manifest-inline-conflict" }
 func (r *manifestInlineConflictRule) Severity() rules.Severity { return rules.Error }
 func (r *manifestInlineConflictRule) Description() string {
-	return "a URN must not be defined in both an import-manifest and inline metadata.import"
+	return "a (workspace_id, urn) must not be defined in both an import-manifest and inline metadata.import with differing remote_ids"
 }
 
 // AppliesTo is the union of manifest + resource patterns, so the engine delivers
@@ -57,66 +57,107 @@ func (r *manifestInlineConflictRule) Validate(_ *rules.ValidationContext) []rule
 	return nil
 }
 
-type urnLoc struct {
-	path    string
-	pointer string
+// wsURN keys an overlap by workspace and urn together: the same urn under two
+// different workspaces maps to a different remote per workspace, so only a
+// shared (workspace_id, urn) can collide.
+type wsURN struct {
+	workspaceID string
+	urn         string
 }
 
-// ValidateSpecs partitions the contexts into manifest URN locations and inline
-// metadata.import URN locations, then flags every URN present in both — at each
-// of its locations on both sides.
+type urnLoc struct {
+	path     string
+	pointer  string
+	remoteID string
+}
+
+// ValidateSpecs partitions the contexts into manifest and inline metadata.import
+// (workspace_id, urn) locations, then flags every key present in both whose
+// remote_ids disagree — at each of its locations on both sides. A key present in
+// both that agrees on remote_id names the same import target and is left clean.
 func (r *manifestInlineConflictRule) ValidateSpecs(
 	contexts map[string]*rules.ValidationContext,
 ) map[string][]rules.ValidationResult {
-	manifestURNs := map[string][]urnLoc{}
-	inlineURNs := map[string][]urnLoc{}
+	manifestURNs := map[wsURN][]urnLoc{}
+	inlineURNs := map[wsURN][]urnLoc{}
 
 	for path, ctx := range contexts {
 		if ctx.Kind == manifestspec.KindImportManifest {
-			r.collectManifestURNs(path, ctx, manifestURNs)
+			r.collectManifestURNs(ctx, manifestURNs)
 			continue
 		}
 		r.collectInlineURNs(path, ctx, inlineURNs)
 	}
 
 	results := map[string][]rules.ValidationResult{}
-	for urn, mLocs := range manifestURNs {
-		iLocs, conflict := inlineURNs[urn]
-		if !conflict {
+	for key, manifestLocs := range manifestURNs {
+		inlineLocs, overlap := inlineURNs[key]
+		if !overlap {
 			continue
 		}
-		msg := fmt.Sprintf("URN '%s' is defined in both an import-manifest and inline metadata; remove the inline metadata entry", urn)
-		for _, l := range append(mLocs, iLocs...) {
-			results[l.path] = append(results[l.path], rules.ValidationResult{Reference: l.pointer, Message: msg})
+
+		allLocs := lo.Flatten([][]urnLoc{manifestLocs, inlineLocs})
+		if sameRemoteID(allLocs) {
+			continue
+		}
+		msg := fmt.Sprintf("URN '%s' in workspace '%s' is defined in both an import-manifest and inline metadata with differing remote_ids; remove the inline metadata entry", key.urn, key.workspaceID)
+		for _, loc := range allLocs {
+			results[loc.path] = append(results[loc.path], rules.ValidationResult{Reference: loc.pointer, Message: msg})
 		}
 	}
 	return results
 }
 
-func (r *manifestInlineConflictRule) collectManifestURNs(path string, ctx *rules.ValidationContext, out map[string][]urnLoc) {
-	parsed, err := r.manifestParseSpec(path, specFromContext(ctx))
+// sameRemoteID reports whether every location shares one remote_id — the "same
+// import target" case that is not a conflict. Empty input is not a match.
+func sameRemoteID(locs []urnLoc) bool {
+	if len(locs) == 0 {
+		return false
+	}
+	sharedRemoteID := locs[0].remoteID
+	return lo.EveryBy(locs, func(loc urnLoc) bool { return loc.remoteID == sharedRemoteID })
+}
+
+func (r *manifestInlineConflictRule) collectManifestURNs(ctx *rules.ValidationContext, out map[wsURN][]urnLoc) {
+	workspaces, err := manifestspec.DecodeWorkspaces(ctx.Spec)
 	if err != nil {
 		return // malformed manifest is the manifest spec-syntax-valid rule's concern
 	}
-	for _, e := range parsed.URNs {
-		out[e.URN] = append(out[e.URN], urnLoc{path: path, pointer: e.JSONPointerPath})
+	for i, workspace := range workspaces {
+		if workspace.WorkspaceID == "" {
+			continue // unidentified workspace — the spec-syntax-valid rule reports it
+		}
+		for j, resource := range workspace.Resources {
+			if resource.URN == "" {
+				continue
+			}
+			key := wsURN{workspaceID: workspace.WorkspaceID, urn: resource.URN}
+			out[key] = append(out[key], urnLoc{
+				path:     ctx.FilePath,
+				pointer:  fmt.Sprintf("/spec/workspaces/%d/resources/%d/urn", i, j),
+				remoteID: resource.RemoteID,
+			})
+		}
 	}
 }
 
 // collectInlineURNs reads a resource spec's inline metadata.import block,
 // resolving each entry to a URN via its urn or local_id (the latter through the
 // resource's LegacyResourceType), mirroring metadata-syntax-valid.
-func (r *manifestInlineConflictRule) collectInlineURNs(path string, ctx *rules.ValidationContext, out map[string][]urnLoc) {
+func (r *manifestInlineConflictRule) collectInlineURNs(path string, ctx *rules.ValidationContext, out map[wsURN][]urnLoc) {
 	metadata, err := specFromContext(ctx).CommonMetadata()
 	if err != nil || metadata.Import == nil {
 		return
 	}
 
 	var legacyResourceType string
-	for wi, ws := range metadata.Import.Workspaces {
-		for ri, res := range ws.Resources {
-			urn := res.URN
-			if urn == "" && res.LocalID != "" {
+	for i, workspace := range metadata.Import.Workspaces {
+		if workspace.WorkspaceID == "" {
+			continue // unidentified workspace — metadata-syntax-valid reports it
+		}
+		for j, resource := range workspace.Resources {
+			urn := resource.URN
+			if urn == "" && resource.LocalID != "" {
 				if legacyResourceType == "" {
 					parsed, perr := r.resourceParseSpec(path, specFromContext(ctx))
 					if perr != nil || parsed.LegacyResourceType == "" {
@@ -124,14 +165,16 @@ func (r *manifestInlineConflictRule) collectInlineURNs(path string, ctx *rules.V
 					}
 					legacyResourceType = parsed.LegacyResourceType
 				}
-				urn = resources.URN(res.LocalID, legacyResourceType)
+				urn = resources.URN(resource.LocalID, legacyResourceType)
 			}
 			if urn == "" {
 				continue
 			}
-			out[urn] = append(out[urn], urnLoc{
-				path:    path,
-				pointer: fmt.Sprintf("/metadata/import/workspaces/%d/resources/%d/urn", wi, ri),
+			key := wsURN{workspaceID: workspace.WorkspaceID, urn: urn}
+			out[key] = append(out[key], urnLoc{
+				path:     path,
+				pointer:  fmt.Sprintf("/metadata/import/workspaces/%d/resources/%d/urn", i, j),
+				remoteID: resource.RemoteID,
 			})
 		}
 	}

--- a/cli/internal/project/rules/manifest_inline_conflict_test.go
+++ b/cli/internal/project/rules/manifest_inline_conflict_test.go
@@ -1,7 +1,6 @@
 package rules
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/rudderlabs/rudder-iac/cli/internal/project/importmanifest/manifestspec"
@@ -18,29 +17,6 @@ var conflictPatterns = []rules.MatchPattern{
 	rules.MatchKindVersion(conflictResourceType, specs.SpecVersionV1),
 }
 
-// manifestParseSpecExtracting returns a ParseSpecFunc that emits the manifest's
-// urn entries (mirrors the real manifest provider's ParseSpec).
-func manifestParseSpecExtracting() ParseSpecFunc {
-	return func(path string, s *specs.Spec) (*specs.ParsedSpec, error) {
-		var urns []specs.URNEntry
-		ws, _ := s.Spec["workspaces"].([]any)
-		for wi, w := range ws {
-			wm, _ := w.(map[string]any)
-			res, _ := wm["resources"].([]any)
-			for ri, r := range res {
-				rm, _ := r.(map[string]any)
-				if urn, ok := rm["urn"].(string); ok && urn != "" {
-					urns = append(urns, specs.URNEntry{
-						URN:             urn,
-						JSONPointerPath: fmt.Sprintf("/spec/workspaces/%d/resources/%d/urn", wi, ri),
-					})
-				}
-			}
-		}
-		return &specs.ParsedSpec{URNs: urns}, nil
-	}
-}
-
 // resourceParseSpecLegacy reports the legacy resource type so inline local_id
 // entries resolve to URNs.
 func resourceParseSpecLegacy() ParseSpecFunc {
@@ -49,23 +25,25 @@ func resourceParseSpecLegacy() ParseSpecFunc {
 	}
 }
 
-func manifestConflictCtx(urns ...string) *rules.ValidationContext {
-	res := make([]any, 0, len(urns))
-	for _, u := range urns {
-		res = append(res, map[string]any{"urn": u, "remote_id": "r"})
-	}
+// manifestConflictCtx builds a manifest declaring urn under workspaceID with the
+// given remote_id.
+func manifestConflictCtx(workspaceID, urn, remoteID string) *rules.ValidationContext {
 	return &rules.ValidationContext{
 		FilePath: "import-manifest.yaml",
 		Kind:     manifestspec.KindImportManifest,
 		Version:  specs.SpecVersionV1,
 		Spec: map[string]any{
-			"workspaces": []any{map[string]any{"workspace_id": "ws-1", "resources": res}},
+			"workspaces": []any{map[string]any{
+				"workspace_id": workspaceID,
+				"resources":    []any{map[string]any{"urn": urn, "remote_id": remoteID}},
+			}},
 		},
 	}
 }
 
-// resourceCtxInlineURN builds a resource spec carrying an inline metadata.import urn.
-func resourceCtxInlineURN(path, urn string) *rules.ValidationContext {
+// resourceCtxInlineURN builds a resource spec carrying an inline metadata.import
+// urn under workspaceID with the given remote_id.
+func resourceCtxInlineURN(path, workspaceID, urn, remoteID string) *rules.ValidationContext {
 	return &rules.ValidationContext{
 		FilePath: path,
 		Kind:     conflictResourceType,
@@ -75,8 +53,8 @@ func resourceCtxInlineURN(path, urn string) *rules.ValidationContext {
 			"import": map[string]any{
 				"workspaces": []any{
 					map[string]any{
-						"workspace_id": "ws-9",
-						"resources":    []any{map[string]any{"urn": urn, "remote_id": "r"}},
+						"workspace_id": workspaceID,
+						"resources":    []any{map[string]any{"urn": urn, "remote_id": remoteID}},
 					},
 				},
 			},
@@ -87,29 +65,29 @@ func resourceCtxInlineURN(path, urn string) *rules.ValidationContext {
 
 func newRule() rules.MultiSpecRule {
 	return NewManifestInlineConflictRule(
-		manifestParseSpecExtracting(), resourceParseSpecLegacy(), conflictPatterns,
+		resourceParseSpecLegacy(), conflictPatterns,
 	).(rules.MultiSpecRule)
 }
 
 func TestManifestInlineConflictRule_Metadata(t *testing.T) {
 	t.Parallel()
-	r := NewManifestInlineConflictRule(manifestParseSpecExtracting(), resourceParseSpecLegacy(), conflictPatterns)
+	r := NewManifestInlineConflictRule(resourceParseSpecLegacy(), conflictPatterns)
 	assert.Equal(t, "project/manifest-inline-conflict", r.ID())
 	assert.Equal(t, rules.Error, r.Severity())
 	assert.Equal(t, conflictPatterns, r.AppliesTo())
-	assert.Nil(t, r.Validate(manifestConflictCtx("a:b")))
+	assert.Nil(t, r.Validate(manifestConflictCtx("ws-1", "a:b", "r")))
 }
 
 func TestManifestInlineConflictRule_ValidateSpecs(t *testing.T) {
 	t.Parallel()
 
-	t.Run("urn in both manifest and inline errors at both", func(t *testing.T) {
+	t.Run("same (ws, urn) with differing remote_ids errors at both", func(t *testing.T) {
 		t.Parallel()
 		results := newRule().ValidateSpecs(map[string]*rules.ValidationContext{
-			"import-manifest.yaml": manifestConflictCtx("event-stream-source:shared"),
-			"src.yaml":             resourceCtxInlineURN("src.yaml", "event-stream-source:shared"),
+			"import-manifest.yaml": manifestConflictCtx("ws-1", "event-stream-source:shared", "remote-a"),
+			"src.yaml":             resourceCtxInlineURN("src.yaml", "ws-1", "event-stream-source:shared", "remote-b"),
 		})
-		msg := "URN 'event-stream-source:shared' is defined in both an import-manifest and inline metadata; remove the inline metadata entry"
+		msg := "URN 'event-stream-source:shared' in workspace 'ws-1' is defined in both an import-manifest and inline metadata with differing remote_ids; remove the inline metadata entry"
 		assert.Equal(t, []rules.ValidationResult{
 			{Reference: "/spec/workspaces/0/resources/0/urn", Message: msg},
 		}, results["import-manifest.yaml"])
@@ -118,20 +96,29 @@ func TestManifestInlineConflictRule_ValidateSpecs(t *testing.T) {
 		}, results["src.yaml"])
 	})
 
-	t.Run("manifest-only urn is clean", func(t *testing.T) {
+	t.Run("same (ws, urn) with matching remote_id is clean", func(t *testing.T) {
 		t.Parallel()
 		results := newRule().ValidateSpecs(map[string]*rules.ValidationContext{
-			"import-manifest.yaml": manifestConflictCtx("event-stream-source:only-manifest"),
-			"src.yaml":             resourceCtxInlineURN("src.yaml", "event-stream-source:only-inline"),
+			"import-manifest.yaml": manifestConflictCtx("ws-1", "event-stream-source:shared", "remote-a"),
+			"src.yaml":             resourceCtxInlineURN("src.yaml", "ws-1", "event-stream-source:shared", "remote-a"),
 		})
 		assert.Empty(t, results)
 	})
 
-	t.Run("inline local_id resolving to a manifest urn conflicts", func(t *testing.T) {
+	t.Run("manifest-only urn is clean", func(t *testing.T) {
+		t.Parallel()
+		results := newRule().ValidateSpecs(map[string]*rules.ValidationContext{
+			"import-manifest.yaml": manifestConflictCtx("ws-1", "event-stream-source:only-manifest", "remote-a"),
+			"src.yaml":             resourceCtxInlineURN("src.yaml", "ws-1", "event-stream-source:only-inline", "remote-b"),
+		})
+		assert.Empty(t, results)
+	})
+
+	t.Run("inline local_id resolving to a manifest urn conflicts when remote_ids differ", func(t *testing.T) {
 		t.Parallel()
 		// inline entry uses local_id "shared"; the resource legacy type is
 		// event-stream-source, so it resolves to event-stream-source:shared,
-		// which the manifest also declares.
+		// which the manifest also declares under the same workspace.
 		inline := &rules.ValidationContext{
 			FilePath: "src.yaml",
 			Kind:     conflictResourceType,
@@ -140,28 +127,29 @@ func TestManifestInlineConflictRule_ValidateSpecs(t *testing.T) {
 				"name": "src",
 				"import": map[string]any{
 					"workspaces": []any{map[string]any{
-						"workspace_id": "ws-9",
-						"resources":    []any{map[string]any{"local_id": "shared", "remote_id": "r"}},
+						"workspace_id": "ws-1",
+						"resources":    []any{map[string]any{"local_id": "shared", "remote_id": "remote-b"}},
 					}},
 				},
 			},
 			Spec: map[string]any{"id": "src"},
 		}
 		results := newRule().ValidateSpecs(map[string]*rules.ValidationContext{
-			"import-manifest.yaml": manifestConflictCtx("event-stream-source:shared"),
+			"import-manifest.yaml": manifestConflictCtx("ws-1", "event-stream-source:shared", "remote-a"),
 			"src.yaml":             inline,
 		})
 		require.Len(t, results, 2)
 		assert.Equal(t, "/metadata/import/workspaces/0/resources/0/urn", results["src.yaml"][0].Reference)
 	})
 
-	t.Run("conflict holds even when workspace_ids differ (workspace-agnostic)", func(t *testing.T) {
+	t.Run("same urn under different workspaces is clean (workspace-scoped)", func(t *testing.T) {
 		t.Parallel()
-		// manifest workspace is ws-1, inline workspace is ws-9 — still a conflict.
+		// manifest workspace is ws-1, inline workspace is ws-9 — different
+		// (workspace_id, urn) keys, so no conflict even though remote_ids differ.
 		results := newRule().ValidateSpecs(map[string]*rules.ValidationContext{
-			"import-manifest.yaml": manifestConflictCtx("event-stream-source:shared"),
-			"src.yaml":             resourceCtxInlineURN("src.yaml", "event-stream-source:shared"),
+			"import-manifest.yaml": manifestConflictCtx("ws-1", "event-stream-source:shared", "remote-a"),
+			"src.yaml":             resourceCtxInlineURN("src.yaml", "ws-9", "event-stream-source:shared", "remote-b"),
 		})
-		require.Len(t, results, 2)
+		assert.Empty(t, results)
 	})
 }


### PR DESCRIPTION
## 🔗 Ticket

resolves [DEX-462](https://linear.app/rudderstack/issue/DEX-462)

---

## Summary

The `manifest-inline-conflict` validation rule previously errored on any URN present in both an import-manifest and a legacy inline `metadata.import` block, keyed on URN alone (workspace-agnostic) — too strict. This relaxes it so a conflict is flagged only when the same `(workspace_id, urn)` appears in both places with **differing** `remote_id`s. The same URN under different workspaces is legal (it maps to a different remote per workspace), and an overlap that agrees on `remote_id` names the same import target and is harmless. This PR also unifies manifest provider state so a workspace split across multiple manifest files is merged into a single entry.

---

## Changes

* Rekey `manifest-inline-conflict` on `(workspace_id, urn)` instead of URN alone (workspace-scoped, matching the manifest duplicate-urn rule).
* Only flag a conflict when the two sides disagree on `remote_id`; matching `remote_id` is treated as the same import target and left clean.
* Drop the manifest `ParseSpec` dependency from the rule — decode manifest workspaces directly so `remote_id` is available (and update the `NewManifestInlineConflictRule` signature + call site).
* `LoadSpec` now merges resources into one entry per workspace via `lo.FindIndexOf` instead of blind-appending; add `ImportManifest()` accessor returning the merged entries.
* Readability: `samber/lo` for the all-match check, clearer names, loop naming aligned with the sibling rule.

---

## Testing

* Unit tests updated/added in `manifest_inline_conflict_test.go` covering: differing-remote_id conflict, matching-remote_id clean, manifest-only clean, local_id resolution, and same-URN-different-workspace clean.
* New `provider_test.go` cases for `ImportManifest()`: empty, one-entry-per-workspace, and merge of a workspace split across files.
* `go build ./...`, `make lint` (0 issues), and `go test ./cli/internal/project/...` all pass.

---

## Risk / Impact

Low
Relaxes an existing validation rule (fewer false-positive errors) and refactors manifest state-merging; no user-facing API changes. Behavior is fully covered by unit tests.

---

## Checklist

* [x] Ticket linked
* [x] Tests added/updated
* [x] No breaking changes (or documented)