### PR TITLE
fix(typer): skip unregistered kinds when loading local specs

### DIFF
--- a/cli/internal/project/ignoreunknownkinds_test.go
+++ b/cli/internal/project/ignoreunknownkinds_test.go
@@ -1,0 +1,75 @@
+package project_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/rudderlabs/rudder-iac/cli/internal/project"
+	"github.com/rudderlabs/rudder-iac/cli/internal/project/specs"
+	"github.com/rudderlabs/rudder-iac/cli/internal/testutils"
+	"github.com/rudderlabs/rudder-iac/cli/internal/validation/renderer"
+	"github.com/rudderlabs/rudder-iac/cli/internal/validation/rules"
+)
+
+// A consumer registering only the Source provider still has to cope with
+// projects whose directories hold specs owned by other providers (rudder-data-gov
+// keeps data-graphs and transformations next to its data catalog). Callers that
+// only read a subset of the project opt into skipping those via
+// WithIgnoreUnknownKinds instead of failing the whole load.
+func TestProject_Load_UnownedKind(t *testing.T) {
+	t.Parallel()
+
+	const (
+		sourceYAML    = "kind: Source\nversion: rudder/v1\nmetadata:\n  name: my_source\nspec:\n  k: v"
+		dataGraphYAML = "kind: data-graph\nversion: rudder/v1\nmetadata:\n  name: my_graph\nspec:\n  k: v"
+	)
+
+	newProject := func(opts ...project.ProjectOption) project.Project {
+		mockProvider := testutils.NewMockProvider(nil, nil)
+		mockProvider.MatchPatterns = []rules.MatchPattern{
+			rules.MatchKindVersion("Source", specs.SpecVersionV1),
+		}
+		mockLoader := &MockLoader{LoadFunc: func(string) (map[string]*specs.RawSpec, error) {
+			return map[string]*specs.RawSpec{
+				"source.yaml":     {Data: []byte(sourceYAML)},
+				"data-graph.yaml": {Data: []byte(dataGraphYAML)},
+			}, nil
+		}}
+
+		opts = append([]project.ProjectOption{
+			project.WithLoader(mockLoader),
+			project.WithRenderer(renderer.NewTextRenderer(&bytes.Buffer{})),
+		}, opts...)
+
+		return project.New(mockProvider, opts...)
+	}
+
+	t.Run("fails syntax validation by default", func(t *testing.T) {
+		t.Parallel()
+
+		err := newProject().Load("test_dir")
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "syntax validation failed")
+	})
+
+	t.Run("is skipped with WithIgnoreUnknownKinds, and owned kinds still load", func(t *testing.T) {
+		t.Parallel()
+
+		proj := newProject(project.WithIgnoreUnknownKinds())
+
+		require.NoError(t, proj.Load("test_dir"))
+		assert.Equal(t, []string{"source.yaml"}, specPaths(proj))
+	})
+}
+
+func specPaths(p project.Project) []string {
+	paths := make([]string, 0, len(p.Specs()))
+	for path := range p.Specs() {
+		paths = append(paths, path)
+	}
+	return paths
+}

--- a/cli/internal/project/project.go
+++ b/cli/internal/project/project.go
@@ -59,6 +59,7 @@ type project struct {
 	validationEngine       validation.ValidationEngine
 	renderer               renderer.Renderer
 	substitutor            varsubst.Substitutor
+	ignoreUnknownKinds     bool
 }
 
 // ProjectOption defines a functional option for configuring a Project.
@@ -89,6 +90,20 @@ func WithRenderer(r renderer.Renderer) ProjectOption {
 func WithSubstitutor(s varsubst.Substitutor) ProjectOption {
 	return func(p *project) {
 		p.substitutor = s
+	}
+}
+
+// WithIgnoreUnknownKinds makes Load skip specs whose kind no registered provider
+// owns, instead of failing syntax validation on them.
+//
+// Only for read-only consumers that need a subset of the project: the local
+// typer reads the data catalog and tracking plan, but a project directory may
+// also hold specs owned by providers it does not register (data-graphs,
+// transformations), which are irrelevant to code generation. The apply path must
+// never set this — silently ignoring a spec there would mean not applying it.
+func WithIgnoreUnknownKinds() ProjectOption {
+	return func(p *project) {
+		p.ignoreUnknownKinds = true
 	}
 }
 
@@ -332,6 +347,14 @@ func (p *project) parseSpecs(raw map[string]*specs.RawSpec) (map[string]*specs.R
 			continue
 		}
 
+		// Dropped before validation so the gatekeeper rules never see the spec at
+		// all: the kind belongs to a provider this caller did not register, so
+		// every rule keyed off it would be a false error.
+		if p.ignoreUnknownKinds && !p.isKnownKind(parsed.Kind) {
+			log.Debug("skipping spec of unregistered kind", "path", path, "kind", parsed.Kind)
+			continue
+		}
+
 		// At this point, we have a valid parsed spec which
 		// we need to add to the specs map on the project required by migrate command.
 		p.specs[path] = parsed
@@ -340,6 +363,23 @@ func (p *project) parseSpecs(raw map[string]*specs.RawSpec) (map[string]*specs.R
 
 	diags.Sort()
 	return parsedRawSpecs, diags
+}
+
+// isKnownKind reports whether any registered provider owns the kind. The pattern
+// union mirrors BuildRegistry's activePatterns, so a kind is skipped only when
+// the gatekeeper rules would have rejected it as unknown.
+func (p *project) isKnownKind(kind string) bool {
+	providers := []ProjectProvider{p.provider, p.importManifestProvider}
+
+	for _, prov := range providers {
+		for _, pattern := range prov.SupportedMatchPatterns() {
+			if pattern.Kind == "*" || pattern.Kind == kind {
+				return true
+			}
+		}
+	}
+
+	return false
 }
 
 func (p *project) registry() (rules.Registry, error) {

--- a/cli/internal/typer/plan/providers/local.go
+++ b/cli/internal/typer/plan/providers/local.go
@@ -33,9 +33,14 @@ func NewLocalCatalogPlanProvider(dc *localcatalog.DataCatalog, trackingPlanID st
 // NewLocalCatalogPlanProviderForProject loads and validates the project at
 // location offline (no auth or network) and returns a provider for its tracking
 // plan. trackingPlanID is optional when the project has exactly one plan.
+//
+// Only the data catalog provider is registered, since that is all code
+// generation reads. A project directory may still hold specs owned by other
+// providers (data-graphs, transformations), so unknown kinds are skipped rather
+// than failing the load.
 func NewLocalCatalogPlanProviderForProject(location, trackingPlanID string) (*LocalCatalogPlanProvider, error) {
 	dcProvider := datacatalog.New(nil)
-	proj := project.New(dcProvider)
+	proj := project.New(dcProvider, project.WithIgnoreUnknownKinds())
 	if err := proj.Load(location); err != nil {
 		return nil, fmt.Errorf("loading and validating project: %w", err)
 	}

--- a/cli/internal/typer/plan/providers/local_test.go
+++ b/cli/internal/typer/plan/providers/local_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"os"
+	"path/filepath"
 	"sort"
 	"testing"
 
@@ -181,6 +182,30 @@ func TestLocalCatalogPlanProvider_Variants(t *testing.T) {
 	}
 
 	assert.Equal(t, want, got.Rules[0].Variants)
+}
+
+// A project directory is not necessarily catalog-only: rudder-data-gov keeps
+// data-graphs and transformations alongside the catalog the typer reads. Those
+// kinds belong to providers the local typer does not register, and they are
+// irrelevant to code generation, so loading must skip them rather than fail.
+func TestNewLocalCatalogPlanProviderForProject_IgnoresNonCatalogSpecs(t *testing.T) {
+	location := t.TempDir()
+	require.NoError(t, os.CopyFS(location, os.DirFS("../testdata/project")))
+
+	dataGraph := []byte(`version: "rudder/v1"
+kind: "data-graph"
+metadata:
+  name: "some-data-graph"
+spec:
+  id: "some-data-graph"
+  nodes: []
+`)
+	require.NoError(t, os.WriteFile(filepath.Join(location, "data-graph.yaml"), dataGraph, 0o644))
+
+	provider, err := providers.NewLocalCatalogPlanProviderForProject(location, "typer-test-tracking-plan")
+
+	require.NoError(t, err)
+	assert.NotNil(t, provider)
 }
 
 func TestLocalCatalogPlanProvider_TrackingPlanNotFound(t *testing.T) {


### PR DESCRIPTION
## 🔗 Ticket

Follow-up to [DEX-450](https://linear.app/rudderstack/issue/DEX-450/generate-data-gov-types-via-rudder-cli-without-control-plane) (`--local`, #628). Happy to file a dedicated ticket if preferred.

---

## Summary

`typer generate --local` cannot load the repo it was built for. It registers only the data catalog provider, and the set of legal `kind:` values is derived from the registered providers (`BuildRegistry` → `SupportedMatchPatterns()` → the `project/spec-syntax-valid` gatekeeper). So **any project that also holds specs owned by other providers fails syntax validation before generation starts** — even though those specs are irrelevant to code generation. `apply` is unaffected because it constructs the full provider set.

`rudder-data-gov` — the repo DEX-450 targets ("Generate data-gov types via rudder-cli without control-plane dependency") — keeps `data-graphs/` and `transformations/` next to its catalog, so `--local` fails outright against it:

```
error[project/spec-syntax-valid]: 'kind' must be one of [properties events categories custom-types tp tracking-plan import-manifest]
  --> data-graphs/webapp.yaml:2:1                          | kind: data-graph
  --> transformations/webapp-identify-back-compat.yaml:2:1 | kind: transformation
```

No `--location` scoping avoids it: the tracking plan needs the catalog loaded alongside it (pointing at `tracking-plans/webapp.yaml` alone → `expanding event refs ... looking up event: identify failed`), the catalog alone has no tracking plan (`tracking plan "webapp" not found in local specs`), and the two only coexist at the repo root — which is where the rejected kinds live.

---

## Changes

- Add `project.WithIgnoreUnknownKinds()`: specs whose kind no registered provider owns are dropped in `parseSpecs` (before validation, so the gatekeeper rules never see them) instead of failing the load. The known-kind set mirrors `BuildRegistry`'s `activePatterns` union exactly, so a spec is skipped only where it would otherwise have been rejected as unknown.
- Use it from `NewLocalCatalogPlanProviderForProject` — the only caller. The apply path is untouched and must never set it: silently ignoring a spec there would mean not applying it.

Rejected alternative: registering every provider with nil API clients in the local path. It mirrors `apply`, but relies on every provider constructor tolerating a nil client through load/validate — a much broader surface to trust for an offline path.

---

## Testing

- **Unit** (`project`): a provider owning only `Source` + a project containing a `data-graph` spec — fails `syntax validation failed` by default (characterizes today's behavior), and with the option the foreign spec is skipped while `Source` still loads.
- **Unit** (`typer/plan/providers`): `NewLocalCatalogPlanProviderForProject` against a project directory that holds a non-catalog spec. Reproduced the exact production error before the fix.
- **Manual**: built the CLI and ran `typer generate --local --location <rudder-data-gov> --tracking-plan-id webapp --platform typescript` against the real repo root — fails on `main`, succeeds here, and the generated TypeScript is byte-identical (modulo the version banner) to generating from a catalog-only copy of the same specs, confirming the skipped kinds change nothing about the output.
- `make lint` clean (0 issues); `make test` green. Note `cli/pkg/exp/project` `TestProjectLoad` fails on unmodified `origin/main` too — pre-existing, unrelated to this change.

---

## Risk / Impact

Low. Opt-in behind a new option with a single caller on the experimental `--local` path; default behavior (including `apply`) is unchanged.

---

## Checklist

- [x] Ticket linked
- [x] Tests added/updated
- [x] No breaking changes (or documented)

---

## Note for the 0.20.0 cut

This is worth including in the release: without it, `--local` ships but cannot read `rudder-data-gov`, which is the use case it was written for.

Separately (not fixed here): `--local` is gated behind **two** flags — `RUDDERSTACK_CLI_EXPERIMENTAL=true` **and** `RUDDERSTACK_X_LOCAL_TYPER=true` — but the error message only mentions the second, so the first failure looks like the flag is broken. Happy to fold in a one-line message fix if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)