### PR TITLE
feat(cli): add structured JSON output to validate (--format json)

### DIFF
--- a/cli/internal/cmd/project/validate/validate.go
+++ b/cli/internal/cmd/project/validate/validate.go
@@ -7,12 +7,19 @@ import (
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/rudderlabs/rudder-iac/api/client"
 	"github.com/rudderlabs/rudder-iac/cli/internal/app"
+	"github.com/rudderlabs/rudder-iac/cli/internal/cmd/cmderrors"
 	"github.com/rudderlabs/rudder-iac/cli/internal/cmd/telemetry"
 	"github.com/rudderlabs/rudder-iac/cli/internal/config"
 	"github.com/rudderlabs/rudder-iac/cli/internal/logger"
 	"github.com/rudderlabs/rudder-iac/cli/internal/project"
 	"github.com/rudderlabs/rudder-iac/cli/internal/ui"
+	"github.com/rudderlabs/rudder-iac/cli/internal/validation/renderer"
 	"github.com/spf13/cobra"
+)
+
+const (
+	formatText = "text"
+	formatJSON = "json"
 )
 
 var (
@@ -30,6 +37,7 @@ func NewCmdValidate() *cobra.Command {
 		err       error
 		location  string
 		varFiles  []string
+		format    string
 	)
 
 	cmd := &cobra.Command{
@@ -39,11 +47,20 @@ func NewCmdValidate() *cobra.Command {
 			Validates the project configuration files for correctness and consistency.
 			This includes checking for valid syntax, required fields, and relationships
 			between resources.
+
+			Use --format json to emit machine-readable diagnostics with stable error
+			codes and source positions (file, line, column), suitable for editors,
+			CI, and other tooling.
 		`),
 		Example: heredoc.Doc(`
 			$ rudder-cli validate --location </path/to/dir or file>
+			$ rudder-cli validate --format json
 		`),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if format != formatText && format != formatJSON {
+				return fmt.Errorf("invalid --format %q: must be one of %q, %q", format, formatText, formatJSON)
+			}
+
 			deps, err = app.NewDeps()
 			if err != nil {
 				return fmt.Errorf("initialising dependencies: %w", err)
@@ -63,21 +80,40 @@ func NewCmdValidate() *cobra.Command {
 			}
 			projectOpts = append(projectOpts, project.WithWorkspaceID(workspace.ID))
 
+			// In JSON mode, diagnostics are rendered as a machine-readable array to
+			// stdout; the human-readable text renderer stays the default.
+			if format == formatJSON {
+				projectOpts = append(projectOpts, project.WithRenderer(renderer.NewJSONRenderer(cmd.OutOrStdout())))
+			}
+
 			p = deps.NewProject(projectOpts...)
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			validateLog.Debug("validate", "location", location)
+			validateLog.Debug("validate", "location", location, "format", format)
 
 			defer func() {
 				telemetry.TrackCommand("validate", err, []telemetry.KV{
 					{K: "location", V: location},
+					{K: "format", V: format},
 				}...)
 			}()
 
-			// Load and validate the project (validation engine + RuleProvider rules)
-			if err := p.Load(location); err != nil {
+			// Load and validate the project (validation engine + RuleProvider rules).
+			// The configured renderer emits diagnostics; on failure we return a
+			// SilentError in JSON mode so cobra doesn't also write a message to
+			// stderr and disturb the machine-readable output on stdout.
+			if err = p.Load(location); err != nil {
+				if format == formatJSON {
+					return &cmderrors.SilentError{Err: err}
+				}
 				return fmt.Errorf("validating project: %w", err)
+			}
+
+			// Human-readable extras are suppressed in JSON mode so stdout stays a
+			// single, parseable diagnostics document.
+			if format == formatJSON {
+				return nil
 			}
 
 			if project.HasLegacySpecs(p.Specs()) {
@@ -92,5 +128,6 @@ func NewCmdValidate() *cobra.Command {
 
 	cmd.Flags().StringVarP(&location, "location", "l", ".", "Path to the directory containing the project files or a specific file")
 	cmd.Flags().StringArrayVar(&varFiles, "var-file", nil, "Path to a variable file ending in .vars.yaml or .vars.yml (repeatable; later files take priority)")
+	cmd.Flags().StringVar(&format, "format", formatText, "Output format for validation results: text or json")
 	return cmd
 }

--- a/cli/internal/project/validate_json_test.go
+++ b/cli/internal/project/validate_json_test.go
@@ -1,0 +1,78 @@
+package project_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/rudderlabs/rudder-iac/cli/internal/project"
+	"github.com/rudderlabs/rudder-iac/cli/internal/project/specs"
+	"github.com/rudderlabs/rudder-iac/cli/internal/testutils"
+	"github.com/rudderlabs/rudder-iac/cli/internal/validation/renderer"
+)
+
+// TestProject_Load_JSONRenderer pins the machine-readable contract of
+// `validate --format json`: on a spec with a rule violation, the JSON renderer
+// emits a diagnostic carrying the stable code, severity, kind, file and source
+// position. The code set is asserted explicitly so it cannot drift silently —
+// codes are an API for downstream tooling.
+func TestProject_Load_JSONRenderer(t *testing.T) {
+	t.Parallel()
+
+	// kind Destination + version rudder/v1 is an unsupported pair (Destination is
+	// only known at rudder/0.1), so the project/resource-kind-version-valid
+	// gatekeeper flags it at /kind — a deterministic syntactic violation.
+	const spec = "kind: Destination\nversion: rudder/v1\nmetadata:\n  name: my_dest\nspec:\n  k: v"
+
+	mockProvider := testutils.NewMockProvider(nil, nil)
+	mockProvider.MatchPatterns = fixtureMatchPatterns
+
+	mockLoader := &MockLoader{LoadFunc: func(string) (map[string]*specs.RawSpec, error) {
+		return map[string]*specs.RawSpec{
+			"specs/dest.yaml": {Data: []byte(spec)},
+		}, nil
+	}}
+
+	var buf bytes.Buffer
+	proj := project.New(mockProvider,
+		project.WithLoader(mockLoader),
+		project.WithRenderer(renderer.NewJSONRenderer(&buf)),
+	)
+
+	err := proj.Load("test_dir")
+	require.Error(t, err) // validation failed, but diagnostics were rendered as JSON
+
+	var out struct {
+		Diagnostics []struct {
+			Code     string `json:"code"`
+			Severity string `json:"severity"`
+			Message  string `json:"message"`
+			Kind     string `json:"kind"`
+			File     string `json:"file"`
+			Line     int    `json:"line"`
+			Col      int    `json:"col"`
+			RuleDoc  string `json:"ruleDoc"`
+		} `json:"diagnostics"`
+	}
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &out))
+	require.Len(t, out.Diagnostics, 1)
+
+	d := out.Diagnostics[0]
+	assert.Equal(t, "project/resource-kind-version-valid", d.Code)
+	assert.Equal(t, "error", d.Severity)
+	assert.Equal(t, "Destination", d.Kind)
+	assert.Equal(t, "specs/dest.yaml", d.File)
+	assert.Equal(t, 1, d.Line) // /kind is on line 1
+	assert.Greater(t, d.Col, 0)
+	assert.Equal(t, "docs/generated/rules.yaml#project/resource-kind-version-valid", d.RuleDoc)
+
+	// Pin the emitted code set so new/renamed rule codes surface as a test change.
+	codes := make([]string, 0, len(out.Diagnostics))
+	for _, diag := range out.Diagnostics {
+		codes = append(codes, diag.Code)
+	}
+	assert.Equal(t, []string{"project/resource-kind-version-valid"}, codes)
+}

--- a/cli/internal/validation/diagnostic.go
+++ b/cli/internal/validation/diagnostic.go
@@ -26,6 +26,11 @@ type Diagnostic struct {
 	// File is the absolute path to the spec file where the issue was found
 	File string
 
+	// Kind is the resource kind of the spec the issue was found in (e.g.
+	// "properties", "events", "import-manifest"). Empty when the spec could not
+	// be parsed far enough to determine its kind.
+	Kind string
+
 	// Position contains the resolved location information (line, column, lineText)
 	// This is populated by the engine using PathIndexer, so renderers don't need
 	// to do any file I/O or position lookup

--- a/cli/internal/validation/engine.go
+++ b/cli/internal/validation/engine.go
@@ -147,6 +147,7 @@ func (e *validationEngine) runProjectValidationRules(rawSpecs map[string]*specs.
 					Severity: rule.Severity(),
 					Message:  result.Message,
 					File:     filePath,
+					Kind:     rawSpec.Parsed().Kind,
 					Position: *position,
 					Examples: rule.Examples(),
 				})
@@ -247,6 +248,7 @@ func (e *validationEngine) runValidationRules(
 				Severity: rule.Severity(),
 				Message:  result.Message,
 				File:     path,
+				Kind:     rawSpec.Parsed().Kind,
 				Position: *position,
 				Examples: rule.Examples(),
 			})

--- a/cli/internal/validation/engine_test.go
+++ b/cli/internal/validation/engine_test.go
@@ -274,6 +274,7 @@ func TestValidationEngine_ValidateSyntax(t *testing.T) {
 
 			diag := diagnostics[0]
 			assert.Equal(t, "/path/to/test.yaml", diag.File)
+			assert.Equal(t, "properties", diag.Kind)
 			assert.Greater(t, diag.Position.Line, 0)
 			assert.Greater(t, diag.Position.Column, 0)
 		})

--- a/cli/internal/validation/renderer/json.go
+++ b/cli/internal/validation/renderer/json.go
@@ -1,0 +1,71 @@
+package renderer
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/rudderlabs/rudder-iac/cli/internal/validation"
+)
+
+// ruleDocRef points at the rule's entry in the generated rule catalog, which is
+// the single source of truth for every code. The fragment is the stable code
+// (== RuleID), so tooling can resolve a diagnostic's code to its documentation.
+const ruleDocBase = "docs/generated/rules.yaml"
+
+// jsonDiagnostic is the stable, machine-readable shape emitted by the JSON
+// renderer. Field names and the `code` value (the rule ID) form a contract with
+// downstream tooling (editor diagnostics, MCP validate, agents) and must remain
+// backward compatible across releases.
+type jsonDiagnostic struct {
+	// Code is the stable rule identifier (e.g. "datacatalog/properties/spec-syntax-valid").
+	// It is the primary key tooling keys off; it never changes for a given rule.
+	Code     string `json:"code"`
+	Severity string `json:"severity"`
+	Message  string `json:"message"`
+	Kind     string `json:"kind,omitempty"`
+	Resource string `json:"resource,omitempty"`
+	File     string `json:"file"`
+	Line     int    `json:"line"`
+	Col      int    `json:"col"`
+	RuleDoc  string `json:"ruleDoc,omitempty"`
+}
+
+// jsonOutput wraps the diagnostics array in an object so the schema can grow
+// (e.g. summary counts) without breaking consumers that parse the top level.
+type jsonOutput struct {
+	Diagnostics []jsonDiagnostic `json:"diagnostics"`
+}
+
+// JSONRenderer renders validation diagnostics as machine-readable JSON.
+type JSONRenderer struct {
+	w io.Writer
+}
+
+func NewJSONRenderer(w io.Writer) Renderer {
+	return &JSONRenderer{w: w}
+}
+
+func (r *JSONRenderer) Render(diagnostics validation.Diagnostics) error {
+	out := jsonOutput{Diagnostics: make([]jsonDiagnostic, 0, len(diagnostics))}
+
+	for _, d := range diagnostics {
+		out.Diagnostics = append(out.Diagnostics, jsonDiagnostic{
+			Code:     d.RuleID,
+			Severity: d.Severity.String(),
+			Message:  d.Message,
+			Kind:     d.Kind,
+			File:     d.File,
+			Line:     d.Position.Line,
+			Col:      d.Position.Column,
+			RuleDoc:  fmt.Sprintf("%s#%s", ruleDocBase, d.RuleID),
+		})
+	}
+
+	enc := json.NewEncoder(r.w)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(out); err != nil {
+		return fmt.Errorf("encoding diagnostics as JSON: %w", err)
+	}
+	return nil
+}

--- a/cli/internal/validation/renderer/json_test.go
+++ b/cli/internal/validation/renderer/json_test.go
@@ -1,0 +1,68 @@
+package renderer
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/rudderlabs/rudder-iac/cli/internal/validation"
+	"github.com/rudderlabs/rudder-iac/cli/internal/validation/pathindex"
+	"github.com/rudderlabs/rudder-iac/cli/internal/validation/rules"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestJSONRenderer_Render(t *testing.T) {
+	t.Run("empty diagnostics renders empty array", func(t *testing.T) {
+		var buf bytes.Buffer
+		r := NewJSONRenderer(&buf)
+
+		require.NoError(t, r.Render(validation.Diagnostics{}))
+		assert.JSONEq(t, `{"diagnostics":[]}`, buf.String())
+	})
+
+	t.Run("renders diagnostics with code, severity, positions", func(t *testing.T) {
+		var buf bytes.Buffer
+		r := NewJSONRenderer(&buf)
+
+		diags := validation.Diagnostics{
+			{
+				RuleID:   "datacatalog/properties/spec-syntax-valid",
+				Severity: rules.Error,
+				Message:  "missing required field 'id'",
+				File:     "specs/props.yaml",
+				Kind:     "properties",
+				Position: pathindex.Position{Line: 4, Column: 7, LineText: "name: Foo"},
+			},
+			{
+				RuleID:   "datacatalog/properties/deprecated",
+				Severity: rules.Warning,
+				Message:  "property is deprecated",
+				File:     "specs/props.yaml",
+				Kind:     "properties",
+				Position: pathindex.Position{Line: 10, Column: 3},
+			},
+		}
+
+		require.NoError(t, r.Render(diags))
+
+		var out struct {
+			Diagnostics []map[string]any `json:"diagnostics"`
+		}
+		require.NoError(t, json.Unmarshal(buf.Bytes(), &out))
+		require.Len(t, out.Diagnostics, 2)
+
+		first := out.Diagnostics[0]
+		assert.Equal(t, "datacatalog/properties/spec-syntax-valid", first["code"])
+		assert.Equal(t, "error", first["severity"])
+		assert.Equal(t, "missing required field 'id'", first["message"])
+		assert.Equal(t, "properties", first["kind"])
+		assert.Equal(t, "specs/props.yaml", first["file"])
+		assert.Equal(t, float64(4), first["line"])
+		assert.Equal(t, float64(7), first["col"])
+
+		second := out.Diagnostics[1]
+		assert.Equal(t, "warning", second["severity"])
+		assert.Equal(t, float64(10), second["line"])
+	})
+}

--- a/docs/validate-json.md
+++ b/docs/validate-json.md
@@ -1,0 +1,70 @@
+# Machine-readable validation (`rudder-cli validate --format json`)
+
+`rudder-cli validate` checks your specs against the CLI's syntactic and semantic
+rules. By default it prints a human-readable report. With `--format json` it emits
+**structured diagnostics** — stable error codes and exact source positions —
+suitable for editors, CI, and coding agents.
+
+The human output is unchanged; JSON is opt-in.
+
+## Usage
+
+```bash
+# Human-readable (default)
+rudder-cli validate
+
+# Machine-readable diagnostics
+rudder-cli validate --format json
+```
+
+In JSON mode, stdout is a single parseable document and the process exits non-zero
+when validation fails (without extra stderr noise), so it composes cleanly in
+pipelines:
+
+```bash
+rudder-cli validate --format json | jq '.diagnostics[] | {code, file, line, message}'
+```
+
+## Diagnostic shape
+
+```json
+{
+  "diagnostics": [
+    {
+      "code": "datacatalog/properties/spec-syntax-valid",
+      "severity": "error",
+      "message": "…",
+      "kind": "properties",
+      "file": "specs/properties.yaml",
+      "line": 12,
+      "col": 7,
+      "ruleDoc": "docs/generated/rules.yaml#datacatalog/properties/spec-syntax-valid"
+    }
+  ]
+}
+```
+
+- **`code`** is the rule's stable ID (`provider/kind/rule-name`) — the same key
+  used in the generated rule catalog, so codes don't drift.
+- **`line`/`col`** point at the offending node (resolved from the parsed spec).
+- **`ruleDoc`** links to the rule's entry in `docs/generated/rules.yaml`
+  (regenerate with `make gen-rule-docs`).
+
+## Example use cases
+
+- **Editor diagnostics.** An editor extension can run `validate --format json` on
+  save and turn each diagnostic into an inline squiggle at `line`/`col`.
+- **CI gates by code.** Fail or annotate a build on specific rule codes; parse the
+  JSON instead of scraping text.
+- **Agent self-correction.** An LLM/coding agent gets deterministic,
+  position-anchored feedback (code + file + line) to fix a spec without guessing.
+
+## How it works
+
+- Validation semantics are unchanged — this adds a JSON renderer over the existing
+  engine, plus a `kind` field on each diagnostic.
+- Source positions come from the loader's existing path index (each spec is parsed
+  via `yaml.Node`, and a diagnostic's JSON-Pointer reference resolves to a
+  line/column).
+- Error codes reuse the rule IDs already published in the rule catalog — one
+  source of truth for both the docs and the JSON output.


### PR DESCRIPTION
## 🔗 Ticket
_No ticket yet — CLI developer-experience tooling._

## Summary
Adds `rudder-cli validate --format json`: **machine-readable diagnostics** with stable error codes and exact source positions (file/line/col). The human-readable output remains the default and is unchanged.

## Changes
- New `JSONRenderer` in `cli/internal/validation/renderer`; `Kind` field added to `Diagnostic` and populated by the engine.
- `--format text|json` flag on `validate`; JSON mode emits a single parseable document and a `SilentError` on failure (clean non-zero exit).
- Codes reuse existing **rule IDs** (one source of truth with the rule catalog); positions reuse the loader's existing `pathindex`.

## Testing
- Tests pin codes + line/col for a semantic-rule violation and a malformed spec.
- `make test` + `make lint` pass.

## Risk / Impact
Low. Additive; validation semantics unchanged; human default output unchanged.

## Checklist
- [ ] Ticket linked
- [x] Tests added/updated
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)