### PR TITLE
test(typer): verify --local against latest rudder-data-gov in CI

### DIFF
--- a/.github/workflows/typer-datagov-verify.yml
+++ b/.github/workflows/typer-datagov-verify.yml
@@ -1,0 +1,75 @@
+name: typer data-gov verify
+
+# Non-blocking signal: on every rudder-iac change, verify that `typer generate
+# --local` still works against the LATEST rudder-data-gov — a real repo that keeps
+# data-graphs/ and transformations/ next to its catalog, exercising the
+# skip-unknown-kinds path. Not pinned: rudder-data-gov's own changes are covered in
+# its own repo; here we only care that current rudder-iac handles current data-gov.
+# Do NOT add this to required status checks — a cross-repo hiccup must not block PRs.
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "cli/**"
+      - "Makefile"
+      - "go.mod"
+      - ".github/workflows/typer-datagov-verify.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "cli/**"
+      - "Makefile"
+      - "go.mod"
+      - ".github/workflows/typer-datagov-verify.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  typer-datagov-verify:
+    name: verify --local typer against latest rudder-data-gov
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout rudder-iac
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Go
+        uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+        with:
+          go-version-file: 'go.mod'
+          cache: false
+
+      # GITHUB_TOKEN can't reach another repo; mint a short-lived token from the
+      # org GitHub App scoped to rudder-data-gov (same app as publish-rules-to-hugo).
+      # Requires RELEASE_APP_ID to be installed on rudderlabs/rudder-data-gov.
+      - name: Generate rudder-data-gov token
+        id: datagov-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PRIVATE_KEY }}
+          owner: rudderlabs
+          repositories: rudder-data-gov
+
+      - name: Checkout latest rudderlabs/rudder-data-gov
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: rudderlabs/rudder-data-gov
+          token: ${{ steps.datagov-token.outputs.token }}
+          path: rudder-data-gov
+          persist-credentials: false
+
+      - name: Generate --local and typecheck against the JS SDK
+        run: make typer-verify-datagov DATAGOV_DIR=rudder-data-gov

--- a/Makefile
+++ b/Makefile
@@ -94,3 +94,25 @@ typer-typescript-validate: ## Validate generated TypeScript code against the Rud
 	cp cli/internal/typer/generator/platforms/typescript/testdata/RudderTyper.ts \
 	   cli/internal/typer/generator/platforms/typescript/testdata/validator/src/RudderTyper/RudderTyper.ts
 	cd cli/internal/typer/generator/platforms/typescript/testdata/validator && docker compose run --rm -T validator
+
+# Directory of a rudder-data-gov checkout to verify `typer generate --local` against.
+# It intentionally holds data-graphs/ and transformations/ next to its catalog —
+# kinds the local typer does not register — so this exercises the skip-unknown-kinds path.
+DATAGOV_DIR ?=
+DATAGOV_TRACKING_PLAN ?= webapp
+TS_VALIDATOR_DIR = cli/internal/typer/generator/platforms/typescript/testdata/validator
+
+.PHONY: typer-verify-datagov
+typer-verify-datagov: build ## Generate a typed TS client from a rudder-data-gov checkout via --local and typecheck it against the JS SDK (set DATAGOV_DIR)
+	@test -n "$(DATAGOV_DIR)" || { echo "DATAGOV_DIR is required, e.g. make typer-verify-datagov DATAGOV_DIR=../rudder-data-gov"; exit 1; }
+	mkdir -p $(TS_VALIDATOR_DIR)/src/RudderTyper
+	RUDDERSTACK_CLI_EXPERIMENTAL=true RUDDERSTACK_X_LOCAL_TYPER=true \
+	  bin/rudder-cli typer generate --local \
+	    --location $(DATAGOV_DIR) \
+	    --tracking-plan-id $(DATAGOV_TRACKING_PLAN) \
+	    --platform typescript \
+	    -o $(TS_VALIDATOR_DIR)/src/RudderTyper
+	# typecheck the generated file only (tsconfig.gen-only) — the reference-plan
+	# vitest suite is written against a different plan and would not compile here.
+	cd $(TS_VALIDATOR_DIR) && docker compose run --rm -T validator \
+	  sh -c "npm ci && npx tsc -p tsconfig.gen-only.json"

--- a/cli/internal/typer/generator/platforms/typescript/testdata/validator/tsconfig.gen-only.json
+++ b/cli/internal/typer/generator/platforms/typescript/testdata/validator/tsconfig.gen-only.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.json",
+  "//": "Type-checks the generated RudderTyper.ts alone against the SDK, without the reference-plan __tests__. Used to validate --local output from an arbitrary project (e.g. rudder-data-gov), whose plan differs from the reference the vitest suite is written against.",
+  "include": ["src/RudderTyper/**/*.ts"]
+}


### PR DESCRIPTION
## 🔗 Ticket

Follow-up to [DEX-450](https://linear.app/rudderstack/issue/DEX-450/generate-data-gov-types-via-rudder-cli-without-control-plane) / #671. Draft — **stacked on #671**, base retargets to `main` when #671 lands.

---

## Summary

Adds a **non-blocking** CI check that runs `typer generate --local` against the **latest** `rudderlabs/rudder-data-gov` and typechecks the generated TypeScript against `@rudderstack/analytics-js`. rudder-data-gov keeps `data-graphs/` and `transformations/` next to its catalog, so this is a real-world exercise of the skip-unknown-kinds path added in #671 — without #671 the same run fails syntax validation on those foreign kinds.

Verified locally against the real repo: generates a ~128 KB `RudderTyper.ts` (exit 0) and `tsc --noEmit` passes clean against the SDK; the identical command on a binary without #671 fails on `data-graph` + `transformation`.

---

## Changes

- `make typer-verify-datagov DATAGOV_DIR=<path>` — build, `--local` generate, then typecheck the generated file only.
- `tsconfig.gen-only.json` — typechecks `src/RudderTyper/**` against the SDK, **excluding** the reference-plan `__tests__` (they're written for a different plan and would not compile against arbitrary `--local` output — this is the one gotcha the real-repo run surfaced; the full `typer-typescript-validate` harness is plan-coupled and can't be reused wholesale).
- `.github/workflows/typer-datagov-verify.yml` — clones data-gov via the org GitHub App (same app as `publish-rules-to-hugo`), **not pinned** (always latest), triggers on rudder-iac changes only.

## Design notes (decided upstream)

- **Latest, not pinned:** rudder-data-gov's own changes are covered in its own repo; here we only assert current rudder-iac works against current data-gov. Safe from flakiness because the assertion is "generated file typechecks", not a golden diff.
- **Non-blocking:** must NOT be added to required status checks — a cross-repo hiccup should never block a rudder-iac PR.

## ⚠️ Open dependency before this can go green

`RELEASE_APP_ID` (the org GitHub App used by `publish-rules-to-hugo`) must be installed on `rudderlabs/rudder-data-gov` so the token step can clone it. One request on **#ask-infra**. Until then the workflow will fail at the token step — acceptable while draft/non-blocking, but confirm before un-drafting.

---

## Testing

- Manual: `make typer-verify-datagov DATAGOV_DIR=../rudder-data-gov` → exit 0, generated file typechecks. Baseline (no #671) fails as expected.

## Risk / Impact

Low. Adds a Make target + a non-blocking workflow + one tsconfig; no product code changes, `apply` untouched.

## Checklist

- [x] Ticket linked
- [x] Tested locally
- [ ] `RELEASE_APP_ID` scoped to rudder-data-gov (blocks green CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)