### PR TITLE
feat(cli): add rudder-cli fmt (canonical spec formatter)

### DIFF
--- a/cli/internal/cmd/format/format.go
+++ b/cli/internal/cmd/format/format.go
@@ -1,0 +1,106 @@
+package format
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/rudderlabs/rudder-iac/cli/internal/cmd/cmderrors"
+	"github.com/rudderlabs/rudder-iac/cli/internal/cmd/telemetry"
+	"github.com/rudderlabs/rudder-iac/cli/internal/format"
+	"github.com/rudderlabs/rudder-iac/cli/internal/logger"
+	"github.com/spf13/cobra"
+)
+
+var fmtLog = logger.New("root", logger.Attr{Key: "cmd", Value: "fmt"})
+
+// NewCmdFmt builds the `rudder-cli fmt` command: a deterministic, idempotent
+// formatter for spec YAML that normalizes layout while preserving comments and
+// key order.
+func NewCmdFmt() *cobra.Command {
+	var (
+		check bool
+		diff  bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "fmt [path...]",
+		Short: "Format spec YAML files into canonical form",
+		Long: heredoc.Doc(`
+			Rewrites spec YAML files into a canonical form: normalized indentation,
+			whitespace and quoting. Comments and key order are preserved, and the
+			formatting is idempotent and semantics-preserving.
+
+			With no paths, the current directory is formatted recursively.
+		`),
+		Example: heredoc.Doc(`
+			$ rudder-cli fmt
+			$ rudder-cli fmt ./specs
+			$ rudder-cli fmt --check ./specs
+			$ rudder-cli fmt --diff spec.yaml
+		`),
+		Args: cobra.ArbitraryArgs,
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
+			if check && diff {
+				return fmt.Errorf("--check and --diff are mutually exclusive")
+			}
+
+			defer func() {
+				telemetry.TrackCommand("fmt", err,
+					telemetry.KV{K: "check", V: check},
+					telemetry.KV{K: "diff", V: diff},
+				)
+			}()
+
+			results, err := format.Run(args, format.Options{Check: check, Diff: diff})
+			if err != nil {
+				return fmt.Errorf("formatting specs: %w", err)
+			}
+
+			return report(cmd.OutOrStdout(), results, check, diff)
+		},
+	}
+
+	cmd.Flags().BoolVar(&check, "check", false, "Report files that need formatting and exit non-zero without writing")
+	cmd.Flags().BoolVar(&diff, "diff", false, "Print a unified diff of changes without writing")
+	return cmd
+}
+
+// report prints per-file outcomes and returns an error when appropriate:
+// per-file formatting failures abort with an error; in check mode any file that
+// would change yields a SilentError (non-zero exit, no stderr noise).
+func report(w io.Writer, results []format.Result, check, diff bool) error {
+	var (
+		changed int
+		failed  error
+	)
+
+	for _, r := range results {
+		if r.Err != nil {
+			fmtLog.Error("formatting file", "path", r.Path, "error", r.Err)
+			failed = r.Err
+			continue
+		}
+		if !r.Changed {
+			continue
+		}
+		changed++
+
+		if diff {
+			fmt.Fprint(w, r.Diff)
+			continue
+		}
+		fmt.Fprintln(w, r.Path)
+	}
+
+	if failed != nil {
+		return failed
+	}
+
+	if check && changed > 0 {
+		fmt.Fprintf(w, "%d file(s) need formatting\n", changed)
+		return &cmderrors.SilentError{Err: fmt.Errorf("%d file(s) not formatted", changed)}
+	}
+
+	return nil
+}

--- a/cli/internal/cmd/format/format_test.go
+++ b/cli/internal/cmd/format/format_test.go
@@ -1,0 +1,99 @@
+package format
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/rudderlabs/rudder-iac/cli/internal/cmd/cmderrors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func writeFile(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+	return path
+}
+
+func runCmd(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	cmd := NewCmdFmt()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+	return out.String(), err
+}
+
+func TestFmt_WriteMode_FormatsInPlace(t *testing.T) {
+	dir := t.TempDir()
+	path := writeFile(t, dir, "a.yaml", "metadata:\n    name: a\n")
+
+	out, err := runCmd(t, path)
+	require.NoError(t, err)
+
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "metadata:\n  name: a\n", string(got))
+	assert.Contains(t, out, "a.yaml")
+}
+
+func TestFmt_CheckMode_ExitsNonZeroWhenUnformatted(t *testing.T) {
+	dir := t.TempDir()
+	path := writeFile(t, dir, "a.yaml", "metadata:\n    name: a\n")
+
+	out, err := runCmd(t, "--check", path)
+	require.Error(t, err)
+
+	var silent *cmderrors.SilentError
+	assert.True(t, errors.As(err, &silent), "check failure must be a SilentError for clean exit")
+
+	// File is untouched in check mode.
+	got, _ := os.ReadFile(path)
+	assert.Equal(t, "metadata:\n    name: a\n", string(got))
+	assert.Contains(t, out, "a.yaml")
+}
+
+func TestFmt_CheckMode_ZeroWhenClean(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "a.yaml", "metadata:\n  name: a\n")
+
+	_, err := runCmd(t, "--check", dir)
+	assert.NoError(t, err)
+}
+
+func TestFmt_DiffMode_PrintsUnifiedDiffWithoutWriting(t *testing.T) {
+	dir := t.TempDir()
+	path := writeFile(t, dir, "a.yaml", "metadata:\n    name: a\n")
+
+	out, err := runCmd(t, "--diff", path)
+	require.NoError(t, err)
+
+	assert.Contains(t, out, "---")
+	assert.Contains(t, out, "+++")
+	assert.Contains(t, out, "name: a")
+
+	got, _ := os.ReadFile(path)
+	assert.Equal(t, "metadata:\n    name: a\n", string(got))
+}
+
+func TestFmt_InvalidYAML_ReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "bad.yaml", "key: : : bad\n")
+
+	_, err := runCmd(t, dir)
+	assert.Error(t, err)
+}
+
+func TestFmt_CheckAndDiffMutuallyExclusive(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "a.yaml", "metadata:\n  name: a\n")
+
+	_, err := runCmd(t, "--check", "--diff", dir)
+	assert.Error(t, err)
+}

--- a/cli/internal/cmd/root.go
+++ b/cli/internal/cmd/root.go
@@ -13,6 +13,7 @@ import (
 	"github.com/rudderlabs/rudder-iac/cli/internal/cmd/auth"
 	d "github.com/rudderlabs/rudder-iac/cli/internal/cmd/debug"
 	"github.com/rudderlabs/rudder-iac/cli/internal/cmd/experimental"
+	fmtcmd "github.com/rudderlabs/rudder-iac/cli/internal/cmd/format"
 	importcmd "github.com/rudderlabs/rudder-iac/cli/internal/cmd/import"
 	"github.com/rudderlabs/rudder-iac/cli/internal/cmd/project/apply"
 	"github.com/rudderlabs/rudder-iac/cli/internal/cmd/project/destroy"
@@ -89,6 +90,7 @@ func init() {
 
 	rootCmd.AddCommand(apply.NewCmdApply())
 	rootCmd.AddCommand(validate.NewCmdValidate())
+	rootCmd.AddCommand(fmtcmd.NewCmdFmt())
 	rootCmd.AddCommand(destroy.NewCmdDestroy())
 	rootCmd.AddCommand(migrate.NewCmdMigrate())
 

--- a/cli/internal/format/format.go
+++ b/cli/internal/format/format.go
@@ -1,0 +1,46 @@
+// Package format provides a deterministic, idempotent canonical formatter for
+// spec YAML, akin to gofmt/terraform fmt. It normalizes whitespace, indentation
+// and quoting only — key order and comments are preserved (author intent), so a
+// formatted spec parses identically to the original.
+package format
+
+import (
+	"bytes"
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+// canonicalIndent is the number of spaces per nesting level in formatted output.
+const canonicalIndent = 2
+
+// Source formats a single YAML document into canonical form. It re-encodes the
+// parsed node tree with fixed indentation while preserving comments and key
+// order. Empty or whitespace-only input formats to empty output.
+//
+// The transform is idempotent: Source(Source(x)) == Source(x).
+func Source(data []byte) ([]byte, error) {
+	var node yaml.Node
+	if err := yaml.Unmarshal(data, &node); err != nil {
+		return nil, fmt.Errorf("parsing YAML: %w", err)
+	}
+
+	// An empty or comment-free blank document yields a zero-value node with no
+	// content; nothing to re-encode.
+	if node.Kind == 0 {
+		return nil, nil
+	}
+
+	var buf bytes.Buffer
+	encoder := yaml.NewEncoder(&buf)
+	encoder.SetIndent(canonicalIndent)
+
+	if err := encoder.Encode(&node); err != nil {
+		return nil, fmt.Errorf("encoding YAML: %w", err)
+	}
+	if err := encoder.Close(); err != nil {
+		return nil, fmt.Errorf("closing YAML encoder: %w", err)
+	}
+
+	return buf.Bytes(), nil
+}

--- a/cli/internal/format/format_test.go
+++ b/cli/internal/format/format_test.go
@@ -1,0 +1,82 @@
+package format
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+// parses the given YAML into a generic value for semantic comparison.
+func parse(t *testing.T, data []byte) any {
+	t.Helper()
+	var v any
+	require.NoError(t, yaml.Unmarshal(data, &v))
+	return v
+}
+
+func TestSource_NormalizesIndentation(t *testing.T) {
+	input := []byte("version: rudderstack/v0.1\nmetadata:\n    name: a\nspec:\n    id: b\n")
+	want := "version: rudderstack/v0.1\nmetadata:\n  name: a\nspec:\n  id: b\n"
+
+	got, err := Source(input)
+	require.NoError(t, err)
+	assert.Equal(t, want, string(got))
+}
+
+func TestSource_PreservesKeyOrder(t *testing.T) {
+	input := []byte("zebra: 1\napple: 2\nmango: 3\n")
+
+	got, err := Source(input)
+	require.NoError(t, err)
+	assert.Equal(t, "zebra: 1\napple: 2\nmango: 3\n", string(got))
+}
+
+func TestSource_PreservesComments(t *testing.T) {
+	input := []byte("# leading comment\nkey: value # inline comment\n")
+
+	got, err := Source(input)
+	require.NoError(t, err)
+	assert.Contains(t, string(got), "# leading comment")
+	assert.Contains(t, string(got), "# inline comment")
+}
+
+func TestSource_Idempotent(t *testing.T) {
+	inputs := [][]byte{
+		[]byte("version: rudderstack/v0.1\nmetadata:\n    name: a\nspec:\n    id: b\n"),
+		[]byte("# head\nlist:\n  - one\n  - two\nnested:\n  a:\n    b: c\n"),
+		[]byte("key: value # inline\nother:   spaced\n"),
+		[]byte("a:\n- x\n- y\n"),
+	}
+
+	for _, in := range inputs {
+		once, err := Source(in)
+		require.NoError(t, err)
+		twice, err := Source(once)
+		require.NoError(t, err)
+		assert.Equal(t, string(once), string(twice), "formatting must be idempotent for %q", string(in))
+	}
+}
+
+func TestSource_SemanticsPreserved(t *testing.T) {
+	input := []byte("version: rudderstack/v0.1\nmetadata:\n    name: a\nspec:\n  list:\n  - 1\n  - 2\n  flag: true\n")
+
+	got, err := Source(input)
+	require.NoError(t, err)
+	assert.Equal(t, parse(t, input), parse(t, got), "formatted output must parse to the same value")
+}
+
+func TestSource_EmptyAndBlank(t *testing.T) {
+	for _, in := range []string{"", "\n", "   \n"} {
+		got, err := Source([]byte(in))
+		require.NoError(t, err)
+		// An empty document round-trips to empty output.
+		assert.Empty(t, string(got))
+	}
+}
+
+func TestSource_InvalidYAMLErrors(t *testing.T) {
+	_, err := Source([]byte("key: : : bad\n"))
+	assert.Error(t, err)
+}

--- a/cli/internal/format/runner.go
+++ b/cli/internal/format/runner.go
@@ -1,0 +1,148 @@
+package format
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+
+	udiff "github.com/aymanbagabas/go-udiff"
+	"github.com/rudderlabs/rudder-iac/cli/internal/project/loader"
+)
+
+// Options controls how Run applies formatting.
+type Options struct {
+	// Check reports which files would change and does not write; the caller
+	// typically exits non-zero when any Result is Changed.
+	Check bool
+	// Diff populates Result.Diff with a unified diff and does not write.
+	Diff bool
+}
+
+// Result is the outcome of formatting a single file.
+type Result struct {
+	Path    string
+	Changed bool
+	// Diff is a unified diff of the change, populated only in diff mode.
+	Diff string
+	// Err records a per-file failure (e.g. invalid YAML) so one bad file does
+	// not abort the whole run.
+	Err error
+}
+
+// Run discovers spec YAML files under the given paths (files or directories;
+// defaults to the current directory when empty) and formats each one according
+// to opts. In the default mode it rewrites changed files in place; Check and
+// Diff modes never write.
+//
+// Discovery errors (a missing path) abort the run; per-file formatting errors
+// are recorded on the corresponding Result instead.
+func Run(paths []string, opts Options) ([]Result, error) {
+	if len(paths) == 0 {
+		paths = []string{"."}
+	}
+
+	files, err := discover(paths)
+	if err != nil {
+		return nil, err
+	}
+
+	results := make([]Result, 0, len(files))
+	for _, path := range files {
+		results = append(results, formatFile(path, opts))
+	}
+	return results, nil
+}
+
+func formatFile(path string, opts Options) Result {
+	res := Result{Path: path}
+
+	original, err := os.ReadFile(path)
+	if err != nil {
+		res.Err = fmt.Errorf("reading %s: %w", path, err)
+		return res
+	}
+
+	formatted, err := Source(original)
+	if err != nil {
+		res.Err = fmt.Errorf("formatting %s: %w", path, err)
+		return res
+	}
+
+	res.Changed = !bytes.Equal(original, formatted)
+	if !res.Changed {
+		return res
+	}
+
+	switch {
+	case opts.Diff:
+		res.Diff = udiff.Unified(path, path, string(original), string(formatted))
+	case opts.Check:
+		// report only
+	default:
+		if err := os.WriteFile(path, formatted, filePerm(path)); err != nil {
+			res.Err = fmt.Errorf("writing %s: %w", path, err)
+		}
+	}
+	return res
+}
+
+// discover walks the given paths and returns the sorted, deduplicated set of
+// spec YAML files (.yaml/.yml, including .vars.yaml var files). A path that is
+// itself a YAML file is included directly; a directory is walked recursively.
+func discover(paths []string) ([]string, error) {
+	seen := make(map[string]struct{})
+
+	for _, p := range paths {
+		info, err := os.Stat(p)
+		if err != nil {
+			return nil, fmt.Errorf("accessing path %s: %w", p, err)
+		}
+
+		if !info.IsDir() {
+			if isYAML(p) {
+				seen[p] = struct{}{}
+			}
+			continue
+		}
+
+		err = filepath.WalkDir(p, func(path string, d os.DirEntry, err error) error {
+			if err != nil {
+				return fmt.Errorf("walking %s: %w", path, err)
+			}
+			if d.IsDir() || !isYAML(path) {
+				return nil
+			}
+			seen[path] = struct{}{}
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	files := make([]string, 0, len(seen))
+	for f := range seen {
+		files = append(files, f)
+	}
+	sort.Strings(files)
+	return files, nil
+}
+
+// isYAML reports whether path is a spec or var YAML file. Var files
+// (*.vars.yaml) are included: fmt normalizes any YAML, unlike the spec loader
+// which skips them.
+func isYAML(path string) bool {
+	ext := filepath.Ext(path)
+	return ext == loader.ExtensionYAML || ext == loader.ExtensionYML
+}
+
+// filePerm preserves the existing file's permission bits, falling back to a
+// sane default if it cannot be stat'd.
+func filePerm(path string) os.FileMode {
+	if info, err := os.Stat(path); err == nil {
+		return info.Mode().Perm()
+	}
+	return 0o644
+}

--- a/cli/internal/format/runner_test.go
+++ b/cli/internal/format/runner_test.go
@@ -1,0 +1,140 @@
+package format
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func writeFile(t *testing.T, dir, rel, content string) string {
+	t.Helper()
+	path := filepath.Join(dir, rel)
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+	return path
+}
+
+func TestRun_WriteMode_RewritesUnformattedFiles(t *testing.T) {
+	dir := t.TempDir()
+	unformatted := writeFile(t, dir, "a.yaml", "metadata:\n    name: a\n")
+	formatted := writeFile(t, dir, "b.yaml", "metadata:\n  name: b\n")
+
+	results, err := Run([]string{dir}, Options{})
+	require.NoError(t, err)
+
+	require.Len(t, results, 2)
+	byPath := map[string]Result{}
+	for _, r := range results {
+		byPath[r.Path] = r
+	}
+	assert.True(t, byPath[unformatted].Changed)
+	assert.False(t, byPath[formatted].Changed)
+
+	got, err := os.ReadFile(unformatted)
+	require.NoError(t, err)
+	assert.Equal(t, "metadata:\n  name: a\n", string(got))
+}
+
+func TestRun_CheckMode_DoesNotWrite(t *testing.T) {
+	dir := t.TempDir()
+	path := writeFile(t, dir, "a.yaml", "metadata:\n    name: a\n")
+
+	results, err := Run([]string{path}, Options{Check: true})
+	require.NoError(t, err)
+
+	require.Len(t, results, 1)
+	assert.True(t, results[0].Changed)
+
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "metadata:\n    name: a\n", string(got), "check mode must not modify the file")
+}
+
+func TestRun_DiffMode_ProducesUnifiedDiffWithoutWriting(t *testing.T) {
+	dir := t.TempDir()
+	path := writeFile(t, dir, "a.yaml", "metadata:\n    name: a\n")
+
+	results, err := Run([]string{path}, Options{Diff: true})
+	require.NoError(t, err)
+
+	require.Len(t, results, 1)
+	assert.True(t, results[0].Changed)
+	assert.Contains(t, results[0].Diff, "---")
+	assert.Contains(t, results[0].Diff, "+++")
+	assert.Contains(t, results[0].Diff, "name: a")
+
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "metadata:\n    name: a\n", string(got), "diff mode must not modify the file")
+}
+
+func TestRun_IncludesVarFiles(t *testing.T) {
+	dir := t.TempDir()
+	varFile := writeFile(t, dir, "secrets.vars.yaml", "KEY:    value\n")
+
+	results, err := Run([]string{dir}, Options{Check: true})
+	require.NoError(t, err)
+
+	require.Len(t, results, 1)
+	assert.Equal(t, varFile, results[0].Path)
+	assert.True(t, results[0].Changed)
+}
+
+func TestRun_SkipsNonYAMLFiles(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "README.md", "# hello\n")
+	writeFile(t, dir, "notes.txt", "text\n")
+	writeFile(t, dir, "spec.yaml", "metadata:\n  name: a\n")
+
+	results, err := Run([]string{dir}, Options{Check: true})
+	require.NoError(t, err)
+
+	require.Len(t, results, 1)
+	assert.Equal(t, filepath.Join(dir, "spec.yaml"), results[0].Path)
+}
+
+func TestRun_ExplicitFileFormattedRegardlessOfExtension(t *testing.T) {
+	// A path passed explicitly is honored even without a YAML extension is NOT
+	// desired; we only format YAML. But an explicit .yml file must be picked up.
+	dir := t.TempDir()
+	path := writeFile(t, dir, "spec.yml", "metadata:\n    name: a\n")
+
+	results, err := Run([]string{path}, Options{Check: true})
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.True(t, results[0].Changed)
+}
+
+func TestRun_InvalidYAMLReportsError(t *testing.T) {
+	dir := t.TempDir()
+	path := writeFile(t, dir, "bad.yaml", "key: : : bad\n")
+
+	results, err := Run([]string{path}, Options{Check: true})
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Error(t, results[0].Err)
+	assert.False(t, results[0].Changed)
+}
+
+func TestRun_MissingPathErrors(t *testing.T) {
+	_, err := Run([]string{filepath.Join(t.TempDir(), "does-not-exist")}, Options{})
+	assert.Error(t, err)
+}
+
+func TestRun_DefaultsToCurrentDirectory(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "spec.yaml", "metadata:\n    name: a\n")
+
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() { _ = os.Chdir(cwd) })
+
+	results, err := Run(nil, Options{Check: true})
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.True(t, results[0].Changed)
+}

--- a/docs/fmt.md
+++ b/docs/fmt.md
@@ -1,0 +1,51 @@
+# Formatting spec files (`rudder-cli fmt`)
+
+`rudder-cli fmt` rewrites spec YAML into a canonical form — like `gofmt` or
+`terraform fmt`. It normalizes **layout only** (indentation, whitespace, quoting)
+and **preserves your comments and key order**. Formatting is idempotent and
+semantics-preserving: a formatted spec parses to exactly the same thing it did
+before.
+
+The point is consistency: identical specs look identical in git, so review diffs
+show real changes instead of whitespace noise — and tools or LLM agents that emit
+specs have a single canonical target to match.
+
+## The `fmt` command
+
+```bash
+# Format the current directory (recursively), rewriting files in place
+rudder-cli fmt
+
+# Format specific files or directories
+rudder-cli fmt ./specs spec.yaml
+
+# CI mode: don't write; exit non-zero if any file isn't formatted
+rudder-cli fmt --check ./specs
+
+# Preview: print a unified diff of what would change, without writing
+rudder-cli fmt --diff spec.yaml
+```
+
+With no path, the current directory is formatted recursively. `--check` and
+`--diff` are mutually exclusive.
+
+## Example use cases
+
+- **Clean PR diffs.** Run `rudder-cli fmt` before committing so reviews surface
+  intent, not reformatting churn.
+- **CI hygiene gate.** Add `rudder-cli fmt --check .` to CI; the non-zero exit
+  fails the build when a spec was committed unformatted.
+- **Pre-commit hook.** Wire `rudder-cli fmt` (or `--check`) into a pre-commit hook
+  to keep the repo canonical automatically.
+- **Canonical output for agents.** When an LLM/coding agent generates or edits
+  specs, run `fmt` afterward so its output is deterministic and diff-stable.
+
+## How it works
+
+- `fmt` operates on the YAML text directly (before any provider parsing) — it is a
+  layout transform, not a semantic one.
+- Files are parsed into a comment-preserving node tree (`yaml.Node`) and
+  re-encoded with canonical indentation and spacing; comments and key order are
+  kept as written.
+- The transform is idempotent: running `fmt` on already-formatted output produces
+  no change (covered by a property test).

--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ replace github.com/rudderlabs/rudder-data-catalog-provider/sdk => ../rudder-data
 
 require (
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
-	github.com/aymanbagabas/go-udiff v0.3.1 // indirect
+	github.com/aymanbagabas/go-udiff v0.3.1
 	github.com/charmbracelet/colorprofile v0.3.2 // indirect
 	github.com/charmbracelet/harmonica v0.2.0 // indirect
 	github.com/charmbracelet/x/ansi v0.10.1 // indirect


### PR DESCRIPTION
## 🔗 Ticket
_No ticket yet — CLI developer-experience tooling._

## Summary
Adds `rudder-cli fmt`, a deterministic, idempotent formatter for spec YAML (gofmt/`terraform fmt` for specs). Normalizes layout only — indentation, whitespace, quoting — while **preserving comments and key order**, so specs stay canonical and diffs stay clean.

## Changes
- New `cli/internal/format` package: comment/order-preserving formatter core (`yaml.Node`-based, idempotent, semantics-preserving).
- New `rudder-cli fmt [path...]` command with `--check` (CI; non-zero exit if unformatted) and `--diff` (preview) modes.
- Docs: `docs/fmt.md` user guide.

## Testing
- Unit tests: formatter idempotence + comment/key-order preservation; command flag/exit behavior.
- `make test` + `make lint` pass; manual `--check`/`--diff`/in-place on a sample project.

## Risk / Impact
Low. Additive command; layout-only and semantics-preserving; no change to existing behavior.

## Checklist
- [ ] Ticket linked
- [x] Tests added/updated
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)