### PR TITLE
fix(typer): resolve analytics instance lazily in generated TS client (stop silent event drops)

### DIFF
--- a/cli/internal/typer/generator/platforms/typescript/generator_test.go
+++ b/cli/internal/typer/generator/platforms/typescript/generator_test.go
@@ -71,6 +71,25 @@ func TestGenerateSingleBranchDispatcher(t *testing.T) {
 	assert.NotContains(t, file.Content, "if (typeof", "single branch must not emit if/else")
 }
 
+// TestGenerateResolvesAnalyticsLazily guards against regressing to eager instance
+// capture. The class must accept a resolver and re-resolve the instance on every
+// call (via the `analytics` getter) so a lazily-loaded browser SDK is picked up
+// instead of the preloader being captured at construction and events dropped.
+func TestGenerateResolvesAnalyticsLazily(t *testing.T) {
+	trackingPlan := testutils.GetReferenceTrackingPlan()
+
+	generator := &typescript.Generator{}
+	files, err := generator.Generate(trackingPlan, core.GenerateOptions{RudderCLIVersion: "1.0.0"}, typescript.TypeScriptOptions{})
+	assert.NoError(t, err)
+	assert.Len(t, files, 1)
+	content := files[0].Content
+
+	assert.Contains(t, content, "constructor(analytics: RudderAnalytics | (() => RudderAnalytics))")
+	assert.Contains(t, content, `this.resolveAnalytics = typeof analytics === "function" ? analytics : () => analytics;`)
+	assert.Contains(t, content, "private get analytics(): RudderAnalytics {")
+	assert.NotContains(t, content, "this.analytics = analytics;", "must not capture the instance eagerly")
+}
+
 func TestGenerateWithCustomOutputFileName(t *testing.T) {
 	trackingPlan := testutils.GetReferenceTrackingPlan()
 

--- a/cli/internal/typer/generator/platforms/typescript/generator_test.go
+++ b/cli/internal/typer/generator/platforms/typescript/generator_test.go
@@ -72,9 +72,11 @@ func TestGenerateSingleBranchDispatcher(t *testing.T) {
 }
 
 // TestGenerateResolvesAnalyticsLazily guards against regressing to eager instance
-// capture. The class must accept a resolver and re-resolve the instance on every
-// call (via the `analytics` getter) so a lazily-loaded browser SDK is picked up
-// instead of the preloader being captured at construction and events dropped.
+// capture. The class must accept a resolver-only constructor and re-resolve the
+// instance on every call (via the `analytics` getter) so a lazily-loaded browser
+// SDK is picked up instead of the preloader being captured at construction and
+// events dropped. The instance form is intentionally not accepted so the unsafe
+// call cannot compile.
 func TestGenerateResolvesAnalyticsLazily(t *testing.T) {
 	trackingPlan := testutils.GetReferenceTrackingPlan()
 
@@ -84,10 +86,11 @@ func TestGenerateResolvesAnalyticsLazily(t *testing.T) {
 	assert.Len(t, files, 1)
 	content := files[0].Content
 
-	assert.Contains(t, content, "constructor(analytics: RudderAnalytics | (() => RudderAnalytics))")
-	assert.Contains(t, content, `this.resolveAnalytics = typeof analytics === "function" ? analytics : () => analytics;`)
+	assert.Contains(t, content, "constructor(resolveAnalytics: () => RudderAnalytics)")
+	assert.Contains(t, content, "this.resolveAnalytics = resolveAnalytics;")
 	assert.Contains(t, content, "private get analytics(): RudderAnalytics {")
 	assert.NotContains(t, content, "this.analytics = analytics;", "must not capture the instance eagerly")
+	assert.NotContains(t, content, "RudderAnalytics | (() => RudderAnalytics)", "must not accept the unsafe instance form")
 }
 
 func TestGenerateWithCustomOutputFileName(t *testing.T) {

--- a/cli/internal/typer/generator/platforms/typescript/templates/ruddertyper.tmpl
+++ b/cli/internal/typer/generator/platforms/typescript/templates/ruddertyper.tmpl
@@ -14,12 +14,31 @@
  * analytics.load("YOUR_WRITE_KEY", "YOUR_DATA_PLANE_URL");
  * const rudderTyper = new RudderTyper(analytics);
  * ```
+ *
+ * In a browser app that loads the SDK asynchronously, the standard RudderStack
+ * snippet swaps `window.rudderanalytics` from the buffering preloader to the real
+ * SDK once it loads. Pass a resolver function instead of the instance so every call
+ * re-resolves the current SDK — otherwise the preloader is captured at construction
+ * and events fired after the SDK loads are silently dropped:
+ *
+ * ```ts
+ * const rudderTyper = new RudderTyper(() => window.rudderanalytics);
+ * ```
  */
 export class RudderTyper {
-    private readonly analytics: RudderAnalytics;
+    private readonly resolveAnalytics: () => RudderAnalytics;
 
-    constructor(analytics: RudderAnalytics) {
-        this.analytics = analytics;
+    /**
+     * @param analytics - a RudderAnalytics instance, or a function that returns the
+     * current instance. Prefer the function form in the browser so a lazily-loaded
+     * SDK is resolved on every call rather than captured once at construction.
+     */
+    constructor(analytics: RudderAnalytics | (() => RudderAnalytics)) {
+        this.resolveAnalytics = typeof analytics === "function" ? analytics : () => analytics;
+    }
+
+    private get analytics(): RudderAnalytics {
+        return this.resolveAnalytics();
     }
 {{ range $method := .AnalyticsMethods }}
 {{- if $method.Overloads }}

--- a/cli/internal/typer/generator/platforms/typescript/templates/ruddertyper.tmpl
+++ b/cli/internal/typer/generator/platforms/typescript/templates/ruddertyper.tmpl
@@ -5,6 +5,10 @@
  * - ID: {{ .TrackingPlanID }}
  * - Version: {{ .TrackingPlanVersion }}
  *
+ * The constructor takes a resolver function that returns the current
+ * RudderAnalytics instance. It is re-invoked on every call, so a lazily-loaded
+ * SDK is always resolved fresh rather than captured once at construction.
+ *
  * @example
  * ```ts
  * import { RudderAnalytics } from "@rudderstack/analytics-js";
@@ -12,14 +16,14 @@
  *
  * const analytics = new RudderAnalytics();
  * analytics.load("YOUR_WRITE_KEY", "YOUR_DATA_PLANE_URL");
- * const rudderTyper = new RudderTyper(analytics);
+ * const rudderTyper = new RudderTyper(() => analytics);
  * ```
  *
  * In a browser app that loads the SDK asynchronously, the standard RudderStack
  * snippet swaps `window.rudderanalytics` from the buffering preloader to the real
- * SDK once it loads. Pass a resolver function instead of the instance so every call
- * re-resolves the current SDK — otherwise the preloader is captured at construction
- * and events fired after the SDK loads are silently dropped:
+ * SDK once it loads. Because the resolver re-resolves on every call, events are
+ * always sent through the current SDK — an eagerly captured instance would pin the
+ * preloader and silently drop events fired after the SDK loads:
  *
  * ```ts
  * const rudderTyper = new RudderTyper(() => window.rudderanalytics);
@@ -29,12 +33,12 @@ export class RudderTyper {
     private readonly resolveAnalytics: () => RudderAnalytics;
 
     /**
-     * @param analytics - a RudderAnalytics instance, or a function that returns the
-     * current instance. Prefer the function form in the browser so a lazily-loaded
-     * SDK is resolved on every call rather than captured once at construction.
+     * @param resolveAnalytics - a function that returns the current RudderAnalytics
+     * instance. Re-invoked on every call so a lazily-loaded SDK is resolved fresh
+     * rather than captured once at construction.
      */
-    constructor(analytics: RudderAnalytics | (() => RudderAnalytics)) {
-        this.resolveAnalytics = typeof analytics === "function" ? analytics : () => analytics;
+    constructor(resolveAnalytics: () => RudderAnalytics) {
+        this.resolveAnalytics = resolveAnalytics;
     }
 
     private get analytics(): RudderAnalytics {

--- a/cli/internal/typer/generator/platforms/typescript/testdata/RudderTyper.ts
+++ b/cli/internal/typer/generator/platforms/typescript/testdata/RudderTyper.ts
@@ -433,12 +433,31 @@ export interface EventWithNameCamelCase1 {
  * analytics.load("YOUR_WRITE_KEY", "YOUR_DATA_PLANE_URL");
  * const rudderTyper = new RudderTyper(analytics);
  * ```
+ *
+ * In a browser app that loads the SDK asynchronously, the standard RudderStack
+ * snippet swaps `window.rudderanalytics` from the buffering preloader to the real
+ * SDK once it loads. Pass a resolver function instead of the instance so every call
+ * re-resolves the current SDK — otherwise the preloader is captured at construction
+ * and events fired after the SDK loads are silently dropped:
+ *
+ * ```ts
+ * const rudderTyper = new RudderTyper(() => window.rudderanalytics);
+ * ```
  */
 export class RudderTyper {
-    private readonly analytics: RudderAnalytics;
+    private readonly resolveAnalytics: () => RudderAnalytics;
 
-    constructor(analytics: RudderAnalytics) {
-        this.analytics = analytics;
+    /**
+     * @param analytics - a RudderAnalytics instance, or a function that returns the
+     * current instance. Prefer the function form in the browser so a lazily-loaded
+     * SDK is resolved on every call rather than captured once at construction.
+     */
+    constructor(analytics: RudderAnalytics | (() => RudderAnalytics)) {
+        this.resolveAnalytics = typeof analytics === "function" ? analytics : () => analytics;
+    }
+
+    private get analytics(): RudderAnalytics {
+        return this.resolveAnalytics();
     }
 
     public group(

--- a/cli/internal/typer/generator/platforms/typescript/testdata/RudderTyper.ts
+++ b/cli/internal/typer/generator/platforms/typescript/testdata/RudderTyper.ts
@@ -424,6 +424,10 @@ export interface EventWithNameCamelCase1 {
  * - ID: plan_12345
  * - Version: 13
  *
+ * The constructor takes a resolver function that returns the current
+ * RudderAnalytics instance. It is re-invoked on every call, so a lazily-loaded
+ * SDK is always resolved fresh rather than captured once at construction.
+ *
  * @example
  * ```ts
  * import { RudderAnalytics } from "@rudderstack/analytics-js";
@@ -431,14 +435,14 @@ export interface EventWithNameCamelCase1 {
  *
  * const analytics = new RudderAnalytics();
  * analytics.load("YOUR_WRITE_KEY", "YOUR_DATA_PLANE_URL");
- * const rudderTyper = new RudderTyper(analytics);
+ * const rudderTyper = new RudderTyper(() => analytics);
  * ```
  *
  * In a browser app that loads the SDK asynchronously, the standard RudderStack
  * snippet swaps `window.rudderanalytics` from the buffering preloader to the real
- * SDK once it loads. Pass a resolver function instead of the instance so every call
- * re-resolves the current SDK — otherwise the preloader is captured at construction
- * and events fired after the SDK loads are silently dropped:
+ * SDK once it loads. Because the resolver re-resolves on every call, events are
+ * always sent through the current SDK — an eagerly captured instance would pin the
+ * preloader and silently drop events fired after the SDK loads:
  *
  * ```ts
  * const rudderTyper = new RudderTyper(() => window.rudderanalytics);
@@ -448,12 +452,12 @@ export class RudderTyper {
     private readonly resolveAnalytics: () => RudderAnalytics;
 
     /**
-     * @param analytics - a RudderAnalytics instance, or a function that returns the
-     * current instance. Prefer the function form in the browser so a lazily-loaded
-     * SDK is resolved on every call rather than captured once at construction.
+     * @param resolveAnalytics - a function that returns the current RudderAnalytics
+     * instance. Re-invoked on every call so a lazily-loaded SDK is resolved fresh
+     * rather than captured once at construction.
      */
-    constructor(analytics: RudderAnalytics | (() => RudderAnalytics)) {
-        this.resolveAnalytics = typeof analytics === "function" ? analytics : () => analytics;
+    constructor(resolveAnalytics: () => RudderAnalytics) {
+        this.resolveAnalytics = resolveAnalytics;
     }
 
     private get analytics(): RudderAnalytics {

--- a/cli/internal/typer/generator/platforms/typescript/testdata/validator/src/__tests__/group.test.ts
+++ b/cli/internal/typer/generator/platforms/typescript/testdata/validator/src/__tests__/group.test.ts
@@ -21,7 +21,7 @@ describe("RudderTyper.group", () => {
       uaChTrackLevel: "none",
     });
     await new Promise<void>((resolve) => analytics.ready(() => resolve()));
-    typer = new RudderTyper(analytics);
+    typer = new RudderTyper(() => analytics);
   });
 
   it("dispatches a group event with groupId and traits routed through context.traits", async () => {

--- a/cli/internal/typer/generator/platforms/typescript/testdata/validator/src/__tests__/identify.test.ts
+++ b/cli/internal/typer/generator/platforms/typescript/testdata/validator/src/__tests__/identify.test.ts
@@ -21,7 +21,7 @@ describe("RudderTyper.identify", () => {
       uaChTrackLevel: "none",
     });
     await new Promise<void>((resolve) => analytics.ready(() => resolve()));
-    typer = new RudderTyper(analytics);
+    typer = new RudderTyper(() => analytics);
   });
 
   it("dispatches an identify event with the provided userId and traits", async () => {

--- a/cli/internal/typer/generator/platforms/typescript/testdata/validator/src/__tests__/multitype.test.ts
+++ b/cli/internal/typer/generator/platforms/typescript/testdata/validator/src/__tests__/multitype.test.ts
@@ -21,7 +21,7 @@ describe("RudderTyper.track (multi-type properties)", () => {
       uaChTrackLevel: "none",
     });
     await new Promise<void>((resolve) => analytics.ready(() => resolve()));
-    typer = new RudderTyper(analytics);
+    typer = new RudderTyper(() => analytics);
   });
 
   // ---- multiTypeField: string | number | boolean ----

--- a/cli/internal/typer/generator/platforms/typescript/testdata/validator/src/__tests__/page.test.ts
+++ b/cli/internal/typer/generator/platforms/typescript/testdata/validator/src/__tests__/page.test.ts
@@ -21,7 +21,7 @@ describe("RudderTyper.page", () => {
       uaChTrackLevel: "none",
     });
     await new Promise<void>((resolve) => analytics.ready(() => resolve()));
-    typer = new RudderTyper(analytics);
+    typer = new RudderTyper(() => analytics);
   });
 
   it("dispatches a page event with name and typed properties", async () => {

--- a/cli/internal/typer/generator/platforms/typescript/testdata/validator/src/__tests__/track.test.ts
+++ b/cli/internal/typer/generator/platforms/typescript/testdata/validator/src/__tests__/track.test.ts
@@ -21,7 +21,7 @@ describe("RudderTyper.track", () => {
       uaChTrackLevel: "none",
     });
     await new Promise<void>((resolve) => analytics.ready(() => resolve()));
-    typer = new RudderTyper(analytics);
+    typer = new RudderTyper(() => analytics);
   });
 
   // ---- trackUserSignedUp (comprehensive) ----

--- a/cli/internal/typer/generator/platforms/typescript/testdata/validator/src/__tests__/variants.test.ts
+++ b/cli/internal/typer/generator/platforms/typescript/testdata/validator/src/__tests__/variants.test.ts
@@ -21,7 +21,7 @@ describe("RudderTyper.track — variant discriminated unions", () => {
       uaChTrackLevel: "none",
     });
     await new Promise<void>((resolve) => analytics.ready(() => resolve()));
-    typer = new RudderTyper(analytics);
+    typer = new RudderTyper(() => analytics);
   });
 
   // ---- trackEventWithVariants (each event-level variant case) ----


### PR DESCRIPTION
### The bug (silent event loss)
The generated `RudderTyper` class captured the analytics instance in its constructor and every method called `this.analytics.*`:

```ts
constructor(analytics: RudderAnalytics) { this.analytics = analytics; }
```

In a browser app the standard RudderStack snippet installs a **buffering preloader** on `window.rudderanalytics` and swaps it for the real SDK once `analytics-js` loads. So the obvious call:

```ts
export const analytics = new RudderTyper(window.rudderanalytics); // runs at import, captures the preloader
```

captured the preloader, and every event fired **after** the SDK loaded went into an abandoned queue. No error, no type error, no failed build: events just quietly stopped arriving. Found while migrating rudder-webapp off the npm typer.

The v1 npm generator did **not** have this. It resolved `window.rudderanalytics` per call via a closure.

### The fix
The constructor is now **resolver-only**, and an `analytics` getter re-resolves on every call:

```ts
constructor(resolveAnalytics: () => RudderAnalytics) {
    this.resolveAnalytics = resolveAnalytics;
}
private get analytics(): RudderAnalytics { return this.resolveAnalytics(); }
```

Consumers pass `new RudderTyper(() => window.rudderanalytics)` (now the documented example in the generated file). Node/server usage passes `() => analytics`.

Resolver-only rather than `RudderAnalytics | (() => RudderAnalytics)`, per review feedback: accepting an instance would leave the unsafe call compiling, and the failure mode it produces is silent. A thunk is trivial to write at every call site, so the union buys nothing but a footgun.

### Breaking change
This changes the generated constructor signature, so previously generated clients need `new RudderTyper(analytics)` updated to `new RudderTyper(() => analytics)`. `rudder-cli typer` is still behind `RUDDERSTACK_CLI_EXPERIMENTAL` and pre-GA, so the blast radius is limited to the current dogfooding consumers. Landing it now is the point: after GA the eager shape is locked for every customer who adopts it.

### Test
- Regenerated the TS golden file (`make typer-typescript-update-testdata`).
- Added `TestGenerateResolvesAnalyticsLazily`, asserting the generator emits the resolver + getter, never `this.analytics = analytics;`, and never the `RudderAnalytics | (() => RudderAnalytics)` union.
- Updated the `testdata/validator` suites, which exercise the generated client against the real `@rudderstack/analytics-js` SDK. The "validate generated TypeScript against RudderStack JS SDK" check passes.
- `go test ./cli/internal/typer/...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
