### PR TITLE
feat(api): deserialize embedded destination transformation link

### DIFF
--- a/api/client/destinations.go
+++ b/api/client/destinations.go
@@ -9,16 +9,21 @@ import (
 	"time"
 )
 
+type DestinationTransformationLink struct {
+	ID string `json:"id"`
+}
+
 type Destination struct {
-	ID          string          `json:"id,omitempty"`
-	Name        string          `json:"name"`
-	Type        string          `json:"type"`
-	Version     int             `json:"version,omitempty"`
-	VersionInfo *VersionInfo    `json:"versionInfo,omitempty"`
-	IsEnabled   bool            `json:"enabled"`
-	Config      json.RawMessage `json:"config"`
-	CreatedAt   *time.Time      `json:"createdAt,omitempty"`
-	UpdatedAt   *time.Time      `json:"updatedAt,omitempty"`
+	ID             string                         `json:"id,omitempty"`
+	Name           string                         `json:"name"`
+	Type           string                         `json:"type"`
+	Version        int                            `json:"version,omitempty"`
+	VersionInfo    *VersionInfo                   `json:"versionInfo,omitempty"`
+	IsEnabled      bool                           `json:"enabled"`
+	Config         json.RawMessage                `json:"config"`
+	CreatedAt      *time.Time                     `json:"createdAt,omitempty"`
+	UpdatedAt      *time.Time                     `json:"updatedAt,omitempty"`
+	Transformation *DestinationTransformationLink `json:"transformation,omitempty"`
 }
 
 type VersionInfo struct {

--- a/api/client/destinations_test.go
+++ b/api/client/destinations_test.go
@@ -29,7 +29,8 @@ func TestClientDestinationsList(t *testing.T) {
 					"id": "id-1",
 					"type": "type-1",
 					"name": "name-1",
-					"config": {"key":"val-1"}
+					"config": {"key":"val-1"},
+					"transformation": {"id":"trans-1"}
 				},  {
 					"id": "id-2",
 					"type": "type-2",
@@ -70,8 +71,15 @@ func TestClientDestinationsList(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, page)
 	assert.Len(t, page.Destinations, 2)
-	assert.Equal(t, client.Destination{ID: "id-1", Type: "type-1", Name: "name-1", Config: []byte(`{"key":"val-1"}`)}, page.Destinations[0])
+	assert.Equal(t, client.Destination{
+		ID:             "id-1",
+		Type:           "type-1",
+		Name:           "name-1",
+		Config:         []byte(`{"key":"val-1"}`),
+		Transformation: &client.DestinationTransformationLink{ID: "trans-1"},
+	}, page.Destinations[0])
 	assert.Equal(t, client.Destination{ID: "id-2", Type: "type-2", Name: "name-2", Config: []byte(`{"key":"val-2"}`)}, page.Destinations[1])
+	assert.Nil(t, page.Destinations[1].Transformation)
 	assert.Equal(t, 3, page.Paging.Total)
 	assert.Equal(t, "/destinations?page=2", page.Paging.Next)
 


### PR DESCRIPTION
## Ticket

Resolves [RUD-2863](https://linear.app/rudderstack/issue/RUD-2863/v2-api-embed-transformation-data-on-destination-responses)

---

## Summary

Adds Go client support for the embedded `transformation: { id }` field on v2 destination list responses, enabling CLI import/state mapping once the rudder-api change lands.

---

## Changes

- Add `DestinationTransformationLink` struct with `id` field (separate from sub-resource `DestinationTransformation`)
- Add `Transformation *DestinationTransformationLink` to `Destination`
- Update list deserialization tests for linked vs unlinked destinations

---

## Testing

- `go test ./api/client/... -count=1`
- `make lint`

---

## Risk / Impact

Low — additive optional field; no breaking changes for existing callers.

---

## Checklist

- [x] Ticket linked
- [x] Tests added/updated
- [x] No breaking changes (or documented)

Made with [Cursor](https://cursor.com)