### PR TITLE
feat(typer): opt-in v1 compatibility layer — un-prefixed free functions [DRAFT]

### DIFF
--- a/cli/internal/typer/generator/platforms/typescript/context.go
+++ b/cli/internal/typer/generator/platforms/typescript/context.go
@@ -121,4 +121,8 @@ type TSContext struct {
 	// from the SDK rather than defined locally so the callback signature stays
 	// in sync with whatever shape the SDK accepts.
 	UsesApiCallback bool
+	// EmitV1Compat, when true, appends the opt-in v1 compatibility layer:
+	// un-prefixed free functions bound to a default client that lazily resolves
+	// window.rudderanalytics. See TypeScriptOptions.V1Compat.
+	EmitV1Compat bool
 }

--- a/cli/internal/typer/generator/platforms/typescript/generator.go
+++ b/cli/internal/typer/generator/platforms/typescript/generator.go
@@ -57,6 +57,7 @@ func (g *Generator) Generate(p *plan.TrackingPlan, opts core.GenerateOptions, pl
 		TrackingPlanVersion: p.Metadata.TrackingPlanVersion,
 		TrackingPlanURL:     p.Metadata.URL,
 		EventContext:        formatEventContext(p.Metadata, opts.RudderCLIVersion),
+		EmitV1Compat:        tsOpts.V1Compat,
 	}
 
 	nr := core.NewNameRegistry(typescriptCollisionHandler)

--- a/cli/internal/typer/generator/platforms/typescript/generator_test.go
+++ b/cli/internal/typer/generator/platforms/typescript/generator_test.go
@@ -71,6 +71,25 @@ func TestGenerateSingleBranchDispatcher(t *testing.T) {
 	assert.NotContains(t, file.Content, "if (typeof", "single branch must not emit if/else")
 }
 
+// TestGenerateResolvesAnalyticsLazily guards against regressing to eager instance
+// capture. The class must accept a resolver and re-resolve the instance on every
+// call (via the `analytics` getter) so a lazily-loaded browser SDK is picked up
+// instead of the preloader being captured at construction and events dropped.
+func TestGenerateResolvesAnalyticsLazily(t *testing.T) {
+	trackingPlan := testutils.GetReferenceTrackingPlan()
+
+	generator := &typescript.Generator{}
+	files, err := generator.Generate(trackingPlan, core.GenerateOptions{RudderCLIVersion: "1.0.0"}, typescript.TypeScriptOptions{})
+	assert.NoError(t, err)
+	assert.Len(t, files, 1)
+	content := files[0].Content
+
+	assert.Contains(t, content, "constructor(analytics: RudderAnalytics | (() => RudderAnalytics))")
+	assert.Contains(t, content, `this.resolveAnalytics = typeof analytics === "function" ? analytics : () => analytics;`)
+	assert.Contains(t, content, "private get analytics(): RudderAnalytics {")
+	assert.NotContains(t, content, "this.analytics = analytics;", "must not capture the instance eagerly")
+}
+
 func TestGenerateWithCustomOutputFileName(t *testing.T) {
 	trackingPlan := testutils.GetReferenceTrackingPlan()
 

--- a/cli/internal/typer/generator/platforms/typescript/generator_test.go
+++ b/cli/internal/typer/generator/platforms/typescript/generator_test.go
@@ -105,7 +105,7 @@ func TestGenerateV1CompatIsOptIn(t *testing.T) {
 	assert.NoError(t, err)
 	content := on[0].Content
 	assert.Contains(t, content, "v1 compatibility layer")
-	assert.Contains(t, content, "const rudderTyperV1Compat = new RudderTyper(() => window.rudderanalytics);")
+	assert.Contains(t, content, "const rudderTyperV1Compat = new RudderTyper(() => window.rudderanalytics as RudderAnalytics);")
 	// Un-prefixed free function for a track event (class method is trackXxx).
 	assert.Contains(t, content, "export const userSignedUp = rudderTyperV1Compat.trackUserSignedUp.bind(rudderTyperV1Compat);")
 	// Non-track singletons keep their names.

--- a/cli/internal/typer/generator/platforms/typescript/generator_test.go
+++ b/cli/internal/typer/generator/platforms/typescript/generator_test.go
@@ -90,6 +90,28 @@ func TestGenerateResolvesAnalyticsLazily(t *testing.T) {
 	assert.NotContains(t, content, "this.analytics = analytics;", "must not capture the instance eagerly")
 }
 
+// TestGenerateV1CompatIsOptIn verifies the v1 compatibility layer is emitted only
+// when --option v1Compat=true, and that it exposes un-prefixed free functions bound
+// to a default client resolving window.rudderanalytics.
+func TestGenerateV1CompatIsOptIn(t *testing.T) {
+	trackingPlan := testutils.GetReferenceTrackingPlan()
+	generator := &typescript.Generator{}
+
+	off, err := generator.Generate(trackingPlan, core.GenerateOptions{RudderCLIVersion: "1.0.0"}, typescript.TypeScriptOptions{})
+	assert.NoError(t, err)
+	assert.NotContains(t, off[0].Content, "v1 compatibility layer", "compat layer must be off by default")
+
+	on, err := generator.Generate(trackingPlan, core.GenerateOptions{RudderCLIVersion: "1.0.0"}, typescript.TypeScriptOptions{V1Compat: true})
+	assert.NoError(t, err)
+	content := on[0].Content
+	assert.Contains(t, content, "v1 compatibility layer")
+	assert.Contains(t, content, "const rudderTyperV1Compat = new RudderTyper(() => window.rudderanalytics);")
+	// Un-prefixed free function for a track event (class method is trackXxx).
+	assert.Contains(t, content, "export const userSignedUp = rudderTyperV1Compat.trackUserSignedUp.bind(rudderTyperV1Compat);")
+	// Non-track singletons keep their names.
+	assert.Contains(t, content, "export const identify = rudderTyperV1Compat.identify.bind(rudderTyperV1Compat);")
+}
+
 func TestGenerateWithCustomOutputFileName(t *testing.T) {
 	trackingPlan := testutils.GetReferenceTrackingPlan()
 

--- a/cli/internal/typer/generator/platforms/typescript/options.go
+++ b/cli/internal/typer/generator/platforms/typescript/options.go
@@ -6,6 +6,10 @@ package typescript
 //	--option outputFileName=Events.ts
 type TypeScriptOptions struct {
 	OutputFileName string `mapstructure:"outputFileName" description:"Name of the generated TypeScript file. Defaults to RudderTyper.ts"`
+	// V1Compat additionally emits un-prefixed free functions bound to a default
+	// client that lazily resolves window.rudderanalytics, as a drop-in for
+	// consumers migrating from the npm rudder-typer v1 module. Off by default.
+	V1Compat bool `mapstructure:"v1Compat" description:"Also emit un-prefixed free functions bound to window.rudderanalytics for drop-in compatibility with the npm rudder-typer v1 module. Defaults to false."`
 }
 
 // DefaultOptions returns the default TypeScript generation options.

--- a/cli/internal/typer/generator/platforms/typescript/templates.go
+++ b/cli/internal/typer/generator/platforms/typescript/templates.go
@@ -3,7 +3,9 @@ package typescript
 import (
 	"bytes"
 	_ "embed"
+	"strings"
 	"text/template"
+	"unicode"
 
 	"github.com/rudderlabs/rudder-iac/cli/internal/typer/generator/core"
 )
@@ -25,12 +27,24 @@ var ruddertyperTemplate string
 
 // compatFreeFunctionName returns the un-prefixed free-function name for the v1
 // compatibility layer. Track methods are named `track<Event>` on the class but
-// were un-prefixed free functions in the v1 module (e.g. `sourceCreated`), so we
-// strip the prefix by re-deriving the name from the event. identify/group/page
-// keep their names.
+// were un-prefixed free functions in the v1 module (e.g. `sourceCreated`). We strip
+// the `track` prefix off the already-registered method name (rather than re-deriving
+// from the event) so the NameRegistry's collision suffixes are preserved — two
+// events that camelCase to the same name stay distinct (`fooBar`, `fooBar1`).
+// identify/group/page keep their names.
+//
+// Residual collision risk: a track event literally named "Identify"/"Page"/"Group"
+// strips to a name that clashes with the singleton method. Not guarded here yet —
+// see the PR discussion.
 func compatFreeFunctionName(m TSAnalyticsMethod) string {
-	if m.SDKMethodName == "track" {
-		return FormatMethodName("", m.EventName)
+	if m.SDKMethodName == "track" && strings.HasPrefix(m.Name, "track") {
+		stripped := strings.TrimPrefix(m.Name, "track")
+		if stripped == "" {
+			return m.Name
+		}
+		r := []rune(stripped)
+		r[0] = unicode.ToLower(r[0])
+		return string(r)
 	}
 	return m.Name
 }

--- a/cli/internal/typer/generator/platforms/typescript/templates.go
+++ b/cli/internal/typer/generator/platforms/typescript/templates.go
@@ -23,11 +23,24 @@ var typealiasTemplate string
 //go:embed templates/ruddertyper.tmpl
 var ruddertyperTemplate string
 
+// compatFreeFunctionName returns the un-prefixed free-function name for the v1
+// compatibility layer. Track methods are named `track<Event>` on the class but
+// were un-prefixed free functions in the v1 module (e.g. `sourceCreated`), so we
+// strip the prefix by re-deriving the name from the event. identify/group/page
+// keep their names.
+func compatFreeFunctionName(m TSAnalyticsMethod) string {
+	if m.SDKMethodName == "track" {
+		return FormatMethodName("", m.EventName)
+	}
+	return m.Name
+}
+
 func GenerateFile(path string, ctx *TSContext) (*core.File, error) {
 	funcMap := template.FuncMap{
 		"escapeString":  EscapeTSStringLiteral,
 		"escapeComment": EscapeJSDocComment,
 		"formatLiteral": FormatTSLiteral,
+		"compatName":    compatFreeFunctionName,
 	}
 
 	tmpl, err := template.New("typescript").Funcs(funcMap).Parse(typescriptTemplate)

--- a/cli/internal/typer/generator/platforms/typescript/templates/ruddertyper.tmpl
+++ b/cli/internal/typer/generator/platforms/typescript/templates/ruddertyper.tmpl
@@ -134,3 +134,27 @@ export class RudderTyper {
         };
     }
 }
+{{- if .EmitV1Compat }}
+
+declare global {
+    interface Window {
+        rudderanalytics: RudderAnalytics;
+    }
+}
+
+// ===== v1 compatibility layer (opt-in: --option v1Compat=true) =====
+//
+// Un-prefixed free functions bound to a default client that lazily resolves
+// window.rudderanalytics on every call. This is a drop-in for consumers migrating
+// from the npm `rudder-typer` v1 module: same imports, same un-prefixed call sites,
+// no `new RudderTyper(...)`. Not emitted by default — see the migration guide.
+//
+// Caveats (see PR discussion): (1) un-prefixing track events can collide with
+// identify/page/group or with each other; the generator does not yet guard against
+// that here. (2) .bind narrows overloaded methods (identify/page/group) to a single
+// signature.
+const rudderTyperV1Compat = new RudderTyper(() => window.rudderanalytics);
+{{ range $method := .AnalyticsMethods }}
+export const {{ compatName $method }} = rudderTyperV1Compat.{{ $method.Name }}.bind(rudderTyperV1Compat);
+{{- end }}
+{{- end }}

--- a/cli/internal/typer/generator/platforms/typescript/templates/ruddertyper.tmpl
+++ b/cli/internal/typer/generator/platforms/typescript/templates/ruddertyper.tmpl
@@ -14,12 +14,31 @@
  * analytics.load("YOUR_WRITE_KEY", "YOUR_DATA_PLANE_URL");
  * const rudderTyper = new RudderTyper(analytics);
  * ```
+ *
+ * In a browser app that loads the SDK asynchronously, the standard RudderStack
+ * snippet swaps `window.rudderanalytics` from the buffering preloader to the real
+ * SDK once it loads. Pass a resolver function instead of the instance so every call
+ * re-resolves the current SDK — otherwise the preloader is captured at construction
+ * and events fired after the SDK loads are silently dropped:
+ *
+ * ```ts
+ * const rudderTyper = new RudderTyper(() => window.rudderanalytics);
+ * ```
  */
 export class RudderTyper {
-    private readonly analytics: RudderAnalytics;
+    private readonly resolveAnalytics: () => RudderAnalytics;
 
-    constructor(analytics: RudderAnalytics) {
-        this.analytics = analytics;
+    /**
+     * @param analytics - a RudderAnalytics instance, or a function that returns the
+     * current instance. Prefer the function form in the browser so a lazily-loaded
+     * SDK is resolved on every call rather than captured once at construction.
+     */
+    constructor(analytics: RudderAnalytics | (() => RudderAnalytics)) {
+        this.resolveAnalytics = typeof analytics === "function" ? analytics : () => analytics;
+    }
+
+    private get analytics(): RudderAnalytics {
+        return this.resolveAnalytics();
     }
 {{ range $method := .AnalyticsMethods }}
 {{- if $method.Overloads }}

--- a/cli/internal/typer/generator/platforms/typescript/templates/ruddertyper.tmpl
+++ b/cli/internal/typer/generator/platforms/typescript/templates/ruddertyper.tmpl
@@ -136,12 +136,6 @@ export class RudderTyper {
 }
 {{- if .EmitV1Compat }}
 
-declare global {
-    interface Window {
-        rudderanalytics: RudderAnalytics;
-    }
-}
-
 // ===== v1 compatibility layer (opt-in: --option v1Compat=true) =====
 //
 // Un-prefixed free functions bound to a default client that lazily resolves
@@ -149,11 +143,15 @@ declare global {
 // from the npm `rudder-typer` v1 module: same imports, same un-prefixed call sites,
 // no `new RudderTyper(...)`. Not emitted by default — see the migration guide.
 //
-// Caveats (see PR discussion): (1) un-prefixing track events can collide with
-// identify/page/group or with each other; the generator does not yet guard against
-// that here. (2) .bind narrows overloaded methods (identify/page/group) to a single
-// signature.
-const rudderTyperV1Compat = new RudderTyper(() => window.rudderanalytics);
+// window.rudderanalytics is declared by @rudderstack/analytics-js as
+// `RudderAnalytics | RudderAnalyticsPreloader | undefined`; the cast mirrors the v1
+// module (which treated the instance as `any`) and the runtime guarantee that the
+// standard snippet defines it before any call fires.
+//
+// Caveats (see PR discussion): (1) a track event literally named Identify/Page/Group
+// strips to a name that collides with the singleton method; not guarded here yet.
+// (2) .bind narrows overloaded methods (identify/page/group) to a single signature.
+const rudderTyperV1Compat = new RudderTyper(() => window.rudderanalytics as RudderAnalytics);
 {{ range $method := .AnalyticsMethods }}
 export const {{ compatName $method }} = rudderTyperV1Compat.{{ $method.Name }}.bind(rudderTyperV1Compat);
 {{- end }}

--- a/cli/internal/typer/generator/platforms/typescript/testdata/RudderTyper.ts
+++ b/cli/internal/typer/generator/platforms/typescript/testdata/RudderTyper.ts
@@ -433,12 +433,31 @@ export interface EventWithNameCamelCase1 {
  * analytics.load("YOUR_WRITE_KEY", "YOUR_DATA_PLANE_URL");
  * const rudderTyper = new RudderTyper(analytics);
  * ```
+ *
+ * In a browser app that loads the SDK asynchronously, the standard RudderStack
+ * snippet swaps `window.rudderanalytics` from the buffering preloader to the real
+ * SDK once it loads. Pass a resolver function instead of the instance so every call
+ * re-resolves the current SDK — otherwise the preloader is captured at construction
+ * and events fired after the SDK loads are silently dropped:
+ *
+ * ```ts
+ * const rudderTyper = new RudderTyper(() => window.rudderanalytics);
+ * ```
  */
 export class RudderTyper {
-    private readonly analytics: RudderAnalytics;
+    private readonly resolveAnalytics: () => RudderAnalytics;
 
-    constructor(analytics: RudderAnalytics) {
-        this.analytics = analytics;
+    /**
+     * @param analytics - a RudderAnalytics instance, or a function that returns the
+     * current instance. Prefer the function form in the browser so a lazily-loaded
+     * SDK is resolved on every call rather than captured once at construction.
+     */
+    constructor(analytics: RudderAnalytics | (() => RudderAnalytics)) {
+        this.resolveAnalytics = typeof analytics === "function" ? analytics : () => analytics;
+    }
+
+    private get analytics(): RudderAnalytics {
+        return this.resolveAnalytics();
     }
 
     public group(


### PR DESCRIPTION
**Draft / RFC.** Opens the design discussion on making v2 backwards compatible with the npm `rudder-typer` v1 module. Stacked on #681 (the lazy-instance fix) — review that first; the diff here is only the compat layer.

### Why
Migrating an instrumented app from v1 → v2 is not a drop-in today: every call site is renamed (`sourceCreated` → `trackSourceCreated`), the module of free functions becomes a class you instantiate, type names change, and `setRudderTyperOptions()` is gone. The DX of the v2 class + `track` prefix is genuinely better and I don't want to change it — but the deployed footprint of v1-generated instrumentation is much larger than the set of teams actively regenerating today, so every one of those consumers eventually hits this rename. A drop-in compat path avoids forcing a codemod on them.

### What this does
Adds `--option v1Compat=true` (off by default). When on, the generated file additionally emits:

```ts
declare global { interface Window { rudderanalytics: RudderAnalytics; } }

const rudderTyperV1Compat = new RudderTyper(() => window.rudderanalytics);
export const userSignedUp = rudderTyperV1Compat.trackUserSignedUp.bind(rudderTyperV1Compat);
export const identify     = rudderTyperV1Compat.identify.bind(rudderTyperV1Compat);
// ...
```

Un-prefixed free functions, bound to a default client that lazily resolves `window.rudderanalytics`. Same imports and call-site shape as v1 → genuine drop-in, no codemod. Reuses the resolver from #681, so it inherits the event-drop fix.

**Not the default**, by design — it's meant to be surfaced through the migration guide, so new adopters get the clean class API and migrating v1 consumers opt in.

### Open questions (why this is a draft)
1. **Collisions.** Un-prefixing track events can collide with `identify`/`page`/`group` or with each other. v1 had the same risk; do we detect and fail loud, or document?
2. **`.bind` overload narrowing.** `.bind` narrows the overloaded singletons (identify/page/group) to a single signature. If we want full overload fidelity we'd emit wrapper functions instead — more template, better types.
3. **`setRudderTyperOptions()` parity** — worth re-adding for true drop-in, or leave out?
4. **TS validation.** Go generation + unit tests pass (`TestGenerateV1CompatIsOptIn`); I have **not** run the docker `typer-typescript-validate` (tsc) step against the compat output yet.

### Test
`go test ./cli/internal/typer/...` and `go vet` pass. `TestGenerateV1CompatIsOptIn` asserts the layer is off by default and, when on, emits the un-prefixed exports bound to the lazy default client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)