### PR TITLE
fix(typer): make isKnownKind flag-aware to mirror import-merge gating

### DIFF
--- a/cli/internal/project/ignoreunknownkinds_test.go
+++ b/cli/internal/project/ignoreunknownkinds_test.go
@@ -66,6 +66,67 @@ func TestProject_Load_UnownedKind(t *testing.T) {
 	})
 }
 
+// import-manifest is owned by the always-present import-manifest provider, but
+// BuildRegistry treats it as a known kind only when the ImportMerge experimental
+// flag is on. WithIgnoreUnknownKinds must mirror that exactly: skip a stray
+// import-manifest when the flag is off (a real project can carry one), keep it
+// when the flag is on. Regression guard for the #671<->#673 interaction — before
+// isKnownKind became flag-aware it treated import-manifest as always-known, so
+// the flag-off case failed syntax validation instead of being skipped.
+func TestProject_Load_ImportManifestKind_RespectsImportMergeFlag(t *testing.T) {
+	const (
+		sourceYAML   = "kind: Source\nversion: rudder/v1\nmetadata:\n  name: my_source\nspec:\n  k: v"
+		manifestYAML = `version: rudder/v1
+kind: import-manifest
+metadata:
+  name: import-manifest
+spec:
+  workspaces:
+    - workspace_id: ws-1
+      resources:
+        - urn: "event-stream-source:my-src"
+          remote_id: rid-1
+`
+	)
+
+	newProject := func(opts ...project.ProjectOption) project.Project {
+		mockProvider := testutils.NewMockProvider(nil, nil)
+		mockProvider.MatchPatterns = []rules.MatchPattern{
+			rules.MatchKindVersion("Source", specs.SpecVersionV1),
+		}
+		mockLoader := &MockLoader{LoadFunc: func(string) (map[string]*specs.RawSpec, error) {
+			return map[string]*specs.RawSpec{
+				"source.yaml":          {Data: []byte(sourceYAML)},
+				"import-manifest.yaml": {Data: []byte(manifestYAML)},
+			}, nil
+		}}
+
+		opts = append([]project.ProjectOption{
+			project.WithLoader(mockLoader),
+			project.WithRenderer(renderer.NewTextRenderer(&bytes.Buffer{})),
+		}, opts...)
+
+		return project.New(mockProvider, opts...)
+	}
+
+	// Toggles global viper state, so this test cannot run in parallel.
+	t.Run("flag off: stray import-manifest is skipped, not rejected", func(t *testing.T) {
+		proj := newProject(project.WithIgnoreUnknownKinds())
+
+		require.NoError(t, proj.Load("test_dir"))
+		assert.Equal(t, []string{"source.yaml"}, specPaths(proj))
+	})
+
+	t.Run("flag on: import-manifest is recognized, not skipped", func(t *testing.T) {
+		enableImportMerge(t)
+
+		proj := newProject(project.WithIgnoreUnknownKinds())
+
+		require.NoError(t, proj.Load("test_dir"))
+		assert.ElementsMatch(t, []string{"source.yaml", "import-manifest.yaml"}, specPaths(proj))
+	})
+}
+
 func specPaths(p project.Project) []string {
 	paths := make([]string, 0, len(p.Specs()))
 	for path := range p.Specs() {

--- a/cli/internal/project/project.go
+++ b/cli/internal/project/project.go
@@ -328,8 +328,9 @@ func (p *project) substituteSpecs(raw map[string]*specs.RawSpec) (map[string]*sp
 // operates on already-parsed specs.
 func (p *project) parseSpecs(raw map[string]*specs.RawSpec) (map[string]*specs.RawSpec, validation.Diagnostics) {
 	var (
-		diags          = make(validation.Diagnostics, 0)
-		parsedRawSpecs = make(map[string]*specs.RawSpec)
+		diags              = make(validation.Diagnostics, 0)
+		parsedRawSpecs     = make(map[string]*specs.RawSpec)
+		importMergeEnabled = config.GetConfig().ExperimentalFlags.ImportMerge
 	)
 
 	for path, rawSpec := range raw {
@@ -351,7 +352,7 @@ func (p *project) parseSpecs(raw map[string]*specs.RawSpec) (map[string]*specs.R
 		// Dropped before validation so the gatekeeper rules never see the spec at
 		// all: the kind belongs to a provider this caller did not register, so
 		// every rule keyed off it would be a false error.
-		if p.ignoreUnknownKinds && !p.isKnownKind(parsed.Kind) {
+		if p.ignoreUnknownKinds && !p.isKnownKind(parsed.Kind, importMergeEnabled) {
 			log.Debug("skipping spec of unregistered kind", "path", path, "kind", parsed.Kind)
 			continue
 		}
@@ -366,17 +367,15 @@ func (p *project) parseSpecs(raw map[string]*specs.RawSpec) (map[string]*specs.R
 	return parsedRawSpecs, diags
 }
 
-// isKnownKind reports whether any registered provider owns the kind. The pattern
-// union mirrors BuildRegistry's activePatterns, so a kind is skipped only when
-// the gatekeeper rules would have rejected it as unknown.
-func (p *project) isKnownKind(kind string) bool {
-	providers := []ProjectProvider{p.provider, p.importManifestProvider}
-
-	for _, prov := range providers {
-		for _, pattern := range prov.SupportedMatchPatterns() {
-			if pattern.Kind == "*" || pattern.Kind == kind {
-				return true
-			}
+// isKnownKind reports whether the kind is in the active pattern set given the
+// current import-merge state. Sharing activePatterns with BuildRegistry is what
+// keeps the skip decision and the gatekeeper's notion of "known" from drifting:
+// a kind is skipped only where BuildRegistry would otherwise reject it as
+// unknown. Notably import-manifest is known only when import-merge is enabled.
+func (p *project) isKnownKind(kind string, importMergeEnabled bool) bool {
+	for _, pattern := range activePatterns(p.provider, p.importManifestProvider, importMergeEnabled) {
+		if pattern.Kind == "*" || pattern.Kind == kind {
+			return true
 		}
 	}
 
@@ -385,6 +384,20 @@ func (p *project) isKnownKind(kind string) bool {
 
 func (p *project) registry() (rules.Registry, error) {
 	return BuildRegistry(p.provider, p.importManifestProvider, config.GetConfig().ExperimentalFlags.ImportMerge)
+}
+
+// activePatterns is the set of kind/version patterns the validation pipeline
+// treats as known: the resource provider's patterns, plus the import-manifest
+// provider's only when import-merge is enabled. Shared by BuildRegistry (which
+// rules fire) and isKnownKind (which specs the local typer may skip) so the two
+// never disagree about which kinds are known.
+func activePatterns(provider, manifestProvider ProjectProvider, importMergeEnabled bool) []rules.MatchPattern {
+	patterns := append([]rules.MatchPattern{}, provider.SupportedMatchPatterns()...)
+	if importMergeEnabled {
+		patterns = append(patterns, manifestProvider.SupportedMatchPatterns()...)
+	}
+
+	return patterns
 }
 
 // BuildRegistry constructs the validation rule registry from the resource
@@ -403,20 +416,16 @@ func (p *project) registry() (rules.Registry, error) {
 // arguments, testable without touching global config.
 func BuildRegistry(provider, manifestProvider ProjectProvider, importMergeEnabled bool) (rules.Registry, error) {
 	resourcePatterns := provider.SupportedMatchPatterns()
+	active := activePatterns(provider, manifestProvider, importMergeEnabled)
 
-	activePatterns := append([]rules.MatchPattern{}, resourcePatterns...)
-	if importMergeEnabled {
-		activePatterns = append(activePatterns, manifestProvider.SupportedMatchPatterns()...)
-	}
-
-	baseRegistry := rules.NewRegistry(activePatterns)
+	baseRegistry := rules.NewRegistry(active)
 
 	syntactic := []rules.Rule{
 		// Gatekeeper rules (spec-syntax-valid, resource-kind-version-valid) keep
-		// MatchAll AppliesTo and use activePatterns as the source of truth for the
-		// supported kinds and versions.
-		prules.NewSpecSyntaxValidRule(activePatterns),
-		prules.NewResourceKindVersionValidRule(activePatterns),
+		// MatchAll AppliesTo and use the active pattern set as the source of truth
+		// for the supported kinds and versions.
+		prules.NewSpecSyntaxValidRule(active),
+		prules.NewResourceKindVersionValidRule(active),
 
 		// metadata-syntax-valid and duplicate-urn are scoped to resourcePatterns so
 		// the engine only hands them resource specs — the import-manifest kind is
@@ -427,7 +436,7 @@ func BuildRegistry(provider, manifestProvider ProjectProvider, importMergeEnable
 	// Cross-source conflict between import-manifest and inline metadata.import
 	// only applies when the import-manifest kind is recognized.
 	if importMergeEnabled {
-		syntactic = append(syntactic, prules.NewManifestInlineConflictRule(provider.ParseSpec, activePatterns))
+		syntactic = append(syntactic, prules.NewManifestInlineConflictRule(provider.ParseSpec, active))
 	}
 	syntactic = append(syntactic, provider.SyntacticRules()...)
 	if importMergeEnabled {


### PR DESCRIPTION
## 🔗 Ticket

Follow-up to [DEX-450](https://linear.app/rudderstack/issue/DEX-450/generate-data-gov-types-via-rudder-cli-without-control-plane) — resolves the interaction between #671 and #673, both now on `main`.

---

## Summary

#671 added `WithIgnoreUnknownKinds` (used by the `--local` typer) whose `isKnownKind` treated **import-manifest as always-known**, walking the providers unconditionally. #673 (landed independently) gates the import-manifest kind behind the `ImportMerge` experimental flag in `BuildRegistry`. With both on `main`, the two disagree about which kinds are "known".

**Reproducible bug on `main` today:** a `--local` project carrying a stray `import-manifest.yaml` with the flag **off** (the default) slips past the skip (`isKnownKind` says known) and is then rejected by `BuildRegistry` as an unknown kind — the exact failure `WithIgnoreUnknownKinds` exists to prevent:

```
error[project/spec-syntax-valid]: 'kind' must be one of [properties events categories custom-types tp tracking-plan]
  --> import-manifest.yaml:2:1 | kind: import-manifest
```

Does **not** affect rudder-data-gov (it has no manifest), so it didn't block the #671 release — but it's a live latent defect.

---

## Changes

- Extract the active-pattern set into a shared `activePatterns(provider, manifestProvider, importMergeEnabled)` helper, consumed by **both** `BuildRegistry` (which rules fire) and `isKnownKind` (which specs the local typer may skip) — single, flag-aware source of truth so the two can't drift.
- `isKnownKind` now takes the resolved flag; `parseSpecs` resolves it once from config.
- `BuildRegistry` builds its pattern set from the helper (local renamed `active` to avoid shadowing).

## Testing

- Regression test (`TestProject_Load_ImportManifestKind_RespectsImportMergeFlag`): with `WithIgnoreUnknownKinds`, a stray import-manifest is **skipped when the flag is off** and **recognized when it's on**.
- Binary-level: `typer generate --local` against a rudder-data-gov copy with an injected `import-manifest.yaml` — fails on `main`, succeeds here; clean rudder-data-gov unaffected.
- `make lint` clean (0 issues); project + typer + ruledoc + app tests green.

## Risk / Impact

Low. Pure refactor of "known kinds" into one helper + a flag-threading; no behavior change except the intended skip of unknown import-manifest under the local typer. `apply` untouched.

## Checklist

- [x] Ticket linked
- [x] Tests added/updated
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)