### PR TITLE
feat: add support for the destination validations

### DIFF
--- a/cli/internal/provider/rules/funcs/utils.go
+++ b/cli/internal/provider/rules/funcs/utils.go
@@ -115,6 +115,13 @@ func getErrorMessage(err validator.FieldError, rootType reflect.Type, resolveTag
 	case "oneof":
 		return fmt.Sprintf("'%s' must be one of [%s]", fieldName, err.Param())
 
+	case "dynamic_or_oneof":
+		return fmt.Sprintf(
+			"'%s' must be one of [%s] or a dynamic config value (env.VAR, {{ path || fallback }}, or {{ .VAR }})",
+			fieldName,
+			err.Param(),
+		)
+
 	case "gte":
 		if err.Kind() == reflect.String || err.Kind() == reflect.Slice {
 			// For string and slice, the gte tag is used to validate the length

--- a/cli/internal/providers/destination/constants.go
+++ b/cli/internal/providers/destination/constants.go
@@ -1,0 +1,21 @@
+package destination
+
+import (
+	"github.com/rudderlabs/rudder-iac/cli/internal/provider/rules/funcs"
+)
+
+const (
+	// destinationDisplayNameRegexPattern mirrors the RudderStack UI constraint:
+	// /^[\w .-]{2,100}$/
+	destinationDisplayNameRegexPattern = `^[\w .-]{2,100}$`
+	destinationDisplayNameRegexTag     = "destination_display_name"
+	destinationDisplayNameErrorMessage = "must be 2-100 characters and contain only letters, digits, underscores, spaces, periods, and hyphens"
+)
+
+func init() {
+	funcs.NewPattern(
+		destinationDisplayNameRegexTag,
+		destinationDisplayNameRegexPattern,
+		destinationDisplayNameErrorMessage,
+	)
+}

--- a/cli/internal/providers/destination/definitions/common/consent_management.go
+++ b/cli/internal/providers/destination/definitions/common/consent_management.go
@@ -3,6 +3,8 @@ package common
 import (
 	"encoding/json"
 	"fmt"
+	"maps"
+	"strings"
 
 	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions/converter"
 )
@@ -97,9 +99,7 @@ func MergeSchemas(base, fragment json.RawMessage) (json.RawMessage, error) {
 		baseSchema["properties"] = baseProperties
 	}
 
-	for key, value := range fragmentSchema {
-		baseProperties[key] = value
-	}
+	maps.Copy(baseProperties, fragmentSchema)
 
 	merged, err := json.Marshal(baseSchema)
 	if err != nil {
@@ -108,17 +108,23 @@ func MergeSchemas(base, fragment json.RawMessage) (json.RawMessage, error) {
 	return json.RawMessage(merged), nil
 }
 
+// LocalSourceTypeKey converts an upstream camelCase source type to the
+// snake_case key used in local YAML config (e.g. reactNative → react_native).
+func LocalSourceTypeKey(sourceType string) string {
+	return camelToSnake(sourceType)
+}
+
 func camelToSnake(s string) string {
-	var res string
+	var res strings.Builder
 	for i, v := range s {
 		if 'A' <= v && v <= 'Z' {
 			if i != 0 {
-				res += "_"
+				res.WriteByte('_')
 			}
-			res += string(v + 32)
+			res.WriteRune(v + 32)
 		} else {
-			res += string(v)
+			res.WriteRune(v)
 		}
 	}
-	return res
+	return res.String()
 }

--- a/cli/internal/providers/destination/definitions/definition.go
+++ b/cli/internal/providers/destination/definitions/definition.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions/common"
 	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions/converter"
 )
 
@@ -60,6 +61,22 @@ func (d *RegisteredDefinition) SupportedSourceTypes() []string {
 		return nil
 	}
 	return append([]string(nil), d.SourceTypes...)
+}
+
+// LocalSourceTypeKeys returns the snake_case config keys for the definition's
+// supported source types — the keys allowed under source-type-scoped config
+// blocks like connection_mode and consent_management.
+func (d *RegisteredDefinition) LocalSourceTypeKeys() []string {
+	sourceTypes := d.SupportedSourceTypes()
+	if len(sourceTypes) == 0 {
+		return nil
+	}
+
+	keys := make([]string, 0, len(sourceTypes))
+	for _, sourceType := range sourceTypes {
+		keys = append(keys, common.LocalSourceTypeKey(sourceType))
+	}
+	return keys
 }
 
 func (d *RegisteredDefinition) ConnectionModes(sourceType string) ([]string, error) {

--- a/cli/internal/providers/destination/definitions/definition_test.go
+++ b/cli/internal/providers/destination/definitions/definition_test.go
@@ -48,6 +48,25 @@ func assertConfigError(t *testing.T, errors []ConfigError, path, message string)
 	t.Fatalf("expected validation error at %q with message %q, got %#v", path, message, errors)
 }
 
+func TestLocalSourceTypeKeys(t *testing.T) {
+	t.Parallel()
+
+	def := GA4TestDefinition()
+	def.SourceTypes = []string{"web", "reactNative", "amp"}
+
+	registered, err := newRegisteredDefinition(def)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"web", "react_native", "amp"}, registered.LocalSourceTypeKeys())
+}
+
+func TestLocalSourceTypeKeysEmpty(t *testing.T) {
+	t.Parallel()
+
+	registered, err := newRegisteredDefinition(WebhookTestDefinitionWithoutConnectionMode())
+	require.NoError(t, err)
+	assert.Nil(t, registered.LocalSourceTypeKeys())
+}
+
 func TestNewRegisteredDefinitionMissingNewConfig(t *testing.T) {
 	t.Parallel()
 

--- a/cli/internal/providers/destination/definitions/dynamicvalues.go
+++ b/cli/internal/providers/destination/definitions/dynamicvalues.go
@@ -1,0 +1,77 @@
+package definitions
+
+import (
+	"reflect"
+	"regexp"
+	"strings"
+
+	"github.com/go-playground/validator/v10"
+
+	"github.com/rudderlabs/rudder-iac/cli/internal/validation/rules"
+)
+
+var (
+	uiEnvValueRegex     = regexp.MustCompile(`^env[.].+`)
+	uiTemplateValueRegex = regexp.MustCompile(`^\{\{.*\|\|(.*)\}\}$`)
+	iacVarValueRegex    = regexp.MustCompile(`^\{\{\s*\.[A-Za-z_][A-Za-z0-9_]*(?:\s*\|\s*((?:[^}]|}[^}])*?))?\s*\}\}$`)
+)
+
+// IsDynamicConfigValue reports whether value uses RudderStack UI dynamic syntax
+// (env.VAR or {{ path || fallback }}) or IaC variable substitution
+// ({{ .VAR }} / {{ .VAR | default }}). These are accepted as opaque pass-through
+// values, matching terraform-provider-rudderstack field validators.
+func IsDynamicConfigValue(value string) bool {
+	if value == "" {
+		return false
+	}
+
+	return uiEnvValueRegex.MatchString(value) ||
+		uiTemplateValueRegex.MatchString(value) ||
+		iacVarValueRegex.MatchString(value)
+}
+
+func configValidateFuncs() []rules.CustomValidateFunc {
+	return []rules.CustomValidateFunc{
+		{
+			Tag:  "dynamic_or_oneof",
+			Func: dynamicOrOneOf,
+		},
+	}
+}
+
+func dynamicOrOneOf(fl validator.FieldLevel) bool {
+	value, ok := stringFieldValue(fl)
+	if !ok || value == "" {
+		return true
+	}
+
+	if IsDynamicConfigValue(value) {
+		return true
+	}
+
+	for _, option := range strings.Fields(fl.Param()) {
+		if value == option {
+			return true
+		}
+	}
+
+	return false
+}
+
+func stringFieldValue(fl validator.FieldLevel) (string, bool) {
+	field := fl.Field()
+	switch field.Kind() {
+	case reflect.String:
+		return field.String(), true
+	case reflect.Ptr:
+		if field.IsNil() {
+			return "", true
+		}
+		if field.Elem().Kind() != reflect.String {
+			return "", false
+		}
+		return field.Elem().String(), true
+	default:
+		return "", false
+	}
+}

--- a/cli/internal/providers/destination/definitions/dynamicvalues.go
+++ b/cli/internal/providers/destination/definitions/dynamicvalues.go
@@ -11,9 +11,9 @@ import (
 )
 
 var (
-	uiEnvValueRegex     = regexp.MustCompile(`^env[.].+`)
+	uiEnvValueRegex      = regexp.MustCompile(`^env[.].+`)
 	uiTemplateValueRegex = regexp.MustCompile(`^\{\{.*\|\|(.*)\}\}$`)
-	iacVarValueRegex    = regexp.MustCompile(`^\{\{\s*\.[A-Za-z_][A-Za-z0-9_]*(?:\s*\|\s*((?:[^}]|}[^}])*?))?\s*\}\}$`)
+	varValueRegex        = regexp.MustCompile(`^\{\{\s*\.[A-Za-z_][A-Za-z0-9_]*(?:\s*\|\s*((?:[^}]|}[^}])*?))?\s*\}\}$`)
 )
 
 // IsDynamicConfigValue reports whether value uses RudderStack UI dynamic syntax
@@ -27,7 +27,7 @@ func IsDynamicConfigValue(value string) bool {
 
 	return uiEnvValueRegex.MatchString(value) ||
 		uiTemplateValueRegex.MatchString(value) ||
-		iacVarValueRegex.MatchString(value)
+		varValueRegex.MatchString(value)
 }
 
 func configValidateFuncs() []rules.CustomValidateFunc {
@@ -60,10 +60,12 @@ func dynamicOrOneOf(fl validator.FieldLevel) bool {
 
 func stringFieldValue(fl validator.FieldLevel) (string, bool) {
 	field := fl.Field()
+
 	switch field.Kind() {
 	case reflect.String:
 		return field.String(), true
-	case reflect.Ptr:
+
+	case reflect.Pointer:
 		if field.IsNil() {
 			return "", true
 		}
@@ -71,6 +73,7 @@ func stringFieldValue(fl validator.FieldLevel) (string, bool) {
 			return "", false
 		}
 		return field.Elem().String(), true
+
 	default:
 		return "", false
 	}

--- a/cli/internal/providers/destination/definitions/dynamicvalues_test.go
+++ b/cli/internal/providers/destination/definitions/dynamicvalues_test.go
@@ -1,0 +1,97 @@
+package definitions_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions"
+)
+
+func TestIsDynamicConfigValue(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		value string
+		want  bool
+	}{
+		{name: "ui env reference", value: "env.API_SECRET", want: true},
+		{name: "ui template fallback", value: "{{ config.url || https://example.com }}", want: true},
+		{name: "iac variable substitution", value: "{{ .API_SECRET }}", want: true},
+		{name: "iac variable with default", value: "{{ .API_SECRET | fallback }}", want: true},
+		{name: "plain literal", value: "secret-value", want: false},
+		{name: "invalid template without dot", value: "{{ API_SECRET }}", want: false},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, c.want, definitions.IsDynamicConfigValue(c.value))
+		})
+	}
+}
+
+func TestValidateConfigAllowsDynamicValues(t *testing.T) {
+	t.Parallel()
+
+	registered := registerTestDefinition(t)
+
+	t.Run("secret via env reference", func(t *testing.T) {
+		t.Parallel()
+
+		errors := registered.ValidateConfig(map[string]any{
+			"api_secret":      "env.API_SECRET",
+			"types_of_client": "gtag",
+			"measurement_id":  "G-123",
+		})
+		assert.Empty(t, errors)
+	})
+
+	t.Run("secret via ui template fallback", func(t *testing.T) {
+		t.Parallel()
+
+		errors := registered.ValidateConfig(map[string]any{
+			"api_secret":      "{{ config.apiSecret || fallback }}",
+			"types_of_client": "gtag",
+			"measurement_id":  "G-123",
+		})
+		assert.Empty(t, errors)
+	})
+
+	t.Run("secret via iac variable substitution", func(t *testing.T) {
+		t.Parallel()
+
+		errors := registered.ValidateConfig(map[string]any{
+			"api_secret":      "{{ .API_SECRET }}",
+			"types_of_client": "gtag",
+			"measurement_id":  "G-123",
+		})
+		assert.Empty(t, errors)
+	})
+
+	t.Run("connection mode via env reference", func(t *testing.T) {
+		t.Parallel()
+
+		errors := registered.ValidateConfig(map[string]any{
+			"api_secret":      "secret",
+			"types_of_client": "gtag",
+			"measurement_id":  "G-123",
+			"connection_mode": map[string]any{
+				"web": "env.WEB_CONNECTION_MODE",
+			},
+		})
+		assert.Empty(t, errors)
+	})
+
+	t.Run("client type via env reference", func(t *testing.T) {
+		t.Parallel()
+
+		errors := registered.ValidateConfig(map[string]any{
+			"api_secret":      "secret",
+			"types_of_client": "env.CLIENT_TYPE",
+			"measurement_id":  "G-123",
+		})
+		assert.Empty(t, errors)
+	})
+}

--- a/cli/internal/providers/destination/definitions/dynamicvalues_test.go
+++ b/cli/internal/providers/destination/definitions/dynamicvalues_test.go
@@ -3,9 +3,8 @@ package definitions_test
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestIsDynamicConfigValue(t *testing.T) {

--- a/cli/internal/providers/destination/definitions/export_test.go
+++ b/cli/internal/providers/destination/definitions/export_test.go
@@ -5,20 +5,20 @@ import (
 )
 
 type testConnectionMode struct {
-	Web     *string `json:"web" mapstructure:"web" validate:"omitempty,oneof=cloud device hybrid"`
-	Android *string `json:"android" mapstructure:"android" validate:"omitempty,oneof=cloud device"`
+	Web     *string `json:"web" mapstructure:"web" validate:"omitempty,dynamic_or_oneof=cloud device hybrid"`
+	Android *string `json:"android" mapstructure:"android" validate:"omitempty,dynamic_or_oneof=cloud device"`
 }
 
 type testGA4Config struct {
 	APISecret      string             `json:"api_secret" mapstructure:"api_secret" validate:"required"`
-	TypesOfClient  string             `json:"types_of_client" mapstructure:"types_of_client" validate:"required,oneof=gtag firebase"`
+	TypesOfClient  string             `json:"types_of_client" mapstructure:"types_of_client" validate:"required,dynamic_or_oneof=gtag firebase"`
 	MeasurementID  string             `json:"measurement_id" mapstructure:"measurement_id" validate:"required_if=TypesOfClient gtag"`
 	DebugMode      *bool              `json:"debug_mode" mapstructure:"debug_mode"`
 	ConnectionMode testConnectionMode `json:"connection_mode" mapstructure:"connection_mode"`
 }
 
 type testWebhookConnectionMode struct {
-	Web *string `json:"web" mapstructure:"web" validate:"omitempty,oneof=cloud"`
+	Web *string `json:"web" mapstructure:"web" validate:"omitempty,dynamic_or_oneof=cloud"`
 }
 
 type testWebhookConfig struct {

--- a/cli/internal/providers/destination/definitions/validator.go
+++ b/cli/internal/providers/destination/definitions/validator.go
@@ -51,7 +51,7 @@ func decodeConfig(config map[string]any, dest any) error {
 }
 
 func structValidationErrors(decoded any, basePath string, rootType reflect.Type) []ConfigError {
-	validationErrors, err := rules.ValidateStructWithTagPriority(decoded, []string{"mapstructure"})
+	validationErrors, err := rules.ValidateStructWithTagPriority(decoded, []string{"mapstructure"}, configValidateFuncs()...)
 	if err != nil {
 		return []ConfigError{{
 			Path:    basePath,

--- a/cli/internal/providers/destination/definitions/validator_test.go
+++ b/cli/internal/providers/destination/definitions/validator_test.go
@@ -74,7 +74,12 @@ func TestValidateConfigConnectionModeEnum(t *testing.T) {
 			"web": "invalid-mode",
 		},
 	})
-	assertConfigError(t, errors, "/connection_mode/web", "'web' must be one of [cloud device hybrid]")
+	assertConfigError(
+		t,
+		errors,
+		"/connection_mode/web",
+		"'web' must be one of [cloud device hybrid] or a dynamic config value (env.VAR, {{ path || fallback }}, or {{ .VAR }})",
+	)
 }
 
 func TestValidateConfigDecodeTypeError(t *testing.T) {

--- a/cli/internal/providers/destination/docs/destination-semantic-valid.docs.yaml
+++ b/cli/internal/providers/destination/docs/destination-semantic-valid.docs.yaml
@@ -1,0 +1,90 @@
+rule_id: "destination/semantic-valid"
+match_behavior:
+  - applies_to:
+      - kind: "destination"
+        version: "rudder/v1"
+    valid:
+      - example_id: "destination-semantic-valid-transformation-exists"
+        title: "Destination whose transformation exists in the project"
+        files:
+          destination.yaml: |
+            version: rudder/v1
+            kind: destination
+            metadata:
+              name: webhook-prod
+            spec:
+              id: webhook-prod
+              display_name: Production Webhook
+              type: WEBHOOK
+              definition_version: 1
+              transformation: "#transformation:my-transformation"
+              config:
+                webhook_url: "https://example.com/hook"
+          transformation.yaml: |
+            version: rudder/v1
+            kind: transformation
+            metadata:
+              name: my-transformation
+            spec:
+              id: my-transformation
+              name: My Transformation
+              language: javascript
+              code: "export function transformEvent(event) { return event; }"
+    invalid:
+      - example_id: "destination-semantic-transformation-not-found"
+        title: "Destination references a transformation that does not exist in the project"
+        files:
+          destination.yaml: |
+            version: rudder/v1
+            kind: destination
+            metadata:
+              name: webhook-prod
+            spec:
+              id: webhook-prod
+              display_name: Production Webhook
+              type: WEBHOOK
+              definition_version: 1
+              transformation: "#transformation:ghost"
+              config:
+                webhook_url: "https://example.com/hook"
+        expected_diagnostics:
+          - file: "destination.yaml"
+            reference: "/transformation"
+            severity: "error"
+            message_contains: "not found in the project"
+      - example_id: "destination-semantic-duplicate-display-name"
+        title: "Two destinations share the same display_name"
+        files:
+          destination-a.yaml: |
+            version: rudder/v1
+            kind: destination
+            metadata:
+              name: webhook-a
+            spec:
+              id: webhook-a
+              display_name: Shared Name
+              type: WEBHOOK
+              definition_version: 1
+              config:
+                webhook_url: "https://example.com/hook-a"
+          destination-b.yaml: |
+            version: rudder/v1
+            kind: destination
+            metadata:
+              name: webhook-b
+            spec:
+              id: webhook-b
+              display_name: Shared Name
+              type: WEBHOOK
+              definition_version: 1
+              config:
+                webhook_url: "https://example.com/hook-b"
+        expected_diagnostics:
+          - file: "destination-a.yaml"
+            reference: "/display_name"
+            severity: "error"
+            message_contains: "duplicate display_name"
+          - file: "destination-b.yaml"
+            reference: "/display_name"
+            severity: "error"
+            message_contains: "duplicate display_name"

--- a/cli/internal/providers/destination/docs/destination-spec-syntax-valid.docs.yaml
+++ b/cli/internal/providers/destination/docs/destination-spec-syntax-valid.docs.yaml
@@ -1,0 +1,84 @@
+rule_id: "destination/spec-syntax-valid"
+match_behavior:
+  - applies_to:
+      - kind: "destination"
+        version: "rudder/v1"
+    valid:
+      - example_id: "destination-spec-syntax-valid-basic"
+        title: "Valid destination with registered type, version and config"
+        files:
+          destination.yaml: |
+            version: rudder/v1
+            kind: destination
+            metadata:
+              name: webhook-prod
+            spec:
+              id: webhook-prod
+              display_name: Production Webhook
+              type: WEBHOOK
+              enabled: true
+              definition_version: 1
+              config:
+                webhook_url: "https://example.com/hook"
+    invalid:
+      - example_id: "destination-spec-syntax-unknown-field"
+        title: "Unknown envelope field is rejected"
+        files:
+          destination.yaml: |
+            version: rudder/v1
+            kind: destination
+            metadata:
+              name: webhook-prod
+            spec:
+              id: webhook-prod
+              display_name: Production Webhook
+              type: WEBHOOK
+              definition_version: 1
+              unexpected_field: true
+              config:
+                webhook_url: "https://example.com/hook"
+        expected_diagnostics:
+          - file: "destination.yaml"
+            reference: "/unexpected_field"
+            severity: "error"
+            message_contains: "unknown field"
+      - example_id: "destination-spec-syntax-unsupported-type"
+        title: "Destination type not present in the definition registry"
+        files:
+          destination.yaml: |
+            version: rudder/v1
+            kind: destination
+            metadata:
+              name: mystery-dest
+            spec:
+              id: mystery-dest
+              display_name: Mystery Destination
+              type: NOT_A_REAL_TYPE
+              definition_version: 1
+              config: {}
+        expected_diagnostics:
+          - file: "destination.yaml"
+            reference: "/type"
+            severity: "error"
+            message_contains: "is not supported"
+      - example_id: "destination-spec-syntax-bad-transformation-ref"
+        title: "Transformation reference must match #transformation:<id>"
+        files:
+          destination.yaml: |
+            version: rudder/v1
+            kind: destination
+            metadata:
+              name: webhook-prod
+            spec:
+              id: webhook-prod
+              display_name: Production Webhook
+              type: WEBHOOK
+              definition_version: 1
+              transformation: "transformation/my-transformation"
+              config:
+                webhook_url: "https://example.com/hook"
+        expected_diagnostics:
+          - file: "destination.yaml"
+            reference: "/transformation"
+            severity: "error"
+            message_contains: "must be of pattern #transformation:<id>"

--- a/cli/internal/providers/destination/docs/embed.go
+++ b/cli/internal/providers/destination/docs/embed.go
@@ -1,0 +1,6 @@
+package docs
+
+import "embed"
+
+//go:embed *.docs.yaml
+var FragmentsFS embed.FS

--- a/cli/internal/providers/destination/model.go
+++ b/cli/internal/providers/destination/model.go
@@ -8,11 +8,11 @@ import (
 
 // DestinationSpec is the user-authored YAML representation of a destination.
 type DestinationSpec struct {
-	ID                string         `mapstructure:"id"`
-	DisplayName       string         `mapstructure:"display_name"`
-	Type              string         `mapstructure:"type"`
+	ID                string         `mapstructure:"id" validate:"required"`
+	DisplayName       string         `mapstructure:"display_name" validate:"required"`
+	Type              string         `mapstructure:"type" validate:"required"`
 	Enabled           bool           `mapstructure:"enabled"`
-	DefinitionVersion int64          `mapstructure:"definition_version"`
+	DefinitionVersion int64          `mapstructure:"definition_version" validate:"required"`
 	Transformation    string         `mapstructure:"transformation"` // scalar "#transformation:<id>" — object form deferred
 	Config            map[string]any `mapstructure:"config"`
 }

--- a/cli/internal/providers/destination/model.go
+++ b/cli/internal/providers/destination/model.go
@@ -9,7 +9,7 @@ import (
 // DestinationSpec is the user-authored YAML representation of a destination.
 type DestinationSpec struct {
 	ID                string         `mapstructure:"id" validate:"required"`
-	DisplayName       string         `mapstructure:"display_name" validate:"required"`
+	DisplayName       string         `mapstructure:"display_name" validate:"required,pattern=destination_display_name"`
 	Type              string         `mapstructure:"type" validate:"required"`
 	Enabled           bool           `mapstructure:"enabled"`
 	DefinitionVersion int64          `mapstructure:"definition_version" validate:"required"`

--- a/cli/internal/providers/destination/provider.go
+++ b/cli/internal/providers/destination/provider.go
@@ -8,6 +8,7 @@ import (
 	"github.com/rudderlabs/rudder-iac/cli/internal/provider"
 	prules "github.com/rudderlabs/rudder-iac/cli/internal/provider/rules"
 	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions"
+	destdocs "github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/docs"
 	vdocs "github.com/rudderlabs/rudder-iac/cli/internal/validation/docs"
 	vrules "github.com/rudderlabs/rudder-iac/cli/internal/validation/rules"
 )
@@ -15,6 +16,7 @@ import (
 // Provider wraps BaseProvider with the single destination handler.
 type Provider struct {
 	*provider.BaseProvider
+	registry *definitions.Registry
 }
 
 // NewProvider constructs the destination provider with the given API client and
@@ -25,6 +27,7 @@ func NewProvider(c *client.Client, registry *definitions.Registry) *Provider {
 		BaseProvider: provider.NewBaseProvider([]provider.Handler{
 			NewHandler(c, registry),
 		}),
+		registry: registry,
 	}
 }
 
@@ -39,18 +42,21 @@ func (p *Provider) SupportedMatchPatterns() []vrules.MatchPattern {
 	return prules.V1VersionPatterns(DestinationSpecKind)
 }
 
-// SyntacticRules returns no rules this ticket — full validation is RUD-2853.
 func (p *Provider) SyntacticRules() []vrules.Rule {
-	return nil
+	return []vrules.Rule{
+		NewSpecSyntaxValidRule(p.registry),
+	}
 }
 
-// SemanticRules returns no rules this ticket — full validation is RUD-2853.
 func (p *Provider) SemanticRules() []vrules.Rule {
-	return nil
+	return []vrules.Rule{
+		NewSemanticValidRule(),
+	}
 }
 
-// RuleDocEntries returns no authored fragments yet — destination validation
-// rules and their docs land with RUD-2853.
+// RuleDocEntries returns the authored documentation fragments embedded with
+// the destination provider, joined to registered rules by the docs generator.
 func (p *Provider) RuleDocEntries() []vdocs.RuleDocEntry {
-	return nil
+	entries, _ := vdocs.LoadRuleDocEntries(destdocs.FragmentsFS, ".")
+	return entries
 }

--- a/cli/internal/providers/destination/provider_test.go
+++ b/cli/internal/providers/destination/provider_test.go
@@ -1,0 +1,34 @@
+package destination
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProviderRules(t *testing.T) {
+	t.Parallel()
+
+	p := NewProvider(nil, ruleTestRegistry(t))
+
+	syntactic := p.SyntacticRules()
+	require.Len(t, syntactic, 1)
+	assert.Equal(t, SpecSyntaxValidRuleID, syntactic[0].ID())
+
+	semantic := p.SemanticRules()
+	require.Len(t, semantic, 1)
+	assert.Equal(t, SemanticValidRuleID, semantic[0].ID())
+}
+
+func TestProviderRuleDocEntries(t *testing.T) {
+	t.Parallel()
+
+	p := NewProvider(nil, ruleTestRegistry(t))
+
+	entries := p.RuleDocEntries()
+	require.Len(t, entries, 2)
+
+	ids := []string{entries[0].RuleID, entries[1].RuleID}
+	assert.ElementsMatch(t, []string{SpecSyntaxValidRuleID, SemanticValidRuleID}, ids)
+}

--- a/cli/internal/providers/destination/rule_semantic_valid.go
+++ b/cli/internal/providers/destination/rule_semantic_valid.go
@@ -1,0 +1,89 @@
+package destination
+
+import (
+	"fmt"
+
+	prules "github.com/rudderlabs/rudder-iac/cli/internal/provider/rules"
+	ttypes "github.com/rudderlabs/rudder-iac/cli/internal/providers/transformations/types"
+	"github.com/rudderlabs/rudder-iac/cli/internal/resources"
+	vrules "github.com/rudderlabs/rudder-iac/cli/internal/validation/rules"
+)
+
+const SemanticValidRuleID = "destination/semantic-valid"
+
+type semanticValidRule struct{}
+
+// NewSemanticValidRule validates cross-resource concerns: the referenced
+// transformation exists in the project and display_name is unique across all
+// destinations. Envelope/config shape errors are owned by the syntactic rule.
+func NewSemanticValidRule() vrules.Rule {
+	return &semanticValidRule{}
+}
+
+func (r *semanticValidRule) ID() string {
+	return SemanticValidRuleID
+}
+
+func (r *semanticValidRule) Severity() vrules.Severity {
+	return vrules.Error
+}
+
+func (r *semanticValidRule) Description() string {
+	return "destination transformation reference must resolve to a project transformation and display_name must be unique across destinations"
+}
+
+func (r *semanticValidRule) AppliesTo() []vrules.MatchPattern {
+	return prules.V1VersionPatterns(DestinationSpecKind)
+}
+
+func (r *semanticValidRule) Examples() vrules.Examples {
+	return vrules.Examples{}
+}
+
+func (r *semanticValidRule) Validate(ctx *vrules.ValidationContext) []vrules.ValidationResult {
+	if !ctx.HasGraph() {
+		return nil
+	}
+
+	// Decode/format failures are reported by the syntactic rule; skip quietly.
+	spec, _, err := decodeDestinationSpec(ctx.Spec)
+	if err != nil {
+		return nil
+	}
+
+	var results []vrules.ValidationResult
+
+	if matches := transformationRefRegex.FindStringSubmatch(spec.Transformation); len(matches) == 2 {
+		transformationID := matches[1]
+		urn := resources.URN(transformationID, ttypes.TransformationResourceType)
+		if _, exists := ctx.Graph.GetResource(urn); !exists {
+			results = append(results, vrules.ValidationResult{
+				Reference: "/transformation",
+				Message:   fmt.Sprintf("transformation '%s' not found in the project", transformationID),
+			})
+		}
+	}
+
+	if spec.DisplayName != "" && countDisplayName(ctx.Graph, spec.DisplayName) > 1 {
+		results = append(results, vrules.ValidationResult{
+			Reference: "/display_name",
+			Message:   fmt.Sprintf("duplicate display_name '%s' within kind '%s'", spec.DisplayName, DestinationSpecKind),
+		})
+	}
+
+	return prefixSpecReferences(results)
+}
+
+func countDisplayName(graph *resources.Graph, displayName string) int {
+	count := 0
+	for _, res := range graph.ResourcesByType(DestinationResourceType) {
+		destination, ok := res.RawData().(*DestinationResource)
+		if !ok {
+			continue
+		}
+		if destination.DisplayName == displayName {
+			count++
+		}
+	}
+	return count
+}

--- a/cli/internal/providers/destination/rule_semantic_valid_test.go
+++ b/cli/internal/providers/destination/rule_semantic_valid_test.go
@@ -1,0 +1,142 @@
+package destination
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	prules "github.com/rudderlabs/rudder-iac/cli/internal/provider/rules"
+	ttypes "github.com/rudderlabs/rudder-iac/cli/internal/providers/transformations/types"
+	"github.com/rudderlabs/rudder-iac/cli/internal/resources"
+	vrules "github.com/rudderlabs/rudder-iac/cli/internal/validation/rules"
+)
+
+func destinationGraphResource(id, displayName string) *resources.Resource {
+	return resources.NewResource(
+		id,
+		DestinationResourceType,
+		resources.ResourceData{},
+		[]string{},
+		resources.WithRawData(&DestinationResource{ID: id, DisplayName: displayName}),
+	)
+}
+
+func transformationGraphResource(id string) *resources.Resource {
+	return resources.NewResource(
+		id,
+		ttypes.TransformationResourceType,
+		resources.ResourceData{},
+		[]string{},
+	)
+}
+
+func runSemanticRule(t *testing.T, spec map[string]any, graph *resources.Graph) []vrules.ValidationResult {
+	t.Helper()
+
+	rule := NewSemanticValidRule()
+	return rule.Validate(&vrules.ValidationContext{
+		Spec:    spec,
+		Kind:    DestinationSpecKind,
+		Version: "rudder/v1",
+		Graph:   graph,
+	})
+}
+
+func TestSemanticValidRuleMetadata(t *testing.T) {
+	t.Parallel()
+
+	rule := NewSemanticValidRule()
+	assert.Equal(t, SemanticValidRuleID, rule.ID())
+	assert.Equal(t, vrules.Error, rule.Severity())
+	assert.NotEmpty(t, rule.Description())
+	assert.Equal(t, prules.V1VersionPatterns(DestinationSpecKind), rule.AppliesTo())
+}
+
+func TestSemanticValidRuleNoGraph(t *testing.T) {
+	t.Parallel()
+
+	results := runSemanticRule(t, validSpecMap(), nil)
+	assert.Nil(t, results)
+}
+
+func TestSemanticValidRuleTransformationExists(t *testing.T) {
+	t.Parallel()
+
+	graph := resources.NewGraph()
+	graph.AddResource(destinationGraphResource("webhook-prod", "Production Webhook"))
+	graph.AddResource(transformationGraphResource("my-transformation"))
+
+	spec := validSpecMap()
+	spec["transformation"] = "#transformation:my-transformation"
+
+	assert.Empty(t, runSemanticRule(t, spec, graph))
+}
+
+func TestSemanticValidRuleTransformationMissing(t *testing.T) {
+	t.Parallel()
+
+	graph := resources.NewGraph()
+	graph.AddResource(destinationGraphResource("webhook-prod", "Production Webhook"))
+
+	spec := validSpecMap()
+	spec["transformation"] = "#transformation:ghost"
+
+	assert.Equal(t, []vrules.ValidationResult{
+		{
+			Reference: "/spec/transformation",
+			Message:   "transformation 'ghost' not found in the project",
+		},
+	}, runSemanticRule(t, spec, graph))
+}
+
+func TestSemanticValidRuleNoTransformationRef(t *testing.T) {
+	t.Parallel()
+
+	graph := resources.NewGraph()
+	graph.AddResource(destinationGraphResource("webhook-prod", "Production Webhook"))
+
+	assert.Empty(t, runSemanticRule(t, validSpecMap(), graph))
+}
+
+func TestSemanticValidRuleDuplicateDisplayName(t *testing.T) {
+	t.Parallel()
+
+	graph := resources.NewGraph()
+	graph.AddResource(destinationGraphResource("webhook-prod", "Production Webhook"))
+	graph.AddResource(destinationGraphResource("webhook-copy", "Production Webhook"))
+
+	assert.Equal(t, []vrules.ValidationResult{
+		{
+			Reference: "/spec/display_name",
+			Message:   "duplicate display_name 'Production Webhook' within kind 'destination'",
+		},
+	}, runSemanticRule(t, validSpecMap(), graph))
+}
+
+func TestSemanticValidRuleUniqueDisplayNames(t *testing.T) {
+	t.Parallel()
+
+	graph := resources.NewGraph()
+	graph.AddResource(destinationGraphResource("webhook-prod", "Production Webhook"))
+	graph.AddResource(destinationGraphResource("webhook-stage", "Staging Webhook"))
+
+	assert.Empty(t, runSemanticRule(t, validSpecMap(), graph))
+}
+
+func TestSemanticValidRuleSkipsForeignRawData(t *testing.T) {
+	t.Parallel()
+
+	graph := resources.NewGraph()
+	graph.AddResource(destinationGraphResource("webhook-prod", "Production Webhook"))
+	// A destination-typed resource whose RawData is not *DestinationResource
+	// must be skipped, not counted or panicked on.
+	graph.AddResource(resources.NewResource(
+		"weird",
+		DestinationResourceType,
+		resources.ResourceData{},
+		[]string{},
+		resources.WithRawData("not-a-destination"),
+	))
+
+	assert.Empty(t, runSemanticRule(t, validSpecMap(), graph))
+}

--- a/cli/internal/providers/destination/rule_spec_syntax_valid.go
+++ b/cli/internal/providers/destination/rule_spec_syntax_valid.go
@@ -1,0 +1,220 @@
+package destination
+
+import (
+	"fmt"
+	"maps"
+	"reflect"
+	"regexp"
+	"slices"
+	"sort"
+	"strings"
+
+	"github.com/go-viper/mapstructure/v2"
+
+	prules "github.com/rudderlabs/rudder-iac/cli/internal/provider/rules"
+	"github.com/rudderlabs/rudder-iac/cli/internal/provider/rules/funcs"
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions"
+	ttypes "github.com/rudderlabs/rudder-iac/cli/internal/providers/transformations/types"
+	vrules "github.com/rudderlabs/rudder-iac/cli/internal/validation/rules"
+)
+
+const SpecSyntaxValidRuleID = "destination/spec-syntax-valid"
+
+// transformationRefRegex matches scalar transformation refs of the form
+// #transformation:<id>, following the datacatalog reference convention.
+var transformationRefRegex = regexp.MustCompile(
+	fmt.Sprintf(`^#%s:([a-zA-Z0-9_-]+)$`, ttypes.TransformationSpecKind),
+)
+
+type specSyntaxValidRule struct {
+	registry *definitions.Registry
+}
+
+// NewSpecSyntaxValidRule validates the destination spec envelope, that the
+// (type, definition_version) pair is registered, the transformation ref
+// format, and the per-type config via the definition registry.
+func NewSpecSyntaxValidRule(registry *definitions.Registry) vrules.Rule {
+	return &specSyntaxValidRule{registry: registry}
+}
+
+func (r *specSyntaxValidRule) ID() string {
+	return SpecSyntaxValidRuleID
+}
+
+func (r *specSyntaxValidRule) Severity() vrules.Severity {
+	return vrules.Error
+}
+
+func (r *specSyntaxValidRule) Description() string {
+	return "destination spec envelope, registered type/version, transformation reference format and config must be valid"
+}
+
+func (r *specSyntaxValidRule) AppliesTo() []vrules.MatchPattern {
+	return prules.V1VersionPatterns(DestinationSpecKind)
+}
+
+func (r *specSyntaxValidRule) Examples() vrules.Examples {
+	return vrules.Examples{}
+}
+
+// Validate builds all references relative to the spec root; prefixSpecReferences
+// prepends /spec on every return path so results address the full document.
+func (r *specSyntaxValidRule) Validate(ctx *vrules.ValidationContext) []vrules.ValidationResult {
+	spec, unknownKeys, err := decodeDestinationSpec(ctx.Spec)
+	if err != nil {
+		return prefixSpecReferences([]vrules.ValidationResult{{
+			Message: err.Error(),
+		}})
+	}
+
+	results := make([]vrules.ValidationResult, 0, len(unknownKeys))
+	for _, key := range unknownKeys {
+		results = append(results, vrules.ValidationResult{
+			Reference: "/" + key,
+			Message:   fmt.Sprintf("unknown field %q", key),
+		})
+	}
+
+	validationErrors, err := vrules.ValidateStructWithTagPriority(spec, []string{"mapstructure"})
+	if err != nil {
+		results = append(results, vrules.ValidationResult{Message: err.Error()})
+		return prefixSpecReferences(results)
+	}
+	if len(validationErrors) > 0 {
+		structResults := funcs.ParseMapstructureValidationErrors(validationErrors, reflect.TypeFor[DestinationSpec]())
+		return prefixSpecReferences(append(results, structResults...))
+	}
+
+	if !r.registry.IsSupported(spec.Type) {
+		results = append(results, vrules.ValidationResult{
+			Reference: "/type",
+			Message:   r.unsupportedTypeMessage(spec.Type),
+		})
+		return prefixSpecReferences(results)
+	}
+
+	versions, err := r.registry.Versions(spec.Type)
+	if err != nil {
+		results = append(results, vrules.ValidationResult{Reference: "/type", Message: err.Error()})
+		return prefixSpecReferences(results)
+	}
+	if !slices.Contains(versions, spec.DefinitionVersion) {
+		results = append(results, vrules.ValidationResult{
+			Reference: "/definition_version",
+			Message: fmt.Sprintf(
+				"definition_version %d is not valid for destination type '%s'; valid versions: %s",
+				spec.DefinitionVersion, spec.Type, joinInt64(versions),
+			),
+		})
+		return prefixSpecReferences(results)
+	}
+
+	if spec.Transformation != "" && !transformationRefRegex.MatchString(spec.Transformation) {
+		results = append(results, vrules.ValidationResult{
+			Reference: "/transformation",
+			Message:   "'transformation' is invalid: must be of pattern #transformation:<id>",
+		})
+	}
+
+	def, err := r.registry.Get(spec.Type, spec.DefinitionVersion)
+	if err != nil {
+		results = append(results, vrules.ValidationResult{Reference: "/definition_version", Message: err.Error()})
+		return prefixSpecReferences(results)
+	}
+
+	for _, configErr := range def.ValidateConfig(spec.Config) {
+		results = append(results, vrules.ValidationResult{
+			Reference: "/config" + configErr.Path,
+			Message:   configErr.Message,
+		})
+	}
+
+	results = append(results, sourceTypeKeyResults(def, spec)...)
+	return prefixSpecReferences(results)
+}
+
+func (r *specSyntaxValidRule) unsupportedTypeMessage(destType string) string {
+	supported := r.registry.SupportedTypes()
+	if len(supported) == 0 {
+		return fmt.Sprintf("destination type '%s' is not supported; no destination types are currently supported", destType)
+	}
+	return fmt.Sprintf("destination type '%s' is not supported; supported types: %s", destType, strings.Join(supported, ", "))
+}
+
+// sourceTypeKeyResults flags platform keys under source-type-scoped config
+// blocks (connection_mode, use_native_sdk, consent_management) that the
+// definition does not support — invalid regardless of project connections.
+func sourceTypeKeyResults(def *definitions.RegisteredDefinition, spec *DestinationSpec) []vrules.ValidationResult {
+	localKeys := def.LocalSourceTypeKeys()
+
+	var results []vrules.ValidationResult
+	for _, configKey := range def.SourceTypeConfigKeys() {
+		// Non-map shapes are owned by the config model validation.
+		block, ok := spec.Config[configKey].(map[string]any)
+		if !ok {
+			continue
+		}
+
+		for _, sourceType := range slices.Sorted(maps.Keys(block)) {
+			if slices.Contains(localKeys, sourceType) {
+				continue
+			}
+			results = append(results, vrules.ValidationResult{
+				Reference: fmt.Sprintf("/config/%s/%s", configKey, sourceType),
+				Message: fmt.Sprintf(
+					"source type '%s' is not supported by destination type '%s'; supported source types: %s",
+					sourceType, spec.Type, strings.Join(localKeys, ", "),
+				),
+			})
+		}
+	}
+	return results
+}
+
+// decodeDestinationSpec decodes the raw spec map with the same mapstructure
+// semantics the apply cycle uses, collecting all unknown envelope keys in one
+// pass instead of failing on the first.
+func decodeDestinationSpec(raw map[string]any) (*DestinationSpec, []string, error) {
+	var (
+		spec DestinationSpec
+		md   mapstructure.Metadata
+	)
+
+	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		Result:   &spec,
+		Metadata: &md,
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("creating spec decoder: %w", err)
+	}
+	if err := decoder.Decode(raw); err != nil {
+		return nil, nil, fmt.Errorf("decoding spec: %w", err)
+	}
+
+	unknown := make([]string, 0, len(md.Unused))
+	for _, key := range md.Unused {
+		// Nested unused paths (dotted) belong to config model validation.
+		if strings.Contains(key, ".") {
+			continue
+		}
+		unknown = append(unknown, key)
+	}
+	sort.Strings(unknown)
+
+	return &spec, unknown, nil
+}
+
+func prefixSpecReferences(results []vrules.ValidationResult) []vrules.ValidationResult {
+	for i := range results {
+		results[i].Reference = "/spec" + results[i].Reference
+	}
+	return results
+}
+
+func joinInt64(values []int64) string {
+	parts := make([]string, 0, len(values))
+	for _, v := range values {
+		parts = append(parts, fmt.Sprintf("%d", v))
+	}
+	return strings.Join(parts, ", ")
+}

--- a/cli/internal/providers/destination/rule_spec_syntax_valid_test.go
+++ b/cli/internal/providers/destination/rule_spec_syntax_valid_test.go
@@ -1,6 +1,7 @@
 package destination
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -125,6 +126,101 @@ func TestSpecSyntaxValidRuleRequiredFields(t *testing.T) {
 		{Reference: "/spec/type", Message: "'type' is required"},
 		{Reference: "/spec/definition_version", Message: "'definition_version' is required"},
 	}, results)
+}
+
+func TestSpecSyntaxValidRuleDisplayNamePattern(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		value    string
+		expected []vrules.ValidationResult
+	}{
+		{
+			name:  "valid display name",
+			value: "Production Webhook",
+		},
+		{
+			name:  "too short",
+			value: "a",
+			expected: []vrules.ValidationResult{{
+				Reference: "/spec/display_name",
+				Message:   "'display_name' is not valid: must be 2-100 characters and contain only letters, digits, underscores, spaces, periods, and hyphens",
+			}},
+		},
+		{
+			name:  "invalid character",
+			value: "Webhook@Prod",
+			expected: []vrules.ValidationResult{{
+				Reference: "/spec/display_name",
+				Message:   "'display_name' is not valid: must be 2-100 characters and contain only letters, digits, underscores, spaces, periods, and hyphens",
+			}},
+		},
+		{
+			name:  "too long",
+			value: strings.Repeat("a", 101),
+			expected: []vrules.ValidationResult{{
+				Reference: "/spec/display_name",
+				Message:   "'display_name' is not valid: must be 2-100 characters and contain only letters, digits, underscores, spaces, periods, and hyphens",
+			}},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+
+			spec := validSpecMap()
+			spec["display_name"] = c.value
+
+			results := runSyntaxRule(t, ruleTestRegistry(t), spec)
+			if c.expected == nil {
+				assert.Empty(t, results)
+				return
+			}
+			assert.Equal(t, c.expected, results)
+		})
+	}
+}
+
+func TestSpecSyntaxValidRuleConfigDynamicValues(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		config map[string]any
+	}{
+		{
+			name: "allows env reference",
+			config: map[string]any{
+				"webhook_url": "env.WEBHOOK_URL",
+			},
+		},
+		{
+			name: "allows ui template fallback",
+			config: map[string]any{
+				"webhook_url": "{{ config.url || https://example.com/hook }}",
+			},
+		},
+		{
+			name: "allows iac variable substitution",
+			config: map[string]any{
+				"webhook_url": "{{ .WEBHOOK_URL }}",
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+
+			spec := validSpecMap()
+			spec["config"] = c.config
+
+			results := runSyntaxRule(t, ruleTestRegistry(t), spec)
+			assert.Empty(t, results)
+		})
+	}
 }
 
 func TestSpecSyntaxValidRuleUnregisteredType(t *testing.T) {

--- a/cli/internal/providers/destination/rule_spec_syntax_valid_test.go
+++ b/cli/internal/providers/destination/rule_spec_syntax_valid_test.go
@@ -1,0 +1,300 @@
+package destination
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	prules "github.com/rudderlabs/rudder-iac/cli/internal/provider/rules"
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions"
+	vrules "github.com/rudderlabs/rudder-iac/cli/internal/validation/rules"
+)
+
+// ruleTestConfig types source-type-scoped blocks as open maps so the config
+// model accepts arbitrary platform keys — the source-type key check is then
+// the only guard, which is exactly what these tests exercise.
+type ruleTestConfig struct {
+	WebhookURL        string            `mapstructure:"webhook_url" validate:"required"`
+	ConnectionMode    map[string]string `mapstructure:"connection_mode"`
+	UseNativeSDK      map[string]bool   `mapstructure:"use_native_sdk"`
+	ConsentManagement map[string]any    `mapstructure:"consent_management"`
+}
+
+func ruleTestRegistry(t *testing.T) *definitions.Registry {
+	t.Helper()
+
+	registry := definitions.NewRegistry()
+	require.NoError(t, registry.Register(&definitions.DestinationDefinition{
+		Type:    "WEBHOOK",
+		Version: 1,
+		NewConfig: func() any {
+			return &ruleTestConfig{}
+		},
+		SourceTypes: []string{"web", "reactNative"},
+		ConnectionModes: map[string][]string{
+			"web":         {"cloud"},
+			"reactNative": {"cloud"},
+		},
+	}))
+	return registry
+}
+
+func validSpecMap() map[string]any {
+	return map[string]any{
+		"id":                 "webhook-prod",
+		"display_name":       "Production Webhook",
+		"type":               "WEBHOOK",
+		"enabled":            true,
+		"definition_version": 1,
+		"config": map[string]any{
+			"webhook_url": "https://example.com/hook",
+		},
+	}
+}
+
+func runSyntaxRule(t *testing.T, registry *definitions.Registry, spec map[string]any) []vrules.ValidationResult {
+	t.Helper()
+
+	rule := NewSpecSyntaxValidRule(registry)
+	return rule.Validate(&vrules.ValidationContext{
+		Spec:    spec,
+		Kind:    DestinationSpecKind,
+		Version: "rudder/v1",
+	})
+}
+
+func TestSpecSyntaxValidRuleMetadata(t *testing.T) {
+	t.Parallel()
+
+	rule := NewSpecSyntaxValidRule(ruleTestRegistry(t))
+	assert.Equal(t, SpecSyntaxValidRuleID, rule.ID())
+	assert.Equal(t, vrules.Error, rule.Severity())
+	assert.NotEmpty(t, rule.Description())
+	assert.Equal(t, prules.V1VersionPatterns(DestinationSpecKind), rule.AppliesTo())
+}
+
+func TestSpecSyntaxValidRuleDecodeFailure(t *testing.T) {
+	t.Parallel()
+
+	spec := validSpecMap()
+	spec["definition_version"] = "abc"
+
+	results := runSyntaxRule(t, ruleTestRegistry(t), spec)
+	require.Len(t, results, 1)
+	assert.Equal(t, "/spec", results[0].Reference)
+	assert.Contains(t, results[0].Message, "definition_version")
+}
+
+func TestSpecSyntaxValidRuleUnknownEnvelopeKeys(t *testing.T) {
+	t.Parallel()
+
+	spec := validSpecMap()
+	spec["foo"] = "x"
+	spec["bar"] = "y"
+
+	results := runSyntaxRule(t, ruleTestRegistry(t), spec)
+	assert.Equal(t, []vrules.ValidationResult{
+		{Reference: "/spec/bar", Message: `unknown field "bar"`},
+		{Reference: "/spec/foo", Message: `unknown field "foo"`},
+	}, results)
+}
+
+func TestSpecSyntaxValidRuleEnvelopeErrorsShortCircuitRegistryChecks(t *testing.T) {
+	t.Parallel()
+
+	spec := validSpecMap()
+	delete(spec, "id")
+	spec["type"] = "UNREGISTERED"
+	spec["extra"] = true
+
+	results := runSyntaxRule(t, ruleTestRegistry(t), spec)
+	assert.Equal(t, []vrules.ValidationResult{
+		{Reference: "/spec/extra", Message: `unknown field "extra"`},
+		{Reference: "/spec/id", Message: "'id' is required"},
+	}, results)
+}
+
+func TestSpecSyntaxValidRuleRequiredFields(t *testing.T) {
+	t.Parallel()
+
+	results := runSyntaxRule(t, ruleTestRegistry(t), map[string]any{})
+	assert.Equal(t, []vrules.ValidationResult{
+		{Reference: "/spec/id", Message: "'id' is required"},
+		{Reference: "/spec/display_name", Message: "'display_name' is required"},
+		{Reference: "/spec/type", Message: "'type' is required"},
+		{Reference: "/spec/definition_version", Message: "'definition_version' is required"},
+	}, results)
+}
+
+func TestSpecSyntaxValidRuleUnregisteredType(t *testing.T) {
+	t.Parallel()
+
+	spec := validSpecMap()
+	spec["type"] = "NOPE"
+
+	results := runSyntaxRule(t, ruleTestRegistry(t), spec)
+	assert.Equal(t, []vrules.ValidationResult{
+		{
+			Reference: "/spec/type",
+			Message:   "destination type 'NOPE' is not supported; supported types: WEBHOOK",
+		},
+	}, results)
+}
+
+func TestSpecSyntaxValidRuleEmptyRegistry(t *testing.T) {
+	t.Parallel()
+
+	results := runSyntaxRule(t, definitions.NewRegistry(), validSpecMap())
+	assert.Equal(t, []vrules.ValidationResult{
+		{
+			Reference: "/spec/type",
+			Message:   "destination type 'WEBHOOK' is not supported; no destination types are currently supported",
+		},
+	}, results)
+}
+
+func TestSpecSyntaxValidRuleInvalidVersion(t *testing.T) {
+	t.Parallel()
+
+	spec := validSpecMap()
+	spec["definition_version"] = 2
+
+	results := runSyntaxRule(t, ruleTestRegistry(t), spec)
+	assert.Equal(t, []vrules.ValidationResult{
+		{
+			Reference: "/spec/definition_version",
+			Message:   "definition_version 2 is not valid for destination type 'WEBHOOK'; valid versions: 1",
+		},
+	}, results)
+}
+
+func TestSpecSyntaxValidRuleTransformationRefFormat(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		ref     string
+		invalid bool
+	}{
+		{name: "valid ref", ref: "#transformation:my-id"},
+		{name: "missing hash", ref: "transformation:my-id", invalid: true},
+		{name: "wrong kind", ref: "#tp:my-id", invalid: true},
+		{name: "empty id", ref: "#transformation:", invalid: true},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+
+			spec := validSpecMap()
+			spec["transformation"] = c.ref
+
+			results := runSyntaxRule(t, ruleTestRegistry(t), spec)
+			if !c.invalid {
+				assert.Empty(t, results)
+				return
+			}
+			assert.Equal(t, []vrules.ValidationResult{
+				{
+					Reference: "/spec/transformation",
+					Message:   "'transformation' is invalid: must be of pattern #transformation:<id>",
+				},
+			}, results)
+		})
+	}
+}
+
+func TestSpecSyntaxValidRuleConfigErrors(t *testing.T) {
+	t.Parallel()
+
+	spec := validSpecMap()
+	spec["config"] = map[string]any{"extra": 1}
+
+	results := runSyntaxRule(t, ruleTestRegistry(t), spec)
+	assert.Equal(t, []vrules.ValidationResult{
+		{Reference: "/spec/config/extra", Message: `unknown config field "extra"`},
+		{Reference: "/spec/config/webhook_url", Message: "'webhook_url' is required"},
+	}, results)
+}
+
+func TestSpecSyntaxValidRuleSourceTypeKeys(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		config   map[string]any
+		expected []vrules.ValidationResult
+	}{
+		{
+			name: "unsupported source type under connection_mode",
+			config: map[string]any{
+				"webhook_url":     "https://example.com/hook",
+				"connection_mode": map[string]any{"ios": "cloud"},
+			},
+			expected: []vrules.ValidationResult{
+				{
+					Reference: "/spec/config/connection_mode/ios",
+					Message:   "source type 'ios' is not supported by destination type 'WEBHOOK'; supported source types: web, react_native",
+				},
+			},
+		},
+		{
+			name: "unsupported source type under use_native_sdk",
+			config: map[string]any{
+				"webhook_url":    "https://example.com/hook",
+				"use_native_sdk": map[string]any{"ios": true},
+			},
+			expected: []vrules.ValidationResult{
+				{
+					Reference: "/spec/config/use_native_sdk/ios",
+					Message:   "source type 'ios' is not supported by destination type 'WEBHOOK'; supported source types: web, react_native",
+				},
+			},
+		},
+		{
+			name: "supported snake_case source types pass",
+			config: map[string]any{
+				"webhook_url":     "https://example.com/hook",
+				"connection_mode": map[string]any{"web": "cloud", "react_native": "cloud"},
+				"use_native_sdk":  map[string]any{"react_native": true},
+			},
+			expected: []vrules.ValidationResult{},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+
+			spec := validSpecMap()
+			spec["config"] = c.config
+
+			results := runSyntaxRule(t, ruleTestRegistry(t), spec)
+			assert.Equal(t, c.expected, results)
+		})
+	}
+}
+
+func TestSpecSyntaxValidRuleScalarSourceTypeBlock(t *testing.T) {
+	t.Parallel()
+
+	spec := validSpecMap()
+	spec["config"] = map[string]any{
+		"webhook_url":     "https://example.com/hook",
+		"connection_mode": "cloud",
+	}
+
+	results := runSyntaxRule(t, ruleTestRegistry(t), spec)
+	// The config model owns the shape error; the source-type key check must
+	// skip the scalar without panicking or piling on.
+	require.Len(t, results, 1)
+	assert.Equal(t, "/spec/config", results[0].Reference)
+}
+
+func TestSpecSyntaxValidRuleValidSpec(t *testing.T) {
+	t.Parallel()
+
+	results := runSyntaxRule(t, ruleTestRegistry(t), validSpecMap())
+	assert.Empty(t, results)
+}


### PR DESCRIPTION
## 🔗 Ticket

Resolves [RUD-2853](https://linear.app/rudderstack/issue/RUD-2853/destination-validations)

---

## Summary

Adds syntactic and semantic validation rules for the `destination` resource kind, filling the rule hooks stubbed in #655. The syntactic rule validates the spec envelope (required fields, unknown keys), that the `(type, definition_version)` pair is registered, the transformation ref format, and the per-type config via the definition registry's struct-based `ValidateConfig`. The semantic rule validates that the referenced transformation exists in the resource graph and that `display_name` is unique across destinations. Scope refined from the original ticket: connection provider and connection-aware checks (source-type compatibility, dead config, completeness) are split to a follow-up ticket.

---

## Changes

- `destination/spec-syntax-valid` rule: envelope decode with all unknown envelope keys reported in one pass (`mapstructure.Metadata`), required-field struct validation, hard error on unregistered type/version with supported types/versions listed, `#transformation:<id>` format check, registry `ValidateConfig` mapping `ConfigError`s to `/spec/config/...` paths, and source-type key check (`connection_mode` / `use_native_sdk` / `consent_management` platform keys must be supported by the definition)
- `destination/semantic-valid` rule: transformation exists in resource graph, `display_name` uniqueness via `RawData()`
- `RegisteredDefinition.LocalSourceTypeKeys()` + exported `common.LocalSourceTypeKey` (camelCase → snake_case source type keys)
- `validate:"required"` tags on `DestinationSpec` (id, display_name, type, definition_version)
- Provider wiring for `SyntacticRules()` / `SemanticRules()` / `RuleDocEntries()` with embedded `*.docs.yaml` fragments for both rules
- Note: rules live in the `destination` package root rather than a `rules/` subpackage — the provider package hosts the spec model, so a subpackage would create an import cycle

---

## Testing

- Unit tests: full-slice `ValidationResult` assertions covering every syntactic step incl. early-return behavior, semantic graph cases (missing transformation, duplicate/unique display_name, foreign `RawData` skipped), provider wiring, and `LocalSourceTypeKeys`
- `make lint` (0 issues), `make test` (all packages pass), `make gen-rule-docs` (both rules join the generated catalog)
- Manual: built the CLI and ran `validate` against a sample destination spec — diagnostics land on exact YAML lines with correct rule IDs

---

## Risk / Impact

Low
Notes: validation-only change; no apply-cycle CRUD behavior touched. Until production definitions are registered, destination specs fail validation with "no destination types are currently supported" — intended gating per refinement decision.

---

## Checklist

- [x] Ticket linked
- [x] Tests added/updated
- [x] No breaking changes (or documented)

🤖 Generated with [Claude Code](https://claude.com/claude-code)