### PR TITLE
fix(typer): make local generate work off-volume and name both experimental flags

### DIFF
--- a/cli/internal/cmd/typer/typer.go
+++ b/cli/internal/cmd/typer/typer.go
@@ -64,7 +64,7 @@ func newCmdGenerate() *cobra.Command {
 			}
 
 			if local && !config.GetConfig().ExperimentalFlags.LocalTyper {
-				return fmt.Errorf("--local is experimental; enable it by setting the 'localTyper' flag (e.g. RUDDERSTACK_X_LOCAL_TYPER=true)")
+				return fmt.Errorf("--local is experimental; enable it by setting both RUDDERSTACK_CLI_EXPERIMENTAL=true (the umbrella experimental flag) and RUDDERSTACK_X_LOCAL_TYPER=true (the 'localTyper' flag). The per-flag setting is ignored unless the umbrella flag is also set")
 			}
 
 			defer func() {

--- a/cli/internal/typer/generator/core/filemanager.go
+++ b/cli/internal/typer/generator/core/filemanager.go
@@ -96,8 +96,11 @@ func (fm *FileManager) ensureParentDir(fullPath string) error {
 func (fm *FileManager) writeFileAtomically(path, content string) error {
 	name := filepath.Base(path)
 
-	// Create temporary file in system temp directory to avoid leaving temp files in output dir
-	tmpFile, err := os.CreateTemp("", name+".tmp.*")
+	// Create the temporary file in the destination directory (not the system temp
+	// dir) so the os.Rename below stays on the same filesystem. Renaming across
+	// devices fails with EXDEV ("cross-device link") when the output lives on a
+	// different volume than $TMPDIR (e.g. a repo under /Volumes/...).
+	tmpFile, err := os.CreateTemp(filepath.Dir(path), name+".tmp.*")
 	if err != nil {
 		return fmt.Errorf("creating temporary file: %w", err)
 	}

--- a/cli/internal/typer/generator/core/filemanager_test.go
+++ b/cli/internal/typer/generator/core/filemanager_test.go
@@ -459,3 +459,29 @@ func TestFileManager_ErrorHandling(t *testing.T) {
 		})
 	}
 }
+
+// TestFileManager_WriteFileIgnoresTmpdir guards against the atomic write routing
+// through the system temp dir. If it does, an unusable $TMPDIR makes the temp-file
+// creation fail (and, when $TMPDIR is on a different volume than the output, the
+// subsequent os.Rename fails with EXDEV). Writing the temp file next to the
+// destination avoids both. Not applicable on Windows, where os.TempDir ignores TMPDIR.
+func TestFileManager_WriteFileIgnoresTmpdir(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("os.TempDir does not consult TMPDIR on Windows")
+	}
+
+	// Point TMPDIR at a path that cannot be used for temp files. The old
+	// implementation (os.CreateTemp("", ...)) would fail here; writing next to the
+	// destination does not touch TMPDIR at all.
+	t.Setenv("TMPDIR", filepath.Join(t.TempDir(), "does-not-exist"))
+
+	outDir := t.TempDir()
+	fm := NewFileManager(outDir)
+	file := &File{Path: "sub/RudderTyper.ts", Content: "export const x = 1;\n"}
+
+	require.NoError(t, fm.WriteFile(file))
+
+	got, err := os.ReadFile(filepath.Join(outDir, file.Path))
+	require.NoError(t, err)
+	assert.Equal(t, file.Content, string(got))
+}


### PR DESCRIPTION
Two small DX fixes surfaced while dogfooding `rudder-cli typer generate --local` (thanks @aris for both reports).

### 1. `--local` fails with `cross-device link` when the repo is on a different volume
`writeFileAtomically` created its temp file in the system temp dir (`$TMPDIR`) and then `os.Rename`d it onto the target. Rename is only atomic *within* a filesystem, so when the output directory lives on a different volume than `$TMPDIR` (e.g. a repo under `/Volumes/...`), it fails with `EXDEV: cross-device link`. The reporter had to pin `TMPDIR` as a workaround.

Fix: create the temp file in the destination directory (`os.CreateTemp(filepath.Dir(path), ...)`) so the rename stays on one filesystem. `WriteFile` already `MkdirAll`s the parent first, so the directory exists. Added a guard test (`TestFileManager_WriteFileIgnoresTmpdir`) that writes successfully even when `$TMPDIR` is unusable — it fails against the old implementation.

### 2. `--local` error names only one of the two required flags
Enabling `--local` needs **both** `RUDDERSTACK_CLI_EXPERIMENTAL=true` (the umbrella flag — `GetConfig()` zeroes all per-flags unless it is set) and `RUDDERSTACK_X_LOCAL_TYPER=true`. The error named only the second, so setting just that still failed with the same message and looked like the flag was broken. Now names both.

### Test
`go test ./internal/typer/generator/core/... ./internal/cmd/typer/...` passes; `go build ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)