### PR TITLE
feat(cli): add destination handler with CRUD lifecycle and state mapping

### DIFF
--- a/api/client/destinations.go
+++ b/api/client/destinations.go
@@ -15,6 +15,7 @@ type DestinationTransformationLink struct {
 
 type Destination struct {
 	ID             string                         `json:"id,omitempty"`
+	ExternalID     string                         `json:"externalId,omitempty"`
 	Name           string                         `json:"name"`
 	Type           string                         `json:"type"`
 	Version        int                            `json:"version,omitempty"`

--- a/api/client/destinations_test.go
+++ b/api/client/destinations_test.go
@@ -600,6 +600,44 @@ func TestClientDestinations_GetTransformation(t *testing.T) {
 		httpClient.AssertNumberOfCalls()
 	})
 }
+
+func TestClientDestinationsGetWithExternalID(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	httpClient := testutils.NewMockHTTPClient(t, testutils.Call{
+		Validate: func(req *http.Request) bool {
+			return testutils.ValidateRequest(t, req, "GET", "https://api.rudderstack.com/v2/destinations/some-id", "")
+		},
+		ResponseStatus: 200,
+		ResponseBody: `{
+			"destination": {
+				"id": "some-id",
+				"externalId": "ga4-production",
+				"name": "some-name",
+				"type": "GA4",
+				"config": {"apiSecret": "secret"}
+			}
+		}`,
+	})
+
+	c, err := client.New("some-access-token", client.WithHTTPClient(httpClient))
+	require.NoError(t, err)
+
+	destination, err := c.Destinations.Get(ctx, "some-id")
+	require.NoError(t, err)
+	assert.Equal(t, &client.Destination{
+		ID:         "some-id",
+		ExternalID: "ga4-production",
+		Name:       "some-name",
+		Type:       "GA4",
+		Config:     []byte(`{"apiSecret": "secret"}`),
+	}, destination)
+
+	httpClient.AssertNumberOfCalls()
+}
+
 func TestClientDestinations_GetAll(t *testing.T) {
 	ctx := context.Background()
 

--- a/cli/internal/app/dependencies.go
+++ b/cli/internal/app/dependencies.go
@@ -14,6 +14,8 @@ import (
 	"github.com/rudderlabs/rudder-iac/cli/internal/provider"
 	"github.com/rudderlabs/rudder-iac/cli/internal/providers/datacatalog"
 	dgProvider "github.com/rudderlabs/rudder-iac/cli/internal/providers/datagraph"
+	destProvider "github.com/rudderlabs/rudder-iac/cli/internal/providers/destination"
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions"
 	esProvider "github.com/rudderlabs/rudder-iac/cli/internal/providers/event-stream"
 	"github.com/rudderlabs/rudder-iac/cli/internal/providers/retl"
 	"github.com/rudderlabs/rudder-iac/cli/internal/providers/transformations"
@@ -39,6 +41,7 @@ type Providers struct {
 	RETL            *retl.Provider
 	EventStream     *esProvider.Provider
 	Transformations *transformations.Provider
+	Destination     *destProvider.Provider
 	Workspace       *workspace.Provider
 	DataGraph       *dgProvider.Provider
 }
@@ -174,6 +177,7 @@ func composeProviders(c *client.Client) (provider.Provider, *Providers, error) {
 		"retl":            p.RETL,
 		"eventstream":     p.EventStream,
 		"transformations": p.Transformations,
+		"destination":     p.Destination,
 	}
 
 	if cfg.ExperimentalFlags.DataGraph {
@@ -212,6 +216,8 @@ func setupProviders(c *client.Client) (*Providers, error) {
 	retlp := retl.New(retlClient.NewRudderRETLStore(c))
 	esp := esProvider.New(esClient.NewRudderEventStreamStore(c))
 	trp := transformations.NewProvider(c)
+	destRegistry := definitions.NewRegistry()
+	dsp := destProvider.NewProvider(c, destRegistry)
 	wsp := workspace.New(c)
 
 	providers := &Providers{
@@ -219,6 +225,7 @@ func setupProviders(c *client.Client) (*Providers, error) {
 		RETL:            retlp,
 		EventStream:     esp,
 		Transformations: trp,
+		Destination:     dsp,
 		Workspace:       wsp,
 	}
 

--- a/cli/internal/project/docs/duplicate-urn.docs.yaml
+++ b/cli/internal/project/docs/duplicate-urn.docs.yaml
@@ -47,6 +47,8 @@ match_behavior:
         version: "rudder/v1"
       - kind: "transformation-library"
         version: "rudder/v1"
+      - kind: "destination"
+        version: "rudder/v1"
     valid:
       - example_id: "duplicate-urn-distinct-urns"
         title: "Distinct URNs across files"

--- a/cli/internal/project/docs/manifest-inline-conflict.docs.yaml
+++ b/cli/internal/project/docs/manifest-inline-conflict.docs.yaml
@@ -47,6 +47,8 @@ match_behavior:
         version: "rudder/v1"
       - kind: "transformation-library"
         version: "rudder/v1"
+      - kind: "destination"
+        version: "rudder/v1"
       - kind: "import-manifest"
         version: "rudder/v1"
     valid:

--- a/cli/internal/project/docs/metadata-syntax-valid.docs.yaml
+++ b/cli/internal/project/docs/metadata-syntax-valid.docs.yaml
@@ -47,6 +47,8 @@ match_behavior:
         version: "rudder/v1"
       - kind: "transformation-library"
         version: "rudder/v1"
+      - kind: "destination"
+        version: "rudder/v1"
     valid:
       - example_id: "metadata-name-only"
         title: "Metadata with only the required name"

--- a/cli/internal/project/docs/ruledoc_test.go
+++ b/cli/internal/project/docs/ruledoc_test.go
@@ -8,6 +8,7 @@ import (
 	providerrules "github.com/rudderlabs/rudder-iac/cli/internal/provider/rules"
 	"github.com/rudderlabs/rudder-iac/cli/internal/providers/datacatalog/localcatalog"
 	essource "github.com/rudderlabs/rudder-iac/cli/internal/providers/event-stream/source"
+	dtypes "github.com/rudderlabs/rudder-iac/cli/internal/providers/destination"
 	"github.com/rudderlabs/rudder-iac/cli/internal/providers/retl/sqlmodel"
 	ttypes "github.com/rudderlabs/rudder-iac/cli/internal/providers/transformations/types"
 	"github.com/rudderlabs/rudder-iac/cli/internal/validation/docs"
@@ -43,6 +44,7 @@ func gatekeeperScopedPatterns() []rules.MatchPattern {
 	// v1-only kinds.
 	p = append(p, providerrules.V1VersionPatterns(ttypes.TransformationSpecKind)...)
 	p = append(p, providerrules.V1VersionPatterns(ttypes.LibrarySpecKind)...)
+	p = append(p, providerrules.V1VersionPatterns(dtypes.DestinationSpecKind)...)
 	return p
 }
 

--- a/cli/internal/providers/destination/handler.go
+++ b/cli/internal/providers/destination/handler.go
@@ -1,0 +1,397 @@
+package destination
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/rudderlabs/rudder-iac/api/client"
+	"github.com/rudderlabs/rudder-iac/cli/internal/namer"
+	"github.com/rudderlabs/rudder-iac/cli/internal/project/writer"
+	"github.com/rudderlabs/rudder-iac/cli/internal/provider/handler"
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions"
+	tmodel "github.com/rudderlabs/rudder-iac/cli/internal/providers/transformations/model"
+	ttypes "github.com/rudderlabs/rudder-iac/cli/internal/providers/transformations/types"
+	"github.com/rudderlabs/rudder-iac/cli/internal/resolver"
+	"github.com/rudderlabs/rudder-iac/cli/internal/resources"
+)
+
+type DestinationHandler = handler.BaseHandler[
+	DestinationSpec,
+	DestinationResource,
+	DestinationState,
+	RemoteDestination,
+]
+
+var HandlerMetadata = handler.HandlerMetadata{
+	ResourceType:     DestinationResourceType,
+	SpecKind:         DestinationSpecKind,
+	SpecMetadataName: DestinationMetadataName,
+}
+
+type HandlerImpl struct {
+	client   *client.Client
+	registry *definitions.Registry
+}
+
+func NewHandler(c *client.Client, registry *definitions.Registry) *DestinationHandler {
+	return handler.NewHandler(&HandlerImpl{
+		client:   c,
+		registry: registry,
+	})
+}
+
+func (h *HandlerImpl) Metadata() handler.HandlerMetadata {
+	return HandlerMetadata
+}
+
+func (h *HandlerImpl) NewSpec() *DestinationSpec {
+	return &DestinationSpec{}
+}
+
+func (h *HandlerImpl) ExtractResourcesFromSpec(_ string, spec *DestinationSpec) (map[string]*DestinationResource, error) {
+	resource := &DestinationResource{
+		ID:                spec.ID,
+		DisplayName:       spec.DisplayName,
+		Type:              spec.Type,
+		Enabled:           spec.Enabled,
+		DefinitionVersion: spec.DefinitionVersion,
+		Config:            spec.Config,
+	}
+
+	if spec.Transformation != "" {
+		transformationRef, err := parseTransformationRef(spec.Transformation)
+		if err != nil {
+			return nil, fmt.Errorf("parsing transformation reference: %w", err)
+		}
+		resource.Transformation = transformationRef
+	}
+
+	return map[string]*DestinationResource{
+		spec.ID: resource,
+	}, nil
+}
+
+func (h *HandlerImpl) LoadRemoteResources(ctx context.Context) ([]*RemoteDestination, error) {
+	destinations, err := h.client.Destinations.GetAll(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("listing destinations: %w", err)
+	}
+
+	result := make([]*RemoteDestination, 0, len(destinations))
+	for i := range destinations {
+		dest := destinations[i]
+		if dest.ExternalID == "" {
+			continue
+		}
+		if !h.registry.IsSupported(dest.Type) {
+			return nil, fmt.Errorf("destination %q has unregistered type %q", dest.ID, dest.Type)
+		}
+		result = append(result, &RemoteDestination{Destination: &dest})
+	}
+
+	return result, nil
+}
+
+func (h *HandlerImpl) LoadImportableResources(ctx context.Context) ([]*RemoteDestination, error) {
+	destinations, err := h.client.Destinations.GetAll(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("listing destinations: %w", err)
+	}
+
+	result := make([]*RemoteDestination, 0, len(destinations))
+	for i := range destinations {
+		dest := destinations[i]
+		if dest.ExternalID != "" {
+			continue
+		}
+		if !h.registry.IsSupported(dest.Type) {
+			continue
+		}
+		result = append(result, &RemoteDestination{Destination: &dest})
+	}
+
+	return result, nil
+}
+
+func (h *HandlerImpl) MapRemoteToState(remote *RemoteDestination, urnResolver handler.URNResolver) (*DestinationResource, *DestinationState, error) {
+	if remote.ExternalID == "" {
+		return nil, nil, nil
+	}
+
+	if !h.registry.IsSupported(remote.Type) {
+		return nil, nil, fmt.Errorf("destination %q has unregistered type %q", remote.ID, remote.Type)
+	}
+
+	definitionVersion, err := h.latestDefinitionVersion(remote.Type)
+	if err != nil {
+		return nil, nil, fmt.Errorf("resolving definition version for type %q: %w", remote.Type, err)
+	}
+
+	registered, err := h.registry.Get(remote.Type, definitionVersion)
+	if err != nil {
+		return nil, nil, fmt.Errorf("getting destination definition: %w", err)
+	}
+
+	apiConfig, err := unmarshalConfig(remote.Config)
+	if err != nil {
+		return nil, nil, fmt.Errorf("unmarshalling destination config: %w", err)
+	}
+
+	localConfig, err := registered.APIToLocal(apiConfig)
+	if err != nil {
+		return nil, nil, fmt.Errorf("converting API config to local: %w", err)
+	}
+
+	transformationRef, transformationID, err := h.mapTransformationRef(remote, urnResolver)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	resource := &DestinationResource{
+		ID:                remote.ExternalID,
+		DisplayName:       remote.Name,
+		Type:              remote.Type,
+		Enabled:           remote.IsEnabled,
+		DefinitionVersion: definitionVersion,
+		Transformation:    transformationRef,
+		Config:            localConfig,
+	}
+
+	state := &DestinationState{
+		ID:               remote.ID,
+		TransformationID: transformationID,
+	}
+
+	return resource, state, nil
+}
+
+func (h *HandlerImpl) Create(ctx context.Context, data *DestinationResource) (*DestinationState, error) {
+	apiConfig, err := h.localConfigToAPI(data.Type, data.DefinitionVersion, data.Config)
+	if err != nil {
+		return nil, err
+	}
+
+	created, err := h.client.Destinations.Create(ctx, &client.Destination{
+		Name:       data.DisplayName,
+		Type:       data.Type,
+		IsEnabled:  data.Enabled,
+		Config:     apiConfig,
+		ExternalID: data.ID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("creating destination: %w", err)
+	}
+
+	transformationID, err := h.connectTransformationIfPresent(ctx, created.ID, data.Transformation)
+	if err != nil {
+		return nil, err
+	}
+
+	return &DestinationState{
+		ID:               created.ID,
+		TransformationID: transformationID,
+	}, nil
+}
+
+func (h *HandlerImpl) Update(ctx context.Context, newData *DestinationResource, oldData *DestinationResource, oldState *DestinationState) (*DestinationState, error) {
+	if newData.Type != oldData.Type {
+		return nil, fmt.Errorf("destination type is immutable: cannot change from %q to %q", oldData.Type, newData.Type)
+	}
+
+	apiConfig, err := h.localConfigToAPI(newData.Type, newData.DefinitionVersion, newData.Config)
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = h.client.Destinations.Update(ctx, &client.Destination{
+		ID:        oldState.ID,
+		Name:      newData.DisplayName,
+		Type:      newData.Type,
+		IsEnabled: newData.Enabled,
+		Config:    apiConfig,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("updating destination: %w", err)
+	}
+
+	transformationID, err := h.syncTransformationLink(ctx, oldState.ID, oldState.TransformationID, newData.Transformation)
+	if err != nil {
+		return nil, err
+	}
+
+	return &DestinationState{
+		ID:               oldState.ID,
+		TransformationID: transformationID,
+	}, nil
+}
+
+func (h *HandlerImpl) Delete(ctx context.Context, _ string, _ *DestinationResource, oldState *DestinationState) error {
+	if oldState.TransformationID != "" {
+		if _, err := h.client.Destinations.DisconnectTransformation(ctx, oldState.ID); err != nil {
+			return fmt.Errorf("disconnecting transformation from destination: %w", err)
+		}
+	}
+
+	if err := h.client.Destinations.Delete(ctx, oldState.ID); err != nil {
+		return fmt.Errorf("deleting destination: %w", err)
+	}
+
+	return nil
+}
+
+func (h *HandlerImpl) Import(_ context.Context, _ *DestinationResource, _ string) (*DestinationState, error) {
+	return nil, fmt.Errorf("import not implemented yet")
+}
+
+func (h *HandlerImpl) FormatForExport(
+	_ map[string]*RemoteDestination,
+	_ namer.Namer,
+	_ resolver.ReferenceResolver,
+) ([]writer.FormattableEntity, error) {
+	return nil, fmt.Errorf("export not implemented yet")
+}
+
+func (h *HandlerImpl) localConfigToAPI(destType string, version int64, local map[string]any) (json.RawMessage, error) {
+	registered, err := h.registry.Get(destType, version)
+	if err != nil {
+		return nil, fmt.Errorf("getting destination definition: %w", err)
+	}
+
+	apiConfig, err := registered.LocalToAPI(local)
+	if err != nil {
+		return nil, fmt.Errorf("converting local config to API: %w", err)
+	}
+
+	configBytes, err := json.Marshal(apiConfig)
+	if err != nil {
+		return nil, fmt.Errorf("marshalling destination config: %w", err)
+	}
+
+	return configBytes, nil
+}
+
+func (h *HandlerImpl) latestDefinitionVersion(destType string) (int64, error) {
+	versions, err := h.registry.Versions(destType)
+	if err != nil {
+		return 0, err
+	}
+	return versions[len(versions)-1], nil
+}
+
+func (h *HandlerImpl) mapTransformationRef(
+	remote *RemoteDestination,
+	urnResolver handler.URNResolver,
+) (*resources.PropertyRef, string, error) {
+	if remote.Transformation == nil || remote.Transformation.ID == "" {
+		return nil, "", nil
+	}
+
+	transformationID := remote.Transformation.ID
+	urn, err := urnResolver.GetURNByID(ttypes.TransformationResourceType, transformationID)
+	if err != nil {
+		if err == resources.ErrRemoteResourceExternalIdNotFound {
+			return nil, transformationID, nil
+		}
+		return nil, "", fmt.Errorf("resolving transformation URN: %w", err)
+	}
+
+	return &resources.PropertyRef{
+		URN:      urn,
+		Property: "id",
+	}, transformationID, nil
+}
+
+func (h *HandlerImpl) connectTransformationIfPresent(ctx context.Context, destinationID string, ref *resources.PropertyRef) (string, error) {
+	transformationID, ok := resolvedTransformationID(ref)
+	if !ok {
+		return "", nil
+	}
+
+	if _, err := h.client.Destinations.ConnectTransformation(ctx, destinationID, transformationID); err != nil {
+		return "", fmt.Errorf("connecting transformation to destination: %w", err)
+	}
+
+	return transformationID, nil
+}
+
+func (h *HandlerImpl) syncTransformationLink(
+	ctx context.Context,
+	destinationID string,
+	oldTransformationID string,
+	newRef *resources.PropertyRef,
+) (string, error) {
+	newTransformationID, hasNewRef := resolvedTransformationID(newRef)
+
+	switch {
+	case hasNewRef && oldTransformationID == "":
+		if _, err := h.client.Destinations.ConnectTransformation(ctx, destinationID, newTransformationID); err != nil {
+			return "", fmt.Errorf("connecting transformation to destination: %w", err)
+		}
+		return newTransformationID, nil
+	case hasNewRef && oldTransformationID != "" && newTransformationID != oldTransformationID:
+		if _, err := h.client.Destinations.ConnectTransformation(ctx, destinationID, newTransformationID); err != nil {
+			return "", fmt.Errorf("connecting transformation to destination: %w", err)
+		}
+		return newTransformationID, nil
+	case hasNewRef && oldTransformationID != "" && newTransformationID == oldTransformationID:
+		return oldTransformationID, nil
+	case !hasNewRef && oldTransformationID != "":
+		if _, err := h.client.Destinations.DisconnectTransformation(ctx, destinationID); err != nil {
+			return "", fmt.Errorf("disconnecting transformation from destination: %w", err)
+		}
+		return "", nil
+	default:
+		return "", nil
+	}
+}
+
+func parseTransformationRef(ref string) (*resources.PropertyRef, error) {
+	ref = strings.TrimSpace(ref)
+	if ref == "" {
+		return nil, fmt.Errorf("transformation reference is empty")
+	}
+
+	refBody := strings.TrimPrefix(ref, "#")
+	parts := strings.SplitN(refBody, ":", 2)
+	if len(parts) != 2 || parts[0] != ttypes.TransformationSpecKind || parts[1] == "" {
+		return nil, fmt.Errorf("invalid transformation reference %q: expected format #transformation:<id>", ref)
+	}
+
+	urn := resources.URN(parts[1], ttypes.TransformationResourceType)
+	return createTransformationRef(urn), nil
+}
+
+func createTransformationRef(urn string) *resources.PropertyRef {
+	ref := handler.CreatePropertyRef[tmodel.TransformationState](
+		urn,
+		func(state *tmodel.TransformationState) (string, error) {
+			if state.ID == "" {
+				return "", fmt.Errorf("transformation state has empty ID")
+			}
+			return state.ID, nil
+		},
+	)
+	ref.Property = "id"
+	return ref
+}
+
+func resolvedTransformationID(ref *resources.PropertyRef) (string, bool) {
+	if ref == nil || !ref.IsResolved || ref.Value == "" {
+		return "", false
+	}
+	return ref.Value, true
+}
+
+func unmarshalConfig(raw json.RawMessage) (map[string]any, error) {
+	if len(raw) == 0 {
+		return map[string]any{}, nil
+	}
+
+	var config map[string]any
+	if err := json.Unmarshal(raw, &config); err != nil {
+		return nil, err
+	}
+	return config, nil
+}

--- a/cli/internal/providers/destination/handler_integration_test.go
+++ b/cli/internal/providers/destination/handler_integration_test.go
@@ -1,0 +1,95 @@
+package destination_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/rudderlabs/rudder-iac/api/client"
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination"
+	"github.com/rudderlabs/rudder-iac/cli/internal/resources"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandlerImpl_GA4RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	registry := testRegistry(t)
+
+	var createBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		require.Equal(t, "/v2/destinations", r.URL.Path)
+
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		createBody = string(body)
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{
+			"destination": {
+				"id": "dst-ga4",
+				"externalId": "ga4-production",
+				"name": "Production GA4",
+				"type": "GA4",
+				"enabled": true,
+				"config": {
+					"apiSecret": "secret-value",
+					"measurementId": "G-123"
+				}
+			}
+		}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	c := newTestClient(t, srv.URL)
+	h := destination.NewHandler(c, registry)
+
+	input := &destination.DestinationResource{
+		ID:                "ga4-production",
+		DisplayName:       "Production GA4",
+		Type:              "GA4",
+		Enabled:           true,
+		DefinitionVersion: 1,
+		Config: map[string]any{
+			"api_secret":     "secret-value",
+			"measurement_id": "G-123",
+		},
+	}
+
+	createdState, err := h.Impl.Create(ctx, input)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{
+		"name": "Production GA4",
+		"type": "GA4",
+		"enabled": true,
+		"externalId": "ga4-production",
+		"config": {
+			"apiSecret": "secret-value",
+			"measurementId": "G-123"
+		}
+	}`, createBody)
+
+	resource, mappedState, err := h.Impl.MapRemoteToState(&destination.RemoteDestination{
+		Destination: &client.Destination{
+			ID:         createdState.ID,
+			ExternalID: input.ID,
+			Name:       input.DisplayName,
+			Type:       input.Type,
+			IsEnabled:  input.Enabled,
+			Config: json.RawMessage(`{
+				"apiSecret": "secret-value",
+				"measurementId": "G-123"
+			}`),
+		},
+	}, resources.NewRemoteResources())
+	require.NoError(t, err)
+
+	assert.Equal(t, input, resource)
+	assert.Equal(t, createdState, mappedState)
+}

--- a/cli/internal/providers/destination/handler_test.go
+++ b/cli/internal/providers/destination/handler_test.go
@@ -1,0 +1,535 @@
+package destination_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/rudderlabs/rudder-iac/api/client"
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination"
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions"
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions/converter"
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/transformations/types"
+	"github.com/rudderlabs/rudder-iac/cli/internal/resources"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandlerImpl_ExtractResourcesFromSpec(t *testing.T) {
+	t.Parallel()
+
+	h := destination.NewHandler(nil, definitions.NewRegistry())
+
+	extracted, err := h.Impl.ExtractResourcesFromSpec("destinations/ga4.yaml", &destination.DestinationSpec{
+		ID:                "ga4-production",
+		DisplayName:       "Production GA4",
+		Type:              "GA4",
+		Enabled:           true,
+		DefinitionVersion: 1,
+		Transformation:    "#transformation:my-transform",
+		Config: map[string]any{
+			"api_secret": "secret",
+		},
+	})
+	require.NoError(t, err)
+
+	resource := extracted["ga4-production"]
+	require.NotNil(t, resource)
+	assert.Equal(t, "ga4-production", resource.ID)
+	assert.Equal(t, "Production GA4", resource.DisplayName)
+	assert.Equal(t, "GA4", resource.Type)
+	assert.True(t, resource.Enabled)
+	assert.Equal(t, int64(1), resource.DefinitionVersion)
+	assert.Equal(t, map[string]any{"api_secret": "secret"}, resource.Config)
+	require.NotNil(t, resource.Transformation)
+	assert.Equal(t, resources.URN("my-transform", types.TransformationResourceType), resource.Transformation.URN)
+	assert.Equal(t, "id", resource.Transformation.Property)
+}
+
+func TestHandlerImpl_Create(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	registry := testRegistry(t)
+
+	var createBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		require.Equal(t, "/v2/destinations", r.URL.Path)
+
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		createBody = string(body)
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{
+			"destination": {
+				"id": "dst-123",
+				"name": "Production Webhook",
+				"type": "WEBHOOK",
+				"enabled": true,
+				"externalId": "webhook-production",
+				"config": {"webhookUrl":"https://example.com"}
+			}
+		}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	c := newTestClient(t, srv.URL)
+	h := destination.NewHandler(c, registry)
+	state, err := h.Impl.Create(ctx, &destination.DestinationResource{
+		ID:                "webhook-production",
+		DisplayName:       "Production Webhook",
+		Type:              "WEBHOOK",
+		Enabled:           true,
+		DefinitionVersion: 1,
+		Config: map[string]any{
+			"webhook_url": "https://example.com",
+		},
+	})
+	require.NoError(t, err)
+	assert.JSONEq(t, `{
+		"name": "Production Webhook",
+		"type": "WEBHOOK",
+		"enabled": true,
+		"externalId": "webhook-production",
+		"config": {"webhookUrl":"https://example.com"}
+	}`, createBody)
+	assert.Equal(t, &destination.DestinationState{
+		ID:               "dst-123",
+		TransformationID: "",
+	}, state)
+}
+
+func TestHandlerImpl_CreateConnectsTransformation(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	registry := testRegistry(t)
+
+	var calls []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls = append(calls, r.Method+" "+r.URL.Path)
+
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v2/destinations":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"destination":{"id":"dst-123","type":"WEBHOOK","enabled":true}}`))
+		case r.Method == http.MethodPut && r.URL.Path == "/v2/destinations/dst-123/transformation":
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			assert.JSONEq(t, `{"transformationId":"trans-456"}`, string(body))
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{
+				"destinationId":"dst-123",
+				"transformationId":"trans-456",
+				"createdAt":"2020-01-01T01:01:01Z",
+				"updatedAt":"2020-01-02T01:01:01Z"
+			}`))
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	c := newTestClient(t, srv.URL)
+	h := destination.NewHandler(c, registry)
+	state, err := h.Impl.Create(ctx, &destination.DestinationResource{
+		ID:                "webhook-production",
+		DisplayName:       "Production Webhook",
+		Type:              "WEBHOOK",
+		Enabled:           true,
+		DefinitionVersion: 1,
+		Transformation: &resources.PropertyRef{
+			URN:        resources.URN("my-transform", types.TransformationResourceType),
+			Property:   "id",
+			IsResolved: true,
+			Value:      "trans-456",
+		},
+		Config: map[string]any{
+			"webhook_url": "https://example.com",
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, &destination.DestinationState{
+		ID:               "dst-123",
+		TransformationID: "trans-456",
+	}, state)
+	assert.Equal(t, []string{
+		"POST /v2/destinations",
+		"PUT /v2/destinations/dst-123/transformation",
+	}, calls)
+}
+
+func TestHandlerImpl_UpdateRejectsTypeChange(t *testing.T) {
+	t.Parallel()
+
+	h := destination.NewHandler(nil, testRegistry(t))
+	_, err := h.Impl.Update(context.Background(),
+		&destination.DestinationResource{Type: "GA4"},
+		&destination.DestinationResource{Type: "WEBHOOK"},
+		&destination.DestinationState{ID: "dst-1"},
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "immutable")
+}
+
+func TestHandlerImpl_UpdateDisconnectsTransformation(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	registry := testRegistry(t)
+
+	var calls []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls = append(calls, r.Method+" "+r.URL.Path)
+		w.WriteHeader(http.StatusOK)
+		switch {
+		case r.Method == http.MethodPut && r.URL.Path == "/v2/destinations/dst-123":
+			_, _ = w.Write([]byte(`{"destination":{"id":"dst-123","type":"WEBHOOK","enabled":true}}`))
+		case r.Method == http.MethodDelete && r.URL.Path == "/v2/destinations/dst-123/transformation":
+			_, _ = w.Write([]byte(`{
+				"destinationId":"dst-123",
+				"transformationId":"trans-old",
+				"createdAt":"2020-01-01T01:01:01Z",
+				"updatedAt":"2020-01-02T01:01:01Z"
+			}`))
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	c := newTestClient(t, srv.URL)
+	h := destination.NewHandler(c, registry)
+	state, err := h.Impl.Update(ctx,
+		&destination.DestinationResource{
+			DisplayName:       "Production Webhook",
+			Type:              "WEBHOOK",
+			Enabled:           true,
+			DefinitionVersion: 1,
+			Config: map[string]any{
+				"webhook_url": "https://example.com/updated",
+			},
+		},
+		&destination.DestinationResource{
+			DisplayName:       "Production Webhook",
+			Type:              "WEBHOOK",
+			Enabled:           true,
+			DefinitionVersion: 1,
+			Transformation: &resources.PropertyRef{
+				URN:        resources.URN("my-transform", types.TransformationResourceType),
+				Property:   "id",
+				IsResolved: true,
+				Value:      "trans-old",
+			},
+			Config: map[string]any{
+				"webhook_url": "https://example.com",
+			},
+		},
+		&destination.DestinationState{
+			ID:               "dst-123",
+			TransformationID: "trans-old",
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &destination.DestinationState{
+		ID:               "dst-123",
+		TransformationID: "",
+	}, state)
+	assert.Equal(t, []string{
+		"PUT /v2/destinations/dst-123",
+		"DELETE /v2/destinations/dst-123/transformation",
+	}, calls)
+}
+
+func TestHandlerImpl_DeleteDisconnectsTransformationFirst(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	var calls []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls = append(calls, r.Method+" "+r.URL.Path)
+		w.WriteHeader(http.StatusOK)
+		if r.Method == http.MethodDelete && strings.HasSuffix(r.URL.Path, "/transformation") {
+			_, _ = w.Write([]byte(`{
+				"destinationId":"dst-123",
+				"transformationId":"trans-456",
+				"createdAt":"2020-01-01T01:01:01Z",
+				"updatedAt":"2020-01-02T01:01:01Z"
+			}`))
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	c := newTestClient(t, srv.URL)
+	h := destination.NewHandler(c, testRegistry(t))
+	err := h.Impl.Delete(ctx, "webhook-production", &destination.DestinationResource{}, &destination.DestinationState{
+		ID:               "dst-123",
+		TransformationID: "trans-456",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		"DELETE /v2/destinations/dst-123/transformation",
+		"DELETE /v2/destinations/dst-123",
+	}, calls)
+}
+
+func TestHandlerImpl_MapRemoteToState(t *testing.T) {
+	t.Parallel()
+
+	registry := testRegistry(t)
+	h := destination.NewHandler(nil, registry)
+
+	collection := resources.NewRemoteResources()
+	collection.Set(types.TransformationResourceType, map[string]*resources.RemoteResource{
+		"trans-456": {
+			ID:         "trans-456",
+			ExternalID: "my-transform",
+			Data:       struct{}{},
+		},
+	})
+
+	resource, state, err := h.Impl.MapRemoteToState(&destination.RemoteDestination{
+		Destination: &client.Destination{
+			ID:         "dst-123",
+			ExternalID: "webhook-production",
+			Name:       "Production Webhook",
+			Type:       "WEBHOOK",
+			IsEnabled:  true,
+			Config:     json.RawMessage(`{"webhookUrl":"https://example.com"}`),
+			Transformation: &client.DestinationTransformationLink{
+				ID: "trans-456",
+			},
+		},
+	}, collection)
+	require.NoError(t, err)
+	require.NotNil(t, resource)
+	require.NotNil(t, state)
+
+	assert.Equal(t, &destination.DestinationResource{
+		ID:                "webhook-production",
+		DisplayName:       "Production Webhook",
+		Type:              "WEBHOOK",
+		Enabled:           true,
+		DefinitionVersion: 1,
+		Config: map[string]any{
+			"webhook_url": "https://example.com",
+		},
+	}, &destination.DestinationResource{
+		ID:                resource.ID,
+		DisplayName:       resource.DisplayName,
+		Type:              resource.Type,
+		Enabled:           resource.Enabled,
+		DefinitionVersion: resource.DefinitionVersion,
+		Config:            resource.Config,
+	})
+	require.NotNil(t, resource.Transformation)
+	assert.Equal(t, resources.URN("my-transform", types.TransformationResourceType), resource.Transformation.URN)
+	assert.Equal(t, "id", resource.Transformation.Property)
+	assert.Equal(t, &destination.DestinationState{
+		ID:               "dst-123",
+		TransformationID: "trans-456",
+	}, state)
+}
+
+func TestHandlerImpl_MapRemoteToStateUnregisteredTypeErrors(t *testing.T) {
+	t.Parallel()
+
+	h := destination.NewHandler(nil, testRegistry(t))
+	_, _, err := h.Impl.MapRemoteToState(&destination.RemoteDestination{
+		Destination: &client.Destination{
+			ID:         "dst-123",
+			ExternalID: "unknown-production",
+			Type:       "UNKNOWN",
+			Config:     json.RawMessage(`{}`),
+		},
+	}, resources.NewRemoteResources())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unregistered type")
+}
+
+func TestHandlerImpl_LoadRemoteResources(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	registry := testRegistry(t)
+
+	t.Run("returns managed destinations", func(t *testing.T) {
+		t.Parallel()
+
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			require.Equal(t, http.MethodGet, r.Method)
+			require.Equal(t, "/v2/destinations", r.URL.Path)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{
+				"destinations": [
+					{
+						"id": "dst-managed",
+						"externalId": "webhook-production",
+						"name": "Managed",
+						"type": "WEBHOOK",
+						"enabled": true,
+						"config": {"webhookUrl":"https://example.com"}
+					},
+					{
+						"id": "dst-unmanaged",
+						"name": "Unmanaged",
+						"type": "WEBHOOK",
+						"enabled": true,
+						"config": {"webhookUrl":"https://example.com"}
+					}
+				],
+				"paging": {"total": 2}
+			}`))
+		}))
+		t.Cleanup(srv.Close)
+
+		h := destination.NewHandler(newTestClient(t, srv.URL), registry)
+		remotes, err := h.Impl.LoadRemoteResources(ctx)
+		require.NoError(t, err)
+		require.Len(t, remotes, 1)
+		assert.Equal(t, "dst-managed", remotes[0].ID)
+		assert.Equal(t, "webhook-production", remotes[0].ExternalID)
+	})
+
+	t.Run("errors on unregistered managed type", func(t *testing.T) {
+		t.Parallel()
+
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{
+				"destinations": [{
+					"id": "dst-unknown",
+					"externalId": "unknown-production",
+					"name": "Unknown",
+					"type": "UNKNOWN",
+					"enabled": true,
+					"config": {}
+				}],
+				"paging": {"total": 1}
+			}`))
+		}))
+		t.Cleanup(srv.Close)
+
+		h := destination.NewHandler(newTestClient(t, srv.URL), registry)
+		_, err := h.Impl.LoadRemoteResources(ctx)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unregistered type")
+	})
+}
+
+func TestHandlerImpl_LoadImportableResourcesFiltersUnregisteredTypes(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	registry := testRegistry(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{
+			"destinations": [
+				{
+					"id": "dst-importable",
+					"name": "Importable",
+					"type": "WEBHOOK",
+					"enabled": true,
+					"config": {"webhookUrl":"https://example.com"}
+				},
+				{
+					"id": "dst-unknown",
+					"name": "Unknown",
+					"type": "UNKNOWN",
+					"enabled": true,
+					"config": {}
+				}
+			],
+			"paging": {"total": 2}
+		}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	h := destination.NewHandler(newTestClient(t, srv.URL), registry)
+	remotes, err := h.Impl.LoadImportableResources(ctx)
+	require.NoError(t, err)
+	require.Len(t, remotes, 1)
+	assert.Equal(t, "dst-importable", remotes[0].ID)
+}
+
+func TestHandlerImpl_ImportAndExportNotImplemented(t *testing.T) {
+	t.Parallel()
+
+	h := destination.NewHandler(nil, testRegistry(t))
+
+	_, err := h.Impl.Import(context.Background(), &destination.DestinationResource{}, "remote-id")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "import not implemented")
+
+	_, err = h.Impl.FormatForExport(nil, nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "export not implemented")
+}
+
+func testRegistry(t *testing.T) *definitions.Registry {
+	t.Helper()
+
+	registry := definitions.NewRegistry()
+	require.NoError(t, registry.Register(webhookTestDefinition()))
+	require.NoError(t, registry.Register(ga4TestDefinition()))
+	return registry
+}
+
+func webhookTestDefinition() *definitions.DestinationDefinition {
+	return &definitions.DestinationDefinition{
+		Type:    "WEBHOOK",
+		Version: 1,
+		Properties: []converter.ConfigProperty{
+			converter.Simple("webhookUrl", "webhook_url"),
+		},
+		NewConfig: func() any {
+			return &struct {
+				WebhookURL string `mapstructure:"webhook_url" validate:"required"`
+			}{}
+		},
+		SourceTypes: []string{"web"},
+		ConnectionModes: map[string][]string{
+			"web": {"cloud"},
+		},
+	}
+}
+
+func ga4TestDefinition() *definitions.DestinationDefinition {
+	return &definitions.DestinationDefinition{
+		Type:    "GA4",
+		Version: 1,
+		Properties: []converter.ConfigProperty{
+			converter.Simple("apiSecret", "api_secret"),
+			converter.Simple("measurementId", "measurement_id"),
+		},
+		SecretKeys: []string{"api_secret"},
+		NewConfig: func() any {
+			return &struct {
+				APISecret     string `mapstructure:"api_secret" validate:"required"`
+				MeasurementID string `mapstructure:"measurement_id"`
+			}{}
+		},
+		SourceTypes: []string{"web", "android"},
+		ConnectionModes: map[string][]string{
+			"web":     {"cloud", "device", "hybrid"},
+			"android": {"cloud", "device"},
+		},
+	}
+}
+
+func newTestClient(t *testing.T, baseURL string) *client.Client {
+	t.Helper()
+
+	c, err := client.New("token", client.WithBaseURL(baseURL))
+	require.NoError(t, err)
+	return c
+}

--- a/cli/internal/providers/destination/model.go
+++ b/cli/internal/providers/destination/model.go
@@ -1,0 +1,44 @@
+package destination
+
+import (
+	"github.com/rudderlabs/rudder-iac/api/client"
+	"github.com/rudderlabs/rudder-iac/cli/internal/provider/handler"
+	"github.com/rudderlabs/rudder-iac/cli/internal/resources"
+)
+
+type DestinationSpec struct {
+	ID                string         `mapstructure:"id"`
+	DisplayName       string         `mapstructure:"display_name"`
+	Type              string         `mapstructure:"type"`
+	Enabled           bool           `mapstructure:"enabled"`
+	DefinitionVersion int64          `mapstructure:"definition_version"`
+	Transformation    string         `mapstructure:"transformation"`
+	Config            map[string]any `mapstructure:"config"`
+}
+
+type DestinationResource struct {
+	ID                string
+	DisplayName       string
+	Type              string
+	Enabled           bool
+	DefinitionVersion int64
+	Transformation    *resources.PropertyRef
+	Config            map[string]any
+}
+
+type DestinationState struct {
+	ID               string
+	TransformationID string
+}
+
+type RemoteDestination struct {
+	*client.Destination
+}
+
+func (r RemoteDestination) Metadata() handler.RemoteResourceMetadata {
+	return handler.RemoteResourceMetadata{
+		ID:         r.ID,
+		ExternalID: r.ExternalID,
+		Name:       r.Name,
+	}
+}

--- a/cli/internal/providers/destination/model_test.go
+++ b/cli/internal/providers/destination/model_test.go
@@ -1,0 +1,61 @@
+package destination_test
+
+import (
+	"testing"
+
+	"github.com/go-viper/mapstructure/v2"
+	"github.com/rudderlabs/rudder-iac/api/client"
+	"github.com/rudderlabs/rudder-iac/cli/internal/provider/handler"
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDestinationSpecMapstructureDecode(t *testing.T) {
+	t.Parallel()
+
+	input := map[string]any{
+		"id":                 "ga4-production",
+		"display_name":       "Production GA4",
+		"type":               "GA4",
+		"enabled":            true,
+		"definition_version": int64(1),
+		"transformation":     "#transformation:my-transform",
+		"config": map[string]any{
+			"api_secret": "secret",
+		},
+	}
+
+	var spec destination.DestinationSpec
+	require.NoError(t, mapstructure.Decode(input, &spec))
+
+	assert.Equal(t, &destination.DestinationSpec{
+		ID:                "ga4-production",
+		DisplayName:       "Production GA4",
+		Type:              "GA4",
+		Enabled:           true,
+		DefinitionVersion: 1,
+		Transformation:    "#transformation:my-transform",
+		Config: map[string]any{
+			"api_secret": "secret",
+		},
+	}, &spec)
+}
+
+func TestRemoteDestinationMetadata(t *testing.T) {
+	t.Parallel()
+
+	remote := destination.RemoteDestination{
+		Destination: &client.Destination{
+			ID:         "dst-remote-1",
+			ExternalID: "ga4-production",
+			Name:       "Production GA4",
+		},
+	}
+
+	assert.Equal(t, handler.RemoteResourceMetadata{
+		ID:         "dst-remote-1",
+		ExternalID: "ga4-production",
+		Name:       "Production GA4",
+	}, remote.Metadata())
+}

--- a/cli/internal/providers/destination/provider.go
+++ b/cli/internal/providers/destination/provider.go
@@ -1,0 +1,38 @@
+package destination
+
+import (
+	"github.com/rudderlabs/rudder-iac/api/client"
+	"github.com/rudderlabs/rudder-iac/cli/internal/project/specs"
+	"github.com/rudderlabs/rudder-iac/cli/internal/provider"
+	prules "github.com/rudderlabs/rudder-iac/cli/internal/provider/rules"
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions"
+	"github.com/rudderlabs/rudder-iac/cli/internal/validation/rules"
+)
+
+type Provider struct {
+	*provider.BaseProvider
+}
+
+func NewProvider(c *client.Client, registry *definitions.Registry) *Provider {
+	return &Provider{
+		BaseProvider: provider.NewBaseProvider([]provider.Handler{
+			NewHandler(c, registry),
+		}),
+	}
+}
+
+func (p *Provider) LoadLegacySpec(_ string, s *specs.Spec) error {
+	return &provider.ErrUnsupportedSpecKind{Kind: s.Kind}
+}
+
+func (p *Provider) SupportedMatchPatterns() []rules.MatchPattern {
+	return prules.V1VersionPatterns(DestinationSpecKind)
+}
+
+func (p *Provider) SyntacticRules() []rules.Rule {
+	return nil
+}
+
+func (p *Provider) SemanticRules() []rules.Rule {
+	return nil
+}

--- a/cli/internal/providers/destination/types.go
+++ b/cli/internal/providers/destination/types.go
@@ -1,0 +1,7 @@
+package destination
+
+const (
+	DestinationResourceType = "destination"
+	DestinationSpecKind     = "destination"
+	DestinationMetadataName = "destination"
+)

--- a/cli/internal/ruledoc/ruledoc_test.go
+++ b/cli/internal/ruledoc/ruledoc_test.go
@@ -6,6 +6,7 @@ import (
 	providerrules "github.com/rudderlabs/rudder-iac/cli/internal/provider/rules"
 	"github.com/rudderlabs/rudder-iac/cli/internal/providers/datacatalog/localcatalog"
 	essource "github.com/rudderlabs/rudder-iac/cli/internal/providers/event-stream/source"
+	dtypes "github.com/rudderlabs/rudder-iac/cli/internal/providers/destination"
 	"github.com/rudderlabs/rudder-iac/cli/internal/providers/retl/sqlmodel"
 	ttypes "github.com/rudderlabs/rudder-iac/cli/internal/providers/transformations/types"
 	"github.com/rudderlabs/rudder-iac/cli/internal/ruledoc"
@@ -39,6 +40,7 @@ func gatekeeperScopedPatterns() []vrules.MatchPattern {
 	// v1-only kinds.
 	p = append(p, providerrules.V1VersionPatterns(ttypes.TransformationSpecKind)...)
 	p = append(p, providerrules.V1VersionPatterns(ttypes.LibrarySpecKind)...)
+	p = append(p, providerrules.V1VersionPatterns(dtypes.DestinationSpecKind)...)
 	return p
 }
 


### PR DESCRIPTION
## 🔗 Ticket

Resolves [RUD-2864](https://linear.app/rudderstack/issue/RUD-2864/destination-handler-models-crud-lifecycle-state-mapping-and-provider)

---

## Summary

Adds the destination provider and handler on BaseHandler, consuming the definitions registry for config conversion and wiring CRUD lifecycle with transformation link side effects. Registers the provider in the CLI app with an empty definition registry (production definitions deferred). Import/export and full validation rules remain stubbed for follow-up tickets.

---

## Changes

- Add `ExternalID` field to `client.Destination` for managed resource filtering
- Create destination models (Spec, Resource, State, RemoteDestination)
- Implement handler lifecycle: Create, Update, Delete, MapRemoteToState, LoadRemote/LoadImportable
- Stub Import and FormatForExport (RUD-2865)
- Wire destination provider + empty registry in `dependencies.go`
- Add unit and registry-integration tests (httptest mocks + GA4/Webhook test definitions)
- Update project gatekeeper rule doc fragments for `destination`/`rudder/v1`

---

## Testing

- `make lint` — pass
- `make test` — pass
- Unit tests for handler lifecycle, model decode, GA4 round-trip integration

---

## Risk / Impact

**Low** — New provider behind empty registry; no production destination types registered yet. E2E apply deferred until definitions are onboarded.

---

## Checklist

- [x] Ticket linked
- [x] Tests added/updated
- [x] No breaking changes (or documented)

Made with [Cursor](https://cursor.com)