### PR TITLE
feat(cli): add accounts provider with kind:accounts spec parsing and validation

### DIFF
--- a/cli/internal/app/dependencies.go
+++ b/cli/internal/app/dependencies.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rudderlabs/rudder-iac/cli/internal/project"
 	"github.com/rudderlabs/rudder-iac/cli/internal/project/importmanifest"
 	"github.com/rudderlabs/rudder-iac/cli/internal/provider"
+	accountsProvider "github.com/rudderlabs/rudder-iac/cli/internal/providers/accounts"
 	"github.com/rudderlabs/rudder-iac/cli/internal/providers/datacatalog"
 	dgProvider "github.com/rudderlabs/rudder-iac/cli/internal/providers/datagraph"
 	destProvider "github.com/rudderlabs/rudder-iac/cli/internal/providers/destination"
@@ -44,6 +45,7 @@ type Providers struct {
 	Workspace       *workspace.Provider
 	DataGraph       *dgProvider.Provider
 	Destination     *destProvider.Provider
+	Accounts        *accountsProvider.Provider
 }
 
 type deps struct {
@@ -177,6 +179,7 @@ func composeProviders(c *client.Client) (provider.Provider, *Providers, error) {
 		"transformations": p.Transformations,
 		"datagraph":       p.DataGraph,
 		"destination":     p.Destination,
+		"accounts":        p.Accounts,
 	}
 
 	cp, err := provider.NewCompositeProvider(providerMap)
@@ -220,6 +223,8 @@ func setupProviders(c *client.Client) (*Providers, error) {
 	destRegistry := definitions.NewRegistry()
 	dp := destProvider.NewProvider(c, destRegistry)
 
+	accp := accountsProvider.NewProvider(c.Accounts)
+
 	providers := &Providers{
 		DataCatalog:     dcp,
 		RETL:            retlp,
@@ -228,6 +233,7 @@ func setupProviders(c *client.Client) (*Providers, error) {
 		Workspace:       wsp,
 		DataGraph:       dgp,
 		Destination:     dp,
+		Accounts:        accp,
 	}
 
 	return providers, nil

--- a/cli/internal/project/docs/duplicate-urn.docs.yaml
+++ b/cli/internal/project/docs/duplicate-urn.docs.yaml
@@ -1,6 +1,8 @@
 rule_id: "project/duplicate-urn"
 match_behavior:
   - applies_to:
+      - kind: "accounts"
+        version: "rudder/v1"
       - kind: "categories"
         version: "rudder/0.1"
       - kind: "categories"

--- a/cli/internal/project/docs/manifest-inline-conflict.docs.yaml
+++ b/cli/internal/project/docs/manifest-inline-conflict.docs.yaml
@@ -1,6 +1,8 @@
 rule_id: "project/manifest-inline-conflict"
 match_behavior:
   - applies_to:
+      - kind: "accounts"
+        version: "rudder/v1"
       - kind: "categories"
         version: "rudder/0.1"
       - kind: "categories"

--- a/cli/internal/project/docs/metadata-syntax-valid.docs.yaml
+++ b/cli/internal/project/docs/metadata-syntax-valid.docs.yaml
@@ -1,6 +1,8 @@
 rule_id: "project/metadata-syntax-valid"
 match_behavior:
   - applies_to:
+      - kind: "accounts"
+        version: "rudder/v1"
       - kind: "categories"
         version: "rudder/0.1"
       - kind: "categories"

--- a/cli/internal/project/docs/ruledoc_test.go
+++ b/cli/internal/project/docs/ruledoc_test.go
@@ -6,10 +6,11 @@ import (
 	projectdocs "github.com/rudderlabs/rudder-iac/cli/internal/project/docs"
 	prules "github.com/rudderlabs/rudder-iac/cli/internal/project/rules"
 	providerrules "github.com/rudderlabs/rudder-iac/cli/internal/provider/rules"
+	accountsprov "github.com/rudderlabs/rudder-iac/cli/internal/providers/accounts"
 	"github.com/rudderlabs/rudder-iac/cli/internal/providers/datacatalog/localcatalog"
 	dgHandler "github.com/rudderlabs/rudder-iac/cli/internal/providers/datagraph/handlers/datagraph"
-	essource "github.com/rudderlabs/rudder-iac/cli/internal/providers/event-stream/source"
 	dtypes "github.com/rudderlabs/rudder-iac/cli/internal/providers/destination"
+	essource "github.com/rudderlabs/rudder-iac/cli/internal/providers/event-stream/source"
 	"github.com/rudderlabs/rudder-iac/cli/internal/providers/retl/sqlmodel"
 	ttypes "github.com/rudderlabs/rudder-iac/cli/internal/providers/transformations/types"
 	"github.com/rudderlabs/rudder-iac/cli/internal/validation/docs"
@@ -47,6 +48,7 @@ func gatekeeperScopedPatterns() []rules.MatchPattern {
 	p = append(p, providerrules.V1VersionPatterns(ttypes.TransformationSpecKind)...)
 	p = append(p, providerrules.V1VersionPatterns(ttypes.LibrarySpecKind)...)
 	p = append(p, providerrules.V1VersionPatterns(dtypes.DestinationSpecKind)...)
+	p = append(p, providerrules.V1VersionPatterns(accountsprov.HandlerMetadata.SpecKind)...)
 	return p
 }
 

--- a/cli/internal/providers/accounts/handler.go
+++ b/cli/internal/providers/accounts/handler.go
@@ -1,0 +1,149 @@
+package accounts
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+
+	"github.com/rudderlabs/rudder-iac/api/client"
+	"github.com/rudderlabs/rudder-iac/cli/internal/namer"
+	"github.com/rudderlabs/rudder-iac/cli/internal/project/importmanifest"
+	"github.com/rudderlabs/rudder-iac/cli/internal/project/writer"
+	"github.com/rudderlabs/rudder-iac/cli/internal/provider/handler"
+	"github.com/rudderlabs/rudder-iac/cli/internal/resolver"
+)
+
+// bigQueryDefinition is the only account definition supported this milestone
+// (BigQuery-only scope). Other warehouses land in the "Post Bigquery" work.
+const bigQueryDefinition = "SOURCE_BIGQUERY"
+
+var (
+	screamingSnakeCase = regexp.MustCompile(`^[A-Z][A-Z0-9_]*$`)
+	validExternalID    = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_-]*$`)
+)
+
+// AccountStore is the subset of the accounts API client the handler needs. It is
+// declared at the point of use so tests can supply a mock. The real client's
+// `*client.Client.Accounts` satisfies it.
+type AccountStore interface {
+	Create(ctx context.Context, req *client.CreateAccountRequest) (*client.Account, error)
+	Update(ctx context.Context, id string, req *client.UpdateAccountRequest) (*client.Account, error)
+	Delete(ctx context.Context, id string) error
+	Get(ctx context.Context, id string) (*client.Account, error)
+	List(ctx context.Context, opts ...client.ListAccountsOption) (*client.AccountsPage, error)
+	SetExternalID(ctx context.Context, id string, externalID string) error
+}
+
+// AccountHandler is the concrete BaseHandler for warehouse accounts.
+type AccountHandler = handler.BaseHandler[AccountSpec, AccountResource, AccountState, RemoteAccount]
+
+// HandlerMetadata identifies the account resource type and its spec kind.
+var HandlerMetadata = handler.HandlerMetadata{
+	ResourceType:     "account",
+	SpecKind:         "accounts",
+	SpecMetadataName: "accounts",
+}
+
+// HandlerImpl provides the account-specific pieces the BaseHandler composes.
+type HandlerImpl struct {
+	store AccountStore
+}
+
+// NewHandler builds the account BaseHandler around the given store.
+func NewHandler(store AccountStore) *AccountHandler {
+	return handler.NewHandler(&HandlerImpl{store: store})
+}
+
+func (h *HandlerImpl) Metadata() handler.HandlerMetadata {
+	return HandlerMetadata
+}
+
+func (h *HandlerImpl) NewSpec() *AccountSpec {
+	return &AccountSpec{}
+}
+
+// ExtractResourcesFromSpec parses the `spec.accounts[]` collection into one
+// AccountResource per item keyed by its `id`, validating each item and rejecting
+// duplicate ids within the spec.
+func (h *HandlerImpl) ExtractResourcesFromSpec(path string, spec *AccountSpec) (map[string]*AccountResource, error) {
+	res := make(map[string]*AccountResource, len(spec.Accounts))
+	for i := range spec.Accounts {
+		item := spec.Accounts[i]
+		if err := validateAccountItem(item); err != nil {
+			return nil, fmt.Errorf("account %q in %s: %w", item.ID, path, err)
+		}
+		if _, dup := res[item.ID]; dup {
+			return nil, fmt.Errorf("duplicate account id %q in %s", item.ID, path)
+		}
+
+		credentials := item.Config.Credentials
+		res[item.ID] = &AccountResource{
+			ID:                    item.ID,
+			AccountDefinitionName: item.AccountDefinitionName,
+			Options:               item.Config.Options,
+			Credentials:           &credentials,
+		}
+	}
+	return res, nil
+}
+
+// validateAccountItem enforces the CLI-side rules (CONTRACT-ACCT-STATE-V1 §6.1):
+// a valid stable id, and an accountDefinitionName that is SCREAMING_SNAKE_CASE
+// and resolves to a supported (BigQuery) definition.
+func validateAccountItem(item AccountItem) error {
+	if item.ID == "" {
+		return fmt.Errorf("id is required")
+	}
+	if !validExternalID.MatchString(item.ID) {
+		return fmt.Errorf("id %q is not a valid external-id token", item.ID)
+	}
+	if item.AccountDefinitionName == "" {
+		return fmt.Errorf("accountDefinitionName is required")
+	}
+	if !screamingSnakeCase.MatchString(item.AccountDefinitionName) {
+		return fmt.Errorf("accountDefinitionName %q must be SCREAMING_SNAKE_CASE", item.AccountDefinitionName)
+	}
+	if item.AccountDefinitionName != bigQueryDefinition {
+		return fmt.Errorf("accountDefinitionName %q is not supported (only %s this milestone)", item.AccountDefinitionName, bigQueryDefinition)
+	}
+	return nil
+}
+
+// --- Remote lifecycle: stubbed here; implemented in DEX-459 (CRUD + load + map)
+//     and DEX-460 (import + export). ---
+
+func (h *HandlerImpl) LoadRemoteResources(ctx context.Context) ([]*RemoteAccount, error) {
+	return nil, fmt.Errorf("accounts: LoadRemoteResources not implemented (DEX-459)")
+}
+
+func (h *HandlerImpl) LoadImportableResources(ctx context.Context) ([]*RemoteAccount, error) {
+	return nil, fmt.Errorf("accounts: LoadImportableResources not implemented (DEX-459)")
+}
+
+func (h *HandlerImpl) MapRemoteToState(remote *RemoteAccount, urnResolver handler.URNResolver) (*AccountResource, *AccountState, error) {
+	return nil, nil, fmt.Errorf("accounts: MapRemoteToState not implemented (DEX-459)")
+}
+
+func (h *HandlerImpl) Create(ctx context.Context, data *AccountResource) (*AccountState, error) {
+	return nil, fmt.Errorf("accounts: Create not implemented (DEX-459)")
+}
+
+func (h *HandlerImpl) Update(ctx context.Context, newData *AccountResource, oldData *AccountResource, oldState *AccountState) (*AccountState, error) {
+	return nil, fmt.Errorf("accounts: Update not implemented (DEX-459)")
+}
+
+func (h *HandlerImpl) Delete(ctx context.Context, id string, oldData *AccountResource, oldState *AccountState) error {
+	return fmt.Errorf("accounts: Delete not implemented (DEX-459)")
+}
+
+func (h *HandlerImpl) Import(ctx context.Context, data *AccountResource, remoteId string) (*AccountState, error) {
+	return nil, fmt.Errorf("accounts: Import not implemented (DEX-460)")
+}
+
+func (h *HandlerImpl) FormatForExport(
+	collection map[string]*RemoteAccount,
+	idNamer namer.Namer,
+	inputResolver resolver.ReferenceResolver,
+) ([]writer.FormattableEntity, []importmanifest.ImportEntry, error) {
+	return nil, nil, fmt.Errorf("accounts: FormatForExport not implemented (DEX-460)")
+}

--- a/cli/internal/providers/accounts/handler_test.go
+++ b/cli/internal/providers/accounts/handler_test.go
@@ -1,0 +1,73 @@
+package accounts
+
+import (
+	"testing"
+
+	"github.com/rudderlabs/rudder-iac/cli/internal/secret"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func bqItem(id string) AccountItem {
+	return AccountItem{
+		ID:                    id,
+		AccountDefinitionName: "SOURCE_BIGQUERY",
+		Config: AccountConfig{
+			Credentials: secret.New("{{ .BQ_CREDENTIALS }}"),
+			Options:     map[string]any{"project": "lovable-prod"},
+		},
+	}
+}
+
+func TestExtractResourcesFromSpecParsesCollection(t *testing.T) {
+	h := &HandlerImpl{}
+	spec := &AccountSpec{Accounts: []AccountItem{bqItem("lovable-prod-bq"), bqItem("lovable-staging-bq")}}
+
+	res, err := h.ExtractResourcesFromSpec("accounts.yaml", spec)
+	require.NoError(t, err)
+	require.Len(t, res, 2)
+
+	a := res["lovable-prod-bq"]
+	require.NotNil(t, a)
+	assert.Equal(t, "lovable-prod-bq", a.ID)
+	assert.Equal(t, "SOURCE_BIGQUERY", a.AccountDefinitionName)
+	assert.Equal(t, "lovable-prod", a.Options["project"])
+	require.NotNil(t, a.Credentials, "credentials must be carried as *secret.String")
+}
+
+func TestExtractResourcesFromSpecRejectsDuplicateID(t *testing.T) {
+	h := &HandlerImpl{}
+	spec := &AccountSpec{Accounts: []AccountItem{bqItem("dup"), bqItem("dup")}}
+
+	_, err := h.ExtractResourcesFromSpec("accounts.yaml", spec)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "duplicate account id")
+}
+
+func TestExtractResourcesFromSpecValidation(t *testing.T) {
+	cases := []struct {
+		name string
+		item AccountItem
+		want string
+	}{
+		{"missing id", AccountItem{AccountDefinitionName: "SOURCE_BIGQUERY"}, "id is required"},
+		{"invalid id token", AccountItem{ID: "bad id!", AccountDefinitionName: "SOURCE_BIGQUERY"}, "not a valid external-id token"},
+		{"missing definition", AccountItem{ID: "a"}, "accountDefinitionName is required"},
+		{"not screaming snake", AccountItem{ID: "a", AccountDefinitionName: "source_bigquery"}, "SCREAMING_SNAKE_CASE"},
+		{"unsupported definition", AccountItem{ID: "a", AccountDefinitionName: "SOURCE_SNOWFLAKE"}, "not supported"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := &HandlerImpl{}
+			_, err := h.ExtractResourcesFromSpec("accounts.yaml", &AccountSpec{Accounts: []AccountItem{tc.item}})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.want)
+		})
+	}
+}
+
+func TestHandlerMetadata(t *testing.T) {
+	h := &HandlerImpl{}
+	assert.Equal(t, "accounts", h.Metadata().SpecKind)
+	assert.Equal(t, "account", h.Metadata().ResourceType)
+}

--- a/cli/internal/providers/accounts/model.go
+++ b/cli/internal/providers/accounts/model.go
@@ -1,0 +1,60 @@
+package accounts
+
+import (
+	"github.com/rudderlabs/rudder-iac/api/client"
+	"github.com/rudderlabs/rudder-iac/cli/internal/provider/handler"
+	"github.com/rudderlabs/rudder-iac/cli/internal/secret"
+)
+
+// AccountConfig is the single flat `config` block a user writes. The handler
+// routes each field to the API's `options` (non-secret) vs `secret` per the
+// account definition's secret-field set. For BigQuery the only secret field is
+// `credentials`; every other key is carried in Options via mapstructure's
+// ",remain".
+type AccountConfig struct {
+	Credentials secret.String  `mapstructure:"credentials"`
+	Options     map[string]any `mapstructure:",remain"`
+}
+
+// AccountItem is one account in the `kind: accounts` collection.
+type AccountItem struct {
+	ID                    string        `mapstructure:"id"`
+	AccountDefinitionName string        `mapstructure:"accountDefinitionName"`
+	Config                AccountConfig `mapstructure:"config"`
+}
+
+// AccountSpec is the decoded `kind: accounts` spec — one file declares one or
+// more accounts.
+type AccountSpec struct {
+	Accounts []AccountItem `mapstructure:"accounts"`
+}
+
+// AccountResource is the RawData (differ input) for a single account. The secret
+// is carried as *secret.String so the value survives the differ's struct→map
+// decode (mirrors the framework's example provider).
+type AccountResource struct {
+	ID                    string         `json:"id"`
+	AccountDefinitionName string         `json:"accountDefinitionName"`
+	Options               map[string]any `json:"options"`
+	Credentials           *secret.String `json:"credentials"`
+}
+
+// AccountState is the computed output — the remote account id.
+type AccountState struct {
+	ID string
+}
+
+// RemoteAccount wraps the API account to implement the RemoteResource interface.
+type RemoteAccount struct {
+	*client.Account
+}
+
+// Metadata implements the RemoteResource interface.
+func (r RemoteAccount) Metadata() handler.RemoteResourceMetadata {
+	return handler.RemoteResourceMetadata{
+		ID:          r.ID,
+		ExternalID:  r.ExternalID,
+		WorkspaceID: r.WorkspaceID,
+		Name:        r.Name,
+	}
+}

--- a/cli/internal/providers/accounts/model_test.go
+++ b/cli/internal/providers/accounts/model_test.go
@@ -1,0 +1,23 @@
+package accounts
+
+import (
+	"testing"
+
+	"github.com/rudderlabs/rudder-iac/api/client"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRemoteAccountMetadata(t *testing.T) {
+	r := RemoteAccount{Account: &client.Account{
+		ID:          "remote-id",
+		ExternalID:  "lovable-prod-bq",
+		WorkspaceID: "ws-1",
+		Name:        "prod",
+	}}
+
+	m := r.Metadata()
+	assert.Equal(t, "remote-id", m.ID)
+	assert.Equal(t, "lovable-prod-bq", m.ExternalID)
+	assert.Equal(t, "ws-1", m.WorkspaceID)
+	assert.Equal(t, "prod", m.Name)
+}

--- a/cli/internal/providers/accounts/provider.go
+++ b/cli/internal/providers/accounts/provider.go
@@ -1,0 +1,32 @@
+package accounts
+
+import (
+	"github.com/rudderlabs/rudder-iac/cli/internal/provider"
+	prules "github.com/rudderlabs/rudder-iac/cli/internal/provider/rules"
+	"github.com/rudderlabs/rudder-iac/cli/internal/validation/rules"
+)
+
+// Provider wraps the base provider to give a concrete type for dependency
+// injection. Accounts are a single collection kind (`kind: accounts`).
+type Provider struct {
+	provider.Provider
+}
+
+// NewProvider creates the accounts provider around the given account store.
+func NewProvider(store AccountStore) *Provider {
+	handlers := []provider.Handler{
+		NewHandler(store),
+	}
+	return &Provider{
+		Provider: provider.NewBaseProvider(handlers),
+	}
+}
+
+// SupportedMatchPatterns declares the `accounts` kind so the gatekeeper rules
+// (duplicate-urn, metadata-syntax-valid, manifest-inline-conflict) scope to it —
+// without this they match nothing for the kind. Accounts is a new resource, so
+// like the destination and data-graph providers it ships `rudder/v1` only (no
+// legacy versions).
+func (p *Provider) SupportedMatchPatterns() []rules.MatchPattern {
+	return prules.V1VersionPatterns(HandlerMetadata.SpecKind)
+}

--- a/cli/internal/ruledoc/ruledoc_test.go
+++ b/cli/internal/ruledoc/ruledoc_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	providerrules "github.com/rudderlabs/rudder-iac/cli/internal/provider/rules"
+	accountsprov "github.com/rudderlabs/rudder-iac/cli/internal/providers/accounts"
 	"github.com/rudderlabs/rudder-iac/cli/internal/providers/datacatalog/localcatalog"
 	dgHandler "github.com/rudderlabs/rudder-iac/cli/internal/providers/datagraph/handlers/datagraph"
 	essource "github.com/rudderlabs/rudder-iac/cli/internal/providers/event-stream/source"
@@ -43,6 +44,7 @@ func gatekeeperScopedPatterns() []vrules.MatchPattern {
 	p = append(p, providerrules.V1VersionPatterns(ttypes.TransformationSpecKind)...)
 	p = append(p, providerrules.V1VersionPatterns(ttypes.LibrarySpecKind)...)
 	p = append(p, providerrules.V1VersionPatterns(dtypes.DestinationSpecKind)...)
+	p = append(p, providerrules.V1VersionPatterns(accountsprov.HandlerMetadata.SpecKind)...)
 	return p
 }
 


### PR DESCRIPTION
## 🔗 Ticket

Resolves [DEX-458](https://linear.app/rudderstack/issue/DEX-458)

> ⚠️ **Stacked on #657 (DEX-457).** This PR targets the DEX-457 branch; its diff is the accounts provider only. Review/merge #657 first — GitHub will auto-retarget this PR to `main` when #657 merges.

## Summary

Stands up the `providers/accounts` package on the `BaseProvider`/`BaseHandler` framework (template: the destination provider #655 + the example provider), with spec parsing + validation only. Remote lifecycle is stubbed for the follow-ups — CRUD/load/map in **DEX-459**, import/export in **DEX-460**. **Scope: BigQuery only.** Implements `CONTRACT-ACCT-STATE-V1` §6/§6.1.

## Changes

- **model** — `AccountSpec`/`AccountItem`/`AccountConfig`, `AccountResource`, `AccountState`, `RemoteAccount` (+ `Metadata()`). Users write a single flat `config` block; the BigQuery secret field `credentials` is typed `secret.String`, every other key lands in `Options` via mapstructure's `,remain`.
- **handler** — `HandlerMetadata` (`kind: accounts`), `NewSpec`, `ExtractResourcesFromSpec` (one `AccountResource` per item keyed by `id`) with validation: required SCREAMING_SNAKE_CASE `accountDefinitionName` resolving to `SOURCE_BIGQUERY`, valid external-id token `id`, and intra-spec `id` uniqueness. `AccountStore` interface declared at point of use (the client's `Accounts` service satisfies it). `Create/Update/Delete/LoadRemoteResources/LoadImportableResources/MapRemoteToState/Import/FormatForExport` are **stubbed** for DEX-459/460.
- **provider** — `NewProvider` + `SupportedMatchPatterns` (`rudder/v1` only, like destination/data-graph). Wired into `dependencies.go` (`Providers.Accounts`, `setupProviders`, composite map with key `accounts`).
- **rule docs** — added `kind: accounts` (`rudder/v1`) to the gatekeeper fragments (`duplicate-urn`, `metadata-syntax-valid`, `manifest-inline-conflict`) and mirrored it in both ruledoc test scoping helpers.

## Testing

- `make lint` — pass, 0 issues.
- `make test` — pass (accounts pkg coverage 63.9%; the uncovered lines are the DEX-459/460 stubs).
- `make gen-rule-docs` — regenerates cleanly (accounts kind covered).
- Unit tests: `ExtractResourcesFromSpec` collection parse + options/secret carry, duplicate-id rejection, 5 validation cases (missing/invalid id, missing/non-screaming/unsupported definition), handler + remote metadata.

## Risk / Impact

**Low** — new provider; the `kind: accounts` collection parses + validates, but the remote lifecycle is stubbed so the binary can't apply/import an account end-to-end until DEX-459/460 land. No change to existing provider behavior.

## Checklist
- [x] Ticket linked
- [x] Tests added
- [x] `make lint` + `make test` green
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
