### PR TITLE
feat(cli): accounts provider import + export with generic secret tokenization (DEX-460)

### DIFF
--- a/cli/internal/providers/accounts/crud_test.go
+++ b/cli/internal/providers/accounts/crud_test.go
@@ -20,6 +20,8 @@ type mockStore struct {
 	updateReq   *client.UpdateAccountRequest
 	updateResp  *client.Account
 	deleteID    string
+	getID       string
+	getResp     *client.Account
 	setExtCalls []setExtCall
 	listOpts    *client.ListAccountsOptions
 	listResp    []client.Account
@@ -41,8 +43,9 @@ func (m *mockStore) Delete(_ context.Context, id string) error {
 	return m.err
 }
 
-func (m *mockStore) Get(_ context.Context, _ string) (*client.Account, error) {
-	return nil, m.err
+func (m *mockStore) Get(_ context.Context, id string) (*client.Account, error) {
+	m.getID = id
+	return m.getResp, m.err
 }
 
 func (m *mockStore) ListAll(_ context.Context, opts ...client.ListAccountsOption) ([]client.Account, error) {
@@ -117,6 +120,33 @@ func TestUpdateFullReplaces(t *testing.T) {
 	assert.Equal(t, "a", m.updateReq.Name)
 	assert.JSONEq(t, `{"project":"p2"}`, string(m.updateReq.Options))
 	assert.JSONEq(t, `{"credentials":"newcreds"}`, string(m.updateReq.Secret))
+}
+
+func TestImportLinksExternalIDAndFullReplaces(t *testing.T) {
+	m := &mockStore{
+		getResp:    &client.Account{ID: "remote-uuid"},
+		updateResp: &client.Account{ID: "remote-uuid"},
+	}
+	h := &HandlerImpl{store: m}
+	cred := secret.New("bq-creds")
+
+	st, err := h.Import(context.Background(), &AccountResource{
+		ID:                    "lovable-prod-bq",
+		AccountDefinitionName: "SOURCE_BIGQUERY",
+		Options:               map[string]any{"project": "p1"},
+		Credentials:           &cred,
+	}, "remote-uuid")
+	require.NoError(t, err)
+	assert.Equal(t, &AccountState{ID: "remote-uuid"}, st)
+
+	assert.Equal(t, "remote-uuid", m.getID)
+	require.Len(t, m.setExtCalls, 1)
+	assert.Equal(t, setExtCall{id: "remote-uuid", externalID: "lovable-prod-bq"}, m.setExtCalls[0])
+
+	assert.Equal(t, "remote-uuid", m.updateID)
+	assert.Equal(t, "lovable-prod-bq", m.updateReq.Name)
+	assert.JSONEq(t, `{"project":"p1"}`, string(m.updateReq.Options))
+	assert.JSONEq(t, `{"credentials":"bq-creds"}`, string(m.updateReq.Secret))
 }
 
 func TestDeleteUsesRemoteID(t *testing.T) {

--- a/cli/internal/providers/accounts/export_test.go
+++ b/cli/internal/providers/accounts/export_test.go
@@ -1,0 +1,103 @@
+package accounts
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/rudderlabs/rudder-iac/api/client"
+	"github.com/rudderlabs/rudder-iac/cli/internal/provider/handler"
+	"github.com/rudderlabs/rudder-iac/cli/internal/provider/handler/export"
+	"github.com/rudderlabs/rudder-iac/cli/internal/varsubst"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+// enableVarSubstitution turns on the experimental gate so WithVariableName is
+// honoured and secrets export as "{{ .VAR }}" tokens rather than masked literals.
+func enableVarSubstitution(t *testing.T) {
+	t.Helper()
+	prevExp, prevFlag := viper.Get("experimental"), viper.Get("flags.enableVarSubstitution")
+	viper.Set("experimental", true)
+	viper.Set("flags.enableVarSubstitution", true)
+	t.Cleanup(func() {
+		viper.Set("experimental", prevExp)
+		viper.Set("flags.enableVarSubstitution", prevFlag)
+	})
+}
+
+// exportHandler builds a handler with the declared credentials secret field
+// injected, mirroring how NewHandler wires the strategy in production.
+func exportHandler() *HandlerImpl {
+	h := &HandlerImpl{}
+	h.SingleSpecExportStrategy = &export.SingleSpecExportStrategy[accountsExportSpec, RemoteAccount]{Handler: h}
+	h.SetSecretFields([]handler.SecretField{{JSONName: bigQuerySecretField}})
+	return h
+}
+
+func remoteAccount(id, externalID, workspaceID string, options json.RawMessage) *RemoteAccount {
+	a := &client.Account{ID: id, ExternalID: externalID, WorkspaceID: workspaceID, Options: options}
+	a.Definition.Name = bigQueryDefinition
+	return &RemoteAccount{Account: a}
+}
+
+func TestFormatForExportTokenizesCredentialsAndNeverLeaks(t *testing.T) {
+	enableVarSubstitution(t)
+
+	// The remote deliberately carries a "credentials" key in its options with a
+	// sentinel value: even if a real secret ever rode along in options, the flat
+	// config's credentials must always be the token, never that literal.
+	h := exportHandler()
+	remotes := map[string]*RemoteAccount{
+		"lovable-prod-bq": remoteAccount("remote-1", "lovable-prod-bq", "ws-1",
+			json.RawMessage(`{"project":"p1","credentials":"SUPER-SECRET-SENTINEL"}`)),
+	}
+
+	entities, entries, err := h.FormatForExport(remotes, nil, nil)
+	require.NoError(t, err)
+	require.Len(t, entities, 1)
+	assert.Equal(t, "accounts/accounts.yaml", entities[0].RelativePath)
+
+	require.Len(t, entries, 1)
+	assert.Equal(t, "ws-1", entries[0].WorkspaceID)
+	assert.Equal(t, "account:lovable-prod-bq", entries[0].URN)
+	assert.Equal(t, "remote-1", entries[0].RemoteID)
+
+	out, err := yaml.Marshal(entities[0].Content)
+	require.NoError(t, err)
+	rendered := string(out)
+
+	assert.Contains(t, rendered, "{{ .ACCOUNT_LOVABLE_PROD_BQ_CREDENTIALS }}",
+		"credentials must export as a per-account variable token")
+	assert.NotContains(t, rendered, "SUPER-SECRET-SENTINEL",
+		"a secret value carried in options must never reach the exported spec")
+	assert.NotContains(t, rendered, "(unknown)",
+		"the secret must be tokenized, not fall back to a masked literal")
+	assert.Contains(t, rendered, "p1", "non-secret options must round-trip")
+
+	// The generic var-file scaffolder derives placeholder keys by scanning the
+	// generated content for tokens; assert the credentials variable is discoverable.
+	assert.Contains(t, varsubst.ExtractVariableNames(out), "ACCOUNT_LOVABLE_PROD_BQ_CREDENTIALS")
+}
+
+func TestFormatForExportGivesEachAccountADistinctVariable(t *testing.T) {
+	enableVarSubstitution(t)
+
+	h := exportHandler()
+	remotes := map[string]*RemoteAccount{
+		"acct-a": remoteAccount("remote-a", "acct-a", "ws-1", json.RawMessage(`{}`)),
+		"acct-b": remoteAccount("remote-b", "acct-b", "ws-1", json.RawMessage(`{}`)),
+	}
+
+	entities, _, err := h.FormatForExport(remotes, nil, nil)
+	require.NoError(t, err)
+	require.Len(t, entities, 1)
+
+	out, err := yaml.Marshal(entities[0].Content)
+	require.NoError(t, err)
+
+	names := varsubst.ExtractVariableNames(out)
+	assert.Contains(t, names, "ACCOUNT_ACCT_A_CREDENTIALS")
+	assert.Contains(t, names, "ACCOUNT_ACCT_B_CREDENTIALS")
+}

--- a/cli/internal/providers/accounts/handler.go
+++ b/cli/internal/providers/accounts/handler.go
@@ -7,10 +7,8 @@ import (
 	"regexp"
 
 	"github.com/rudderlabs/rudder-iac/api/client"
-	"github.com/rudderlabs/rudder-iac/cli/internal/namer"
-	"github.com/rudderlabs/rudder-iac/cli/internal/project/importmanifest"
-	"github.com/rudderlabs/rudder-iac/cli/internal/project/writer"
 	"github.com/rudderlabs/rudder-iac/cli/internal/provider/handler"
+	"github.com/rudderlabs/rudder-iac/cli/internal/provider/handler/export"
 	"github.com/rudderlabs/rudder-iac/cli/internal/resolver"
 	"github.com/rudderlabs/rudder-iac/cli/internal/secret"
 )
@@ -51,13 +49,19 @@ var HandlerMetadata = handler.HandlerMetadata{
 }
 
 // HandlerImpl provides the account-specific pieces the BaseHandler composes.
+// It embeds the single-spec export strategy so export (one `kind: accounts`
+// file) and generic secret tokenization come from the framework; the strategy
+// also carries the declared secret fields BaseHandler injects via SetSecretFields.
 type HandlerImpl struct {
+	*export.SingleSpecExportStrategy[accountsExportSpec, RemoteAccount]
 	store AccountStore
 }
 
 // NewHandler builds the account BaseHandler around the given store.
 func NewHandler(store AccountStore) *AccountHandler {
-	return handler.NewHandler(&HandlerImpl{store: store})
+	h := &HandlerImpl{store: store}
+	h.SingleSpecExportStrategy = &export.SingleSpecExportStrategy[accountsExportSpec, RemoteAccount]{Handler: h}
+	return handler.NewHandler(h)
 }
 
 func (h *HandlerImpl) Metadata() handler.HandlerMetadata {
@@ -221,18 +225,68 @@ func (h *HandlerImpl) MapRemoteToState(remote *RemoteAccount, urnResolver handle
 	return res, state, nil
 }
 
-// --- Import + export: stubbed here; implemented in DEX-460. ---
-
+// Import claims an existing remote account for this project: it links the remote
+// to the spec id via externalId, then full-replaces the account with the spec's
+// config so the imported resource immediately matches what the user declared. The
+// next apply then reconciles it like any managed account.
 func (h *HandlerImpl) Import(ctx context.Context, data *AccountResource, remoteId string) (*AccountState, error) {
-	return nil, fmt.Errorf("accounts: Import not implemented (DEX-460)")
+	remote, err := h.store.Get(ctx, remoteId)
+	if err != nil {
+		return nil, fmt.Errorf("getting account %s: %w", remoteId, err)
+	}
+
+	if err := h.store.SetExternalID(ctx, remote.ID, data.ID); err != nil {
+		return nil, fmt.Errorf("claiming external id for account %q: %w", data.ID, err)
+	}
+
+	options, secretPayload, err := splitConfig(data)
+	if err != nil {
+		return nil, err
+	}
+
+	updated, err := h.store.Update(ctx, remote.ID, &client.UpdateAccountRequest{
+		Name:    data.ID,
+		Options: options,
+		Secret:  secretPayload,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("updating account %q: %w", data.ID, err)
+	}
+
+	return &AccountState{ID: updated.ID}, nil
 }
 
-func (h *HandlerImpl) FormatForExport(
-	collection map[string]*RemoteAccount,
-	idNamer namer.Namer,
-	inputResolver resolver.ReferenceResolver,
-) ([]writer.FormattableEntity, []importmanifest.ImportEntry, error) {
-	return nil, nil, fmt.Errorf("accounts: FormatForExport not implemented (DEX-460)")
+// MapRemoteToSpec builds the single `kind: accounts` spec from the managed
+// remotes, one item per account keyed by externalId. Credentials is a placeholder
+// (a remote never returns the real value); the framework's AttachSecretVariables
+// replaces it with a per-account "{{ .VAR }}" token before the spec is written.
+func (h *HandlerImpl) MapRemoteToSpec(
+	remotes map[string]*RemoteAccount,
+	_ resolver.ReferenceResolver,
+) (*export.SpecExportData[accountsExportSpec], error) {
+	items := make([]accountExportItem, 0, len(remotes))
+	for externalID, remote := range remotes {
+		var options map[string]any
+		if len(remote.Options) > 0 {
+			if err := json.Unmarshal(remote.Options, &options); err != nil {
+				return nil, fmt.Errorf("unmarshalling options for account %s: %w", remote.ID, err)
+			}
+		}
+
+		items = append(items, accountExportItem{
+			ID:                    externalID,
+			AccountDefinitionName: remote.Definition.Name,
+			Config: accountExportConfig{
+				Credentials: secret.NewUnknown(),
+				Options:     options,
+			},
+		})
+	}
+
+	return &export.SpecExportData[accountsExportSpec]{
+		RelativePath: "accounts/accounts.yaml",
+		Data:         &accountsExportSpec{Accounts: items},
+	}, nil
 }
 
 // splitConfig routes the flat config into the API's options (non-secret) and

--- a/cli/internal/providers/accounts/model.go
+++ b/cli/internal/providers/accounts/model.go
@@ -1,6 +1,8 @@
 package accounts
 
 import (
+	"encoding/json"
+
 	"github.com/rudderlabs/rudder-iac/api/client"
 	"github.com/rudderlabs/rudder-iac/cli/internal/provider/handler"
 	"github.com/rudderlabs/rudder-iac/cli/internal/secret"
@@ -45,6 +47,52 @@ type AccountResource struct {
 // AccountState is the computed output — the remote account id.
 type AccountState struct {
 	ID string
+}
+
+// --- Export spec shapes ---
+//
+// Export uses a struct (not the decode-side AccountSpec/AccountConfig, which
+// carry only mapstructure tags) so the framework's secret reflection
+// (AttachSecretVariables) can discover the credentials field by its `json`
+// name and type `secret.String`, replacing it with a "{{ .VAR }}" token. Item
+// ids carry a `json:"id"` tag too, so each account gets its own variable name.
+
+// accountsExportSpec is the `kind: accounts` spec produced on export — the
+// collection of accounts, mirroring AccountSpec but json-tagged for
+// serialization and secret discovery.
+type accountsExportSpec struct {
+	Accounts []accountExportItem `json:"accounts"`
+}
+
+// accountExportItem is one exported account. `id` is json-tagged so the secret
+// reflection derives a per-account variable name from it.
+type accountExportItem struct {
+	ID                    string              `json:"id"`
+	AccountDefinitionName string              `json:"accountDefinitionName"`
+	Config                accountExportConfig `json:"config"`
+}
+
+// accountExportConfig serializes back to the flat `config` block a user writes:
+// the secret `credentials` field alongside every non-secret option key. It
+// keeps Credentials as a named `secret.String` field (not a map value) so the
+// framework can find and tokenize it; Options is merged in by MarshalJSON since
+// encoding/json has no inline-map support.
+type accountExportConfig struct {
+	Credentials secret.String  `json:"credentials"`
+	Options     map[string]any `json:"-"`
+}
+
+// MarshalJSON flattens Options and Credentials into a single object so the
+// exported `config` round-trips to the flat form the decoder expects. Credentials
+// serializes through secret.String.MarshalJSON, emitting the "{{ .VAR }}" token
+// (or a masked literal when the substitution gate is off) — never the real value.
+func (c accountExportConfig) MarshalJSON() ([]byte, error) {
+	out := make(map[string]any, len(c.Options)+1)
+	for k, v := range c.Options {
+		out[k] = v
+	}
+	out["credentials"] = c.Credentials
+	return json.Marshal(out)
 }
 
 // RemoteAccount wraps the API account to implement the RemoteResource interface.


### PR DESCRIPTION
## 🔗 Ticket

[DEX-460](https://linear.app/rudderstack/issue/DEX-460/pr-5-rudder-iac-accounts-provider-import-export-var-file) — PR-5 · rudder-iac accounts provider: import + export + var-file scaffolding

_Stacked on #660 (DEX-459). Base is `feat/DEX-459-accounts-crud`._

---

## Summary

Completes the managed-resource surface of the accounts provider by implementing the two remaining `HandlerImpl` stubs — `Import` and `FormatForExport` — so `rudder-cli import workspace` scaffolds accounts and export never leaks secrets. Secret masking is done **through the DEX-457 BaseHandler framework** (generic secret-field support), not hand-rolled: the credentials field is emitted as a `{{ .VAR }}` token via the framework's `SingleSpecExportStrategy` + `AttachSecretVariables`.

---

## Changes

- **`Import`** — Get remote → `SetExternalID(remoteId, id)` to claim identity → full-replace `Update` with the spec's split options/secret. Mirrors the transformation import template. `Name: data.ID`, consistent with `Create`/`Update` (no import→apply churn).
- **`FormatForExport`** — `HandlerImpl` embeds the framework's `SingleSpecExportStrategy[accountsExportSpec, RemoteAccount]`; export produces one `accounts/accounts.yaml`. `MapRemoteToSpec` builds the collection with `credentials` as a placeholder that the framework tokenizes per-account.
- **Export spec shapes** (`accountsExportSpec`/`accountExportItem`/`accountExportConfig`) — json-tagged so the framework's secret reflection discovers `credentials` (type `secret.String`, `json:"credentials"`) and derives a per-account variable name from each item's `id`. `accountExportConfig.MarshalJSON` flattens options + the credentials token back into the flat `config` block.
- **Var-file scaffolding** — no accounts-specific code needed: the importer's `scaffoldSecretsVarFile` is already generic (scans generated entities for `{{ .VAR }}` tokens → `secrets.vars.yaml`).

---

## Testing

- **Unit** — `Import` test (mock store asserts Get + SetExternalID + Update + returned state). Export/no-leak tests: exported spec carries `{{ .VAR }}` tokens; a seeded `SUPER-SECRET-SENTINEL` in options is absent from the rendered spec; the masked `(unknown)` literal does not fall through (proving tokenization fired); two accounts get distinct variable names; the token is discoverable by `varsubst.ExtractVariableNames` (so the generic var-file scanner finds it).
- `go build ./...`, `go vet ./cli/internal/providers/accounts/...`, `make lint` (0 issues), and the full unit suite (excluding the live-backend `cli/tests`) — all green.
- The `cli/tests` import→apply→re-apply E2E is authored separately (Phase 5) and runs against a live stack.

---

## Risk / Impact

Low. Additive — completes two stubs; no change to Create/Update/Delete or the API client. Secret handling reuses the already-merged DEX-457 framework. The `credentials`-as-only-secret set is hardcoded for BigQuery this milestone (dynamic secret-field discovery is a tracked follow-up).

---

## Checklist

- [x] Ticket linked
- [x] Tests added/updated
- [x] No breaking changes
- [x] `make lint` + unit `make test` green