### PR TITLE
feat(cli): add rudder-cli graph (dependency graph export)

### DIFF
--- a/cli/internal/cmd/project/graph/graph.go
+++ b/cli/internal/cmd/project/graph/graph.go
@@ -1,0 +1,106 @@
+package graph
+
+import (
+	"fmt"
+
+	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/rudderlabs/rudder-iac/cli/internal/app"
+	"github.com/rudderlabs/rudder-iac/cli/internal/cmd/telemetry"
+	"github.com/rudderlabs/rudder-iac/cli/internal/config"
+	graphrender "github.com/rudderlabs/rudder-iac/cli/internal/graph"
+	"github.com/rudderlabs/rudder-iac/cli/internal/logger"
+	"github.com/rudderlabs/rudder-iac/cli/internal/project"
+	"github.com/spf13/cobra"
+)
+
+var graphLog = logger.New("root", logger.Attr{
+	Key:   "cmd",
+	Value: "graph",
+})
+
+func NewCmdGraph() *cobra.Command {
+	var (
+		deps       app.Deps
+		p          project.Project
+		err        error
+		location   string
+		format     string
+		typeFilter string
+		varFiles   []string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "graph [path]",
+		Short: "Export the project's resource dependency graph",
+		Long: heredoc.Doc(`
+			Exports the resource dependency graph of a project.
+
+			The 'dot' and 'mermaid' formats are meant for humans (assessing
+			blast-radius during review, onboarding). The 'json' format is a
+			stable machine contract consumed by the VS Code graph view and by
+			agents.
+
+			This is a pure, read-only export: it loads the local project and
+			renders its graph. It never mutates any resource.
+		`),
+		Example: heredoc.Doc(`
+			$ rudder-cli graph
+			$ rudder-cli graph ./project --format dot | dot -Tsvg > graph.svg
+			$ rudder-cli graph --format mermaid
+			$ rudder-cli graph --format json --type event
+		`),
+		Args: cobra.MaximumNArgs(1),
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			// A positional path argument overrides --location when provided.
+			if len(args) == 1 {
+				location = args[0]
+			}
+
+			deps, err = app.NewDeps()
+			if err != nil {
+				return fmt.Errorf("initialising dependencies: %w", err)
+			}
+
+			projectOpts, err := app.NewProjectOptions(config.GetConfig(), varFiles)
+			if err != nil {
+				return err
+			}
+
+			p = deps.NewProject(projectOpts...)
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			graphLog.Debug("graph", "location", location, "format", format, "type", typeFilter)
+
+			defer func() {
+				telemetry.TrackCommand("graph", err, []telemetry.KV{
+					{K: "format", V: format},
+				}...)
+			}()
+
+			if err = p.Load(location); err != nil {
+				return fmt.Errorf("loading project: %w", err)
+			}
+
+			g, err := p.ResourceGraph()
+			if err != nil {
+				return fmt.Errorf("building resource graph: %w", err)
+			}
+
+			if err = graphrender.Render(cmd.OutOrStdout(), g, graphrender.Options{
+				Format:     graphrender.Format(format),
+				TypeFilter: typeFilter,
+			}); err != nil {
+				return fmt.Errorf("rendering graph: %w", err)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&location, "location", "l", ".", "Path to the directory containing the project files or a specific file")
+	cmd.Flags().StringVarP(&format, "format", "f", string(graphrender.FormatDOT), "Output format: dot, mermaid, or json")
+	cmd.Flags().StringVarP(&typeFilter, "type", "t", "", "Restrict the graph to resources of this type (default: whole graph)")
+	cmd.Flags().StringArrayVar(&varFiles, "var-file", nil, "Path to a variable file ending in .vars.yaml or .vars.yml (repeatable; later files take priority)")
+	return cmd
+}

--- a/cli/internal/cmd/project/graph/graph_test.go
+++ b/cli/internal/cmd/project/graph/graph_test.go
@@ -1,0 +1,34 @@
+package graph
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewCmdGraph_Defaults(t *testing.T) {
+	t.Parallel()
+
+	cmd := NewCmdGraph()
+	assert.Equal(t, "graph [path]", cmd.Use)
+
+	format, err := cmd.Flags().GetString("format")
+	assert.NoError(t, err)
+	assert.Equal(t, "dot", format)
+
+	location, err := cmd.Flags().GetString("location")
+	assert.NoError(t, err)
+	assert.Equal(t, ".", location)
+
+	typeFilter, err := cmd.Flags().GetString("type")
+	assert.NoError(t, err)
+	assert.Empty(t, typeFilter)
+}
+
+func TestNewCmdGraph_AcceptsAtMostOnePositionalArg(t *testing.T) {
+	t.Parallel()
+
+	cmd := NewCmdGraph()
+	assert.NoError(t, cmd.Args(cmd, []string{"./project"}))
+	assert.Error(t, cmd.Args(cmd, []string{"a", "b"}))
+}

--- a/cli/internal/cmd/root.go
+++ b/cli/internal/cmd/root.go
@@ -9,19 +9,20 @@ import (
 
 	"github.com/kyokomi/emoji/v2"
 	"github.com/rudderlabs/rudder-iac/cli/internal/app"
-	"github.com/rudderlabs/rudder-iac/cli/internal/cmd/cmderrors"
 	"github.com/rudderlabs/rudder-iac/cli/internal/cmd/auth"
+	"github.com/rudderlabs/rudder-iac/cli/internal/cmd/cmderrors"
+	datagraphPkg "github.com/rudderlabs/rudder-iac/cli/internal/cmd/datagraph"
 	d "github.com/rudderlabs/rudder-iac/cli/internal/cmd/debug"
 	"github.com/rudderlabs/rudder-iac/cli/internal/cmd/experimental"
 	importcmd "github.com/rudderlabs/rudder-iac/cli/internal/cmd/import"
 	"github.com/rudderlabs/rudder-iac/cli/internal/cmd/project/apply"
 	"github.com/rudderlabs/rudder-iac/cli/internal/cmd/project/destroy"
+	graphcmd "github.com/rudderlabs/rudder-iac/cli/internal/cmd/project/graph"
 	"github.com/rudderlabs/rudder-iac/cli/internal/cmd/project/migrate"
 	"github.com/rudderlabs/rudder-iac/cli/internal/cmd/project/validate"
 	retlsource "github.com/rudderlabs/rudder-iac/cli/internal/cmd/retl-sources"
 	telemetryCmd "github.com/rudderlabs/rudder-iac/cli/internal/cmd/telemetry"
 	"github.com/rudderlabs/rudder-iac/cli/internal/cmd/trackingplan"
-	datagraphPkg "github.com/rudderlabs/rudder-iac/cli/internal/cmd/datagraph"
 	"github.com/rudderlabs/rudder-iac/cli/internal/cmd/transformations"
 	"github.com/rudderlabs/rudder-iac/cli/internal/cmd/typer"
 	"github.com/rudderlabs/rudder-iac/cli/internal/cmd/workspace"
@@ -91,6 +92,7 @@ func init() {
 	rootCmd.AddCommand(validate.NewCmdValidate())
 	rootCmd.AddCommand(destroy.NewCmdDestroy())
 	rootCmd.AddCommand(migrate.NewCmdMigrate())
+	rootCmd.AddCommand(graphcmd.NewCmdGraph())
 
 	debugCmd = d.NewCmdDebug()
 	experimentalCmd = experimental.NewCmdExperimental()

--- a/cli/internal/graph/encoders.go
+++ b/cli/internal/graph/encoders.go
@@ -1,0 +1,95 @@
+package graph
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+)
+
+func renderJSON(w io.Writer, doc Document) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(doc); err != nil {
+		return fmt.Errorf("encoding json graph: %w", err)
+	}
+	return nil
+}
+
+// renderDOT emits a graphviz digraph. Nodes are shaped/coloured by resource
+// type so the rendered image conveys the type at a glance.
+func renderDOT(w io.Writer, doc Document) error {
+	var b strings.Builder
+	b.WriteString("digraph resources {\n")
+	b.WriteString("  rankdir=LR;\n")
+
+	for _, n := range doc.Nodes {
+		shape, color := dotStyle(n.Type)
+		fmt.Fprintf(&b, "  %q [label=%q, shape=%s, style=filled, fillcolor=%q];\n",
+			n.URN, n.URN, shape, color)
+	}
+
+	for _, e := range doc.Edges {
+		fmt.Fprintf(&b, "  %q -> %q;\n", e.From, e.To)
+	}
+
+	for _, c := range doc.Cycles {
+		fmt.Fprintf(&b, "  // cycle: %s\n", c)
+	}
+
+	b.WriteString("}\n")
+
+	if _, err := io.WriteString(w, b.String()); err != nil {
+		return fmt.Errorf("writing dot graph: %w", err)
+	}
+	return nil
+}
+
+// renderMermaid emits a mermaid `graph TD` diagram. Node ids are sanitised to
+// mermaid-safe identifiers while the URN is kept as the visible label.
+func renderMermaid(w io.Writer, doc Document) error {
+	var b strings.Builder
+	b.WriteString("graph TD\n")
+
+	for _, n := range doc.Nodes {
+		fmt.Fprintf(&b, "  %s[%q]\n", mermaidID(n.URN), n.URN)
+	}
+
+	for _, e := range doc.Edges {
+		fmt.Fprintf(&b, "  %s --> %s\n", mermaidID(e.From), mermaidID(e.To))
+	}
+
+	for _, c := range doc.Cycles {
+		fmt.Fprintf(&b, "  %%%% cycle: %s\n", c)
+	}
+
+	if _, err := io.WriteString(w, b.String()); err != nil {
+		return fmt.Errorf("writing mermaid graph: %w", err)
+	}
+	return nil
+}
+
+// dotStyle maps a resource type to a graphviz shape and fill colour. Unknown
+// types fall back to a neutral default rather than being rejected, so new
+// resource types render without a code change.
+func dotStyle(resourceType string) (shape, color string) {
+	switch resourceType {
+	case "event":
+		return "box", "#cfe2ff"
+	case "property":
+		return "ellipse", "#d1e7dd"
+	case "tracking-plan":
+		return "component", "#fff3cd"
+	case "custom-type":
+		return "ellipse", "#e2e3e5"
+	default:
+		return "box", "#f8f9fa"
+	}
+}
+
+// mermaidID converts a URN into a mermaid-safe node identifier. Mermaid node
+// ids may not contain ":" or "-", so they are replaced with "_".
+func mermaidID(urn string) string {
+	r := strings.NewReplacer(":", "_", "-", "_", ".", "_", "/", "_")
+	return "n_" + r.Replace(urn)
+}

--- a/cli/internal/graph/graph.go
+++ b/cli/internal/graph/graph.go
@@ -1,0 +1,145 @@
+// Package graph renders a project's resource dependency graph into
+// human- and machine-readable formats (dot, mermaid, json).
+//
+// It is a pure renderer over the already-built resources.Graph: it performs no
+// I/O beyond writing to the provided io.Writer and never mutates the graph.
+//
+// # JSON schema (stable contract)
+//
+// The json format is the machine contract consumed by the VS Code graph view
+// and by agents. It MUST remain backward compatible. A document looks like:
+//
+//		{
+//		  "nodes": [ { "urn": "event:a", "type": "event", "id": "a" } ],
+//		  "edges": [ { "from": "event:a", "to": "property:b" } ],
+//		  "cycles": [ "event:a → event:b → event:a" ]
+//		}
+//
+//	  - node.urn   fully-qualified resource identifier, formatted "type:id".
+//	  - node.type  resource type (the URN prefix).
+//	  - node.id    resource id within its type (the URN suffix).
+//	  - edge.from  URN of the dependent resource.
+//	  - edge.to    URN of the dependency. "from depends on to".
+//	  - cycles     each entry is a human-readable path of a circular dependency;
+//	               the field is omitted when no cycles exist.
+//
+// nodes and edges are sorted (nodes by urn, edges by from then to) so the
+// output is deterministic and diff-friendly.
+package graph
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"github.com/rudderlabs/rudder-iac/cli/internal/resources"
+)
+
+// ErrUnsupportedFormat is returned when Options.Format is not one of the
+// supported formats.
+var ErrUnsupportedFormat = errors.New("unsupported graph format")
+
+// Format identifies an output encoding.
+type Format string
+
+const (
+	FormatDOT     Format = "dot"
+	FormatMermaid Format = "mermaid"
+	FormatJSON    Format = "json"
+)
+
+// Options configures a Render call.
+type Options struct {
+	// Format selects the output encoding. Required.
+	Format Format
+	// TypeFilter, when non-empty, restricts the output to nodes of this
+	// resource type; edges touching filtered-out nodes are dropped.
+	TypeFilter string
+}
+
+// Node is a single resource in the exported graph. See the package doc for the
+// JSON schema contract.
+type Node struct {
+	URN  string `json:"urn"`
+	Type string `json:"type"`
+	ID   string `json:"id"`
+}
+
+// Edge is a directed dependency: From depends on To.
+type Edge struct {
+	From string `json:"from"`
+	To   string `json:"to"`
+}
+
+// Document is the json representation of the graph (the stable contract).
+type Document struct {
+	Nodes  []Node   `json:"nodes"`
+	Edges  []Edge   `json:"edges"`
+	Cycles []string `json:"cycles,omitempty"`
+}
+
+// Render writes g to w in the format selected by opts. It reuses the existing
+// resources.Graph and never mutates it.
+func Render(w io.Writer, g *resources.Graph, opts Options) error {
+	doc := buildDocument(g, opts.TypeFilter)
+
+	switch opts.Format {
+	case FormatJSON:
+		return renderJSON(w, doc)
+	case FormatDOT:
+		return renderDOT(w, doc)
+	case FormatMermaid:
+		return renderMermaid(w, doc)
+	default:
+		return fmt.Errorf("%w: %q", ErrUnsupportedFormat, opts.Format)
+	}
+}
+
+// buildDocument extracts nodes, edges and cycles from the graph, applying the
+// optional type filter and sorting everything for deterministic output.
+func buildDocument(g *resources.Graph, typeFilter string) Document {
+	included := make(map[string]bool)
+
+	// Initialise as empty (non-nil) slices so the json contract always renders
+	// "nodes": [] / "edges": [] rather than null, which is friendlier to the
+	// VS Code view and other consumers.
+	nodes := []Node{}
+	for urn, r := range g.Resources() {
+		if typeFilter != "" && r.Type() != typeFilter {
+			continue
+		}
+		included[urn] = true
+		nodes = append(nodes, Node{URN: urn, Type: r.Type(), ID: r.ID()})
+	}
+	sort.Slice(nodes, func(i, j int) bool { return nodes[i].URN < nodes[j].URN })
+
+	edges := []Edge{}
+	for _, n := range nodes {
+		for _, dep := range g.GetDependencies(n.URN) {
+			// Drop edges pointing at nodes excluded by the type filter so the
+			// document never references a node that isn't present.
+			if !included[dep] {
+				continue
+			}
+			edges = append(edges, Edge{From: n.URN, To: dep})
+		}
+	}
+	sort.Slice(edges, func(i, j int) bool {
+		if edges[i].From != edges[j].From {
+			return edges[i].From < edges[j].From
+		}
+		return edges[i].To < edges[j].To
+	})
+
+	// DetectCycles walks the whole graph regardless of the type filter, which is
+	// intentional: a cycle can run through a filtered-out type, and surfacing it
+	// is more useful than hiding it.
+	var cycles []string
+	if cycle, err := g.DetectCycles(); err != nil {
+		cycles = append(cycles, strings.Join(cycle, " → "))
+	}
+
+	return Document{Nodes: nodes, Edges: edges, Cycles: cycles}
+}

--- a/cli/internal/graph/graph_test.go
+++ b/cli/internal/graph/graph_test.go
@@ -1,0 +1,139 @@
+package graph
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/rudderlabs/rudder-iac/cli/internal/resources"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// buildGraph returns a small graph:
+//
+//	event:a  ──▶  property:b
+//	tracking-plan:c ──▶ event:a
+//
+// where "──▶" means "depends on".
+func buildGraph(t *testing.T) *resources.Graph {
+	t.Helper()
+
+	g := resources.NewGraph()
+	g.AddResource(resources.NewResource("b", "property", resources.ResourceData{}, nil))
+	g.AddResource(resources.NewResource("a", "event", resources.ResourceData{}, nil))
+	g.AddResource(resources.NewResource("c", "tracking-plan", resources.ResourceData{}, nil))
+	g.AddDependency("event:a", "property:b")
+	g.AddDependency("tracking-plan:c", "event:a")
+	return g
+}
+
+func TestRenderJSON_Schema(t *testing.T) {
+	var buf bytes.Buffer
+	err := Render(&buf, buildGraph(t), Options{Format: FormatJSON})
+	require.NoError(t, err)
+
+	var doc Document
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &doc))
+
+	// Nodes and edges are sorted deterministically so the contract is stable.
+	assert.Equal(t, Document{
+		Nodes: []Node{
+			{URN: "event:a", Type: "event", ID: "a"},
+			{URN: "property:b", Type: "property", ID: "b"},
+			{URN: "tracking-plan:c", Type: "tracking-plan", ID: "c"},
+		},
+		Edges: []Edge{
+			{From: "event:a", To: "property:b"},
+			{From: "tracking-plan:c", To: "event:a"},
+		},
+		Cycles: nil,
+	}, doc)
+}
+
+func TestRenderJSON_KeysAreStable(t *testing.T) {
+	var buf bytes.Buffer
+	err := Render(&buf, buildGraph(t), Options{Format: FormatJSON})
+	require.NoError(t, err)
+
+	// Pin the exact JSON key names since the VS Code view depends on them.
+	out := buf.String()
+	for _, key := range []string{`"nodes"`, `"edges"`, `"urn"`, `"type"`, `"id"`, `"from"`, `"to"`} {
+		assert.Contains(t, out, key)
+	}
+}
+
+func TestRenderJSON_EmptyGraphUsesArraysNotNull(t *testing.T) {
+	var buf bytes.Buffer
+	err := Render(&buf, resources.NewGraph(), Options{Format: FormatJSON})
+	require.NoError(t, err)
+
+	// The contract requires empty arrays, never null, so consumers can iterate
+	// without a nil check.
+	out := buf.String()
+	assert.Contains(t, out, `"nodes": []`)
+	assert.Contains(t, out, `"edges": []`)
+	assert.NotContains(t, out, "null")
+}
+
+func TestRenderJSON_ReportsCycles(t *testing.T) {
+	g := resources.NewGraph()
+	g.AddResource(resources.NewResource("a", "event", resources.ResourceData{}, nil))
+	g.AddResource(resources.NewResource("b", "event", resources.ResourceData{}, nil))
+	g.AddDependency("event:a", "event:b")
+	g.AddDependency("event:b", "event:a")
+
+	var buf bytes.Buffer
+	err := Render(&buf, g, Options{Format: FormatJSON})
+	require.NoError(t, err)
+
+	var doc Document
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &doc))
+	require.NotEmpty(t, doc.Cycles, "cycle should be surfaced, not cause a hang")
+	assert.Contains(t, doc.Cycles[0], "event:a")
+}
+
+func TestRenderDOT(t *testing.T) {
+	var buf bytes.Buffer
+	err := Render(&buf, buildGraph(t), Options{Format: FormatDOT})
+	require.NoError(t, err)
+
+	out := buf.String()
+	assert.True(t, strings.HasPrefix(out, "digraph"))
+	assert.Contains(t, out, `"event:a" -> "property:b"`)
+	assert.Contains(t, out, `"tracking-plan:c" -> "event:a"`)
+	// URN used as node label.
+	assert.Contains(t, out, `label="event:a"`)
+	assert.True(t, strings.HasSuffix(strings.TrimSpace(out), "}"))
+}
+
+func TestRenderMermaid(t *testing.T) {
+	var buf bytes.Buffer
+	err := Render(&buf, buildGraph(t), Options{Format: FormatMermaid})
+	require.NoError(t, err)
+
+	out := buf.String()
+	assert.True(t, strings.HasPrefix(strings.TrimSpace(out), "graph TD"))
+	assert.Contains(t, out, "-->")
+	assert.Contains(t, out, "event:a")
+}
+
+func TestRender_TypeFilter(t *testing.T) {
+	var buf bytes.Buffer
+	err := Render(&buf, buildGraph(t), Options{Format: FormatJSON, TypeFilter: "event"})
+	require.NoError(t, err)
+
+	var doc Document
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &doc))
+
+	// Only event nodes remain; edges touching filtered-out nodes are dropped.
+	assert.Equal(t, []Node{{URN: "event:a", Type: "event", ID: "a"}}, doc.Nodes)
+	assert.Empty(t, doc.Edges)
+}
+
+func TestRender_UnknownFormat(t *testing.T) {
+	var buf bytes.Buffer
+	err := Render(&buf, buildGraph(t), Options{Format: "yaml"})
+	assert.ErrorIs(t, err, ErrUnsupportedFormat)
+}

--- a/docs/graph.md
+++ b/docs/graph.md
@@ -1,0 +1,77 @@
+# Dependency graph export (`rudder-cli graph`)
+
+`rudder-cli graph` exports the **resource dependency graph** of a project — the
+resources you declare and the references between them. Render it for humans
+(Graphviz / Mermaid) to understand blast radius and structure, or emit JSON to
+feed other tools.
+
+It reads the same graph the apply cycle builds, so what you see is exactly what
+`apply` reasons about.
+
+## The `graph` command
+
+```bash
+# Print a Graphviz DOT graph of the current project
+rudder-cli graph
+
+# Choose a format explicitly
+rudder-cli graph --format dot
+rudder-cli graph --format mermaid
+rudder-cli graph --format json
+
+# Point at a specific project directory or file
+rudder-cli graph ./specs
+
+# Restrict to one resource type
+rudder-cli graph --type event
+```
+
+Render the human formats with the usual tools:
+
+```bash
+rudder-cli graph --format dot | dot -Tsvg > graph.svg
+rudder-cli graph --format mermaid   # paste into any Mermaid viewer
+```
+
+## JSON output (stable contract)
+
+`--format json` emits a documented, stable shape that other tools can depend on:
+
+```json
+{
+  "nodes": [{ "urn": "event:signed_up", "type": "event", "id": "signed_up" }],
+  "edges": [{ "from": "event:signed_up", "to": "property:user_id" }],
+  "cycles": ["event:a → event:b → event:a"]
+}
+```
+
+- `urn` is `type:id`; `type`/`id` are its parts.
+- `edge.from` **depends on** `edge.to`.
+- `nodes`/`edges` are always arrays (never `null`) and are sorted for
+  deterministic output; `cycles` is omitted when there are none.
+
+## Example use cases
+
+- **Blast-radius review.** Before changing a shared property or model, export the
+  graph to see everything that depends on it.
+- **Onboarding / mental model.** A picture of sources → connections → destinations,
+  or tracking-plan → events → properties, orients new contributors fast.
+- **Cycle detection.** Cycles are reported (never hang), surfacing accidental
+  circular references.
+- **Tooling data source.** The JSON form is the input for editor/graph
+  visualizations (e.g. the planned VS Code graph view).
+
+## Notes
+
+- `graph` currently initializes the full app dependencies, so it needs an access
+  token (`RUDDERSTACK_ACCESS_TOKEN` or `rudder-cli auth login`) even though the
+  export itself is local. Making local commands credential-free is a tracked
+  follow-up.
+
+## How it works
+
+- The project is loaded the same way `validate`/`apply` load it, then
+  `provider.ResourceGraph()` produces the graph — `graph` only renders it, it does
+  not re-implement graph building.
+- `--type` filters to nodes of one resource type and drops edges to filtered-out
+  nodes.


### PR DESCRIPTION
## 🔗 Ticket
_No ticket yet — CLI developer-experience tooling._

## Summary
Adds `rudder-cli graph`, exporting a project's **resource dependency graph** as Graphviz DOT, Mermaid, or JSON — for blast-radius review, onboarding, and tooling.

## Changes
- New `cli/internal/graph` package: renderer + dot/mermaid/json encoders. Reuses `provider.ResourceGraph()` (no re-implementation); surfaces cycles; deterministic output.
- New `rudder-cli graph [path] [--format dot|mermaid|json] [--type <t>]` command. The JSON `{nodes,edges}` shape is a documented, test-pinned contract.
- Docs: `docs/graph.md`.

## Testing
- Renderer tests pin the JSON schema, cycle reporting, and dot/mermaid output; command flag/args tests.
- `make test` + `make lint` pass; manual: `graph --format dot | dot -Tsvg`.

## Risk / Impact
Low. Pure read/export; no mutation.

## Notes
Known follow-up: `graph` initializes `app.NewDeps()` and so currently needs an access token even though the export is local — candidate for a "local commands shouldn't need auth" cleanup.

## Checklist
- [ ] Ticket linked
- [x] Tests added/updated
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)