### PR TITLE
feat: addded support for source type gated path on the configproperties for a definition

### DIFF
--- a/cli/internal/providers/destination/definitions/converter/configproperty.go
+++ b/cli/internal/providers/destination/definitions/converter/configproperty.go
@@ -25,6 +25,10 @@ type ConfigProperty struct {
 // Gated restricts prop's local key to the given local source types. The
 // property must carry a LocalKey (i.e. not be a Discriminator); the registry
 // rejects gated properties without one at registration.
+//
+// We added this abstraction of gating because in future in validation layer of explicit connections,
+// we would need to identify the config keys which can only be added if a corresponding sourcetype
+// is connected to it.
 func Gated(prop ConfigProperty, sourceTypes ...string) ConfigProperty {
 	prop.SourceTypes = sourceTypes
 	return prop
@@ -44,6 +48,13 @@ func Simple(apiKey, localKey string, filters ...ValueFilter) ConfigProperty {
 		ToLocalFunc:   copyToLocal(apiKey, localKey),
 	}
 }
+
+// bucketName -> bucket_name ( Simple )
+// abcdef -> abc-> {def} ( ArrayWith ) ( )
+// abcghi -> abc-> {ghi}
+
+// skipWhilelistEvents > skip_list_events->white_listed
+// skipBlacklistEvents > skip_list_events->black_listed
 
 type ValueFilter func(a any) bool
 
@@ -353,4 +364,3 @@ func discriminatorValue(apiKey string, values DiscriminatorValues) FromLocalFunc
 		return config, nil
 	}
 }
-

--- a/cli/internal/providers/destination/definitions/converter/configproperty.go
+++ b/cli/internal/providers/destination/definitions/converter/configproperty.go
@@ -12,6 +12,22 @@ import (
 type ConfigProperty struct {
 	ToLocalFunc   ToLocalFunc
 	FromLocalFunc FromLocalFunc
+	// LocalKey is the gjson dot path of this property in local config
+	// (e.g. "webhook_url"). Empty for derived properties that have no
+	// single local key, such as Discriminator.
+	LocalKey string
+	// SourceTypes, when set via Gated, restricts LocalKey to destinations
+	// connected to one of these local source types. Empty means the key is
+	// allowed for every connected source type.
+	SourceTypes []string
+}
+
+// Gated restricts prop's local key to the given local source types. The
+// property must carry a LocalKey (i.e. not be a Discriminator); the registry
+// rejects gated properties without one at registration.
+func Gated(prop ConfigProperty, sourceTypes ...string) ConfigProperty {
+	prop.SourceTypes = sourceTypes
+	return prop
 }
 
 // FromLocalFunc modifies an API config JSON object using local config information.
@@ -23,6 +39,7 @@ type ToLocalFunc func(local, config string) (string, error)
 // Simple returns a ConfigProperty that maps an API config key to a local config key and vice versa.
 func Simple(apiKey, localKey string, filters ...ValueFilter) ConfigProperty {
 	return ConfigProperty{
+		LocalKey:      localKey,
 		FromLocalFunc: copyFromLocal(apiKey, localKey, filters...),
 		ToLocalFunc:   copyToLocal(apiKey, localKey),
 	}
@@ -54,6 +71,7 @@ func SkipZeroValue(a any) bool {
 // only if the provided condition is satisfied for that API config.
 func Conditional(apiKey, localKey string, condition ConfigConditionFunc) ConfigProperty {
 	return ConfigProperty{
+		LocalKey:      localKey,
 		FromLocalFunc: copyFromLocal(apiKey, localKey),
 		ToLocalFunc:   copyToLocalConditional(apiKey, localKey, condition),
 	}
@@ -85,6 +103,7 @@ type DiscriminatorValues map[string]any
 
 func ArrayWithStrings(rootAPIKey, nestedAPIField, localKey string) ConfigProperty {
 	return ConfigProperty{
+		LocalKey: localKey,
 		FromLocalFunc: func(config, local string) (string, error) {
 			result := config
 			v := gjson.Get(local, localKey)
@@ -153,6 +172,7 @@ func ArrayWithObjects(rootAPIKey, localKey string, fields map[string]any) Config
 	inverseFields := GetInverseFields(fields)
 
 	return ConfigProperty{
+		LocalKey: localKey,
 		FromLocalFunc: func(config, local string) (string, error) {
 			result := config
 			v := gjson.Get(local, localKey)

--- a/cli/internal/providers/destination/definitions/converter/gated_test.go
+++ b/cli/internal/providers/destination/definitions/converter/gated_test.go
@@ -1,0 +1,51 @@
+package converter_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions/converter"
+)
+
+func TestConstructorsPopulateLocalKey(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		prop     converter.ConfigProperty
+		localKey string
+	}{
+		{"Simple", converter.Simple("apiKey", "api_key"), "api_key"},
+		{"Conditional", converter.Conditional("apiKey", "api_key", converter.Equals("k", "v")), "api_key"},
+		{"ArrayWithStrings", converter.ArrayWithStrings("root", "nested", "items"), "items"},
+		{"ArrayWithObjects", converter.ArrayWithObjects("root", "objects", map[string]any{"a": "b"}), "objects"},
+		{"Discriminator", converter.Discriminator("apiKey", converter.DiscriminatorValues{"k": "v"}), ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.localKey, tc.prop.LocalKey)
+			assert.Empty(t, tc.prop.SourceTypes)
+		})
+	}
+}
+
+func TestGatedSetsSourceTypesAndPreservesBehavior(t *testing.T) {
+	t.Parallel()
+
+	prop := converter.Gated(converter.Simple("apiKey", "api_key"), "web", "android")
+
+	assert.Equal(t, "api_key", prop.LocalKey)
+	assert.Equal(t, []string{"web", "android"}, prop.SourceTypes)
+
+	api, err := prop.FromLocalFunc(`{}`, `{ "api_key": "123" }`)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{ "apiKey": "123" }`, api)
+
+	local, err := prop.ToLocalFunc(`{}`, `{ "apiKey": "123" }`)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{ "api_key": "123" }`, local)
+}

--- a/cli/internal/providers/destination/definitions/definition.go
+++ b/cli/internal/providers/destination/definitions/definition.go
@@ -40,6 +40,9 @@ type ConfigError struct {
 type RegisteredDefinition struct {
 	*DestinationDefinition
 	configType reflect.Type
+	// keyPathSourceTypes is the reverse index of gated properties:
+	// local config keypath (JSON pointer) -> source types entitled to it.
+	keyPathSourceTypes map[string][]string
 }
 
 func (d *RegisteredDefinition) ValidateConfig(config map[string]any) []ConfigError {
@@ -86,25 +89,51 @@ func (d *RegisteredDefinition) SourceTypeConfigKeys() []string {
 	return append([]string(nil), sourceTypeConfigKeys...)
 }
 
+// GatedKeyPaths returns local config keypaths (JSON pointer, e.g.
+// "/event_upload_period_millis") mapped to the source types entitled to use
+// them. Keypaths absent from the map are default keys, allowed for every
+// connected source type.
+func (d *RegisteredDefinition) GatedKeyPaths() map[string][]string {
+	out := make(
+		map[string][]string,
+		len(d.keyPathSourceTypes),
+	)
+
+	for keyPath, sourceTypes := range d.keyPathSourceTypes {
+		out[keyPath] = append([]string(nil), sourceTypes...)
+	}
+
+	return out
+}
+
 func newRegisteredDefinition(def *DestinationDefinition) (*RegisteredDefinition, error) {
 	if def.NewConfig == nil {
 		return nil, fmt.Errorf("NewConfig is required")
 	}
 
-	sample := def.NewConfig()
-	configType := reflect.TypeOf(sample)
+	var (
+		sample     = def.NewConfig()
+		configType = reflect.TypeOf(sample)
+	)
+
 	if configType == nil || configType.Kind() != reflect.Pointer || configType.Elem().Kind() != reflect.Struct {
 		return nil, fmt.Errorf("NewConfig must return a pointer to struct")
 	}
 	configType = configType.Elem()
 
 	if err := validateConsentConfigModel(def, configType); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("validating consent config model: %w", err)
+	}
+
+	keyPathSourceTypes, err := buildGatedKeyPaths(def, configType)
+	if err != nil {
+		return nil, fmt.Errorf("building gated key paths: %w", err)
 	}
 
 	return &RegisteredDefinition{
 		DestinationDefinition: def,
 		configType:            configType,
+		keyPathSourceTypes:    keyPathSourceTypes,
 	}, nil
 }
 

--- a/cli/internal/providers/destination/definitions/gatedkeys.go
+++ b/cli/internal/providers/destination/definitions/gatedkeys.go
@@ -1,0 +1,75 @@
+package definitions
+
+import (
+	"fmt"
+	"reflect"
+	"slices"
+	"strings"
+)
+
+// buildGatedKeyPaths derives the reverse index of source-type-gated config
+// properties (keypath -> entitled source types), failing on definitions that
+// gate unsupported source types or keys absent from the config model.
+func buildGatedKeyPaths(def *DestinationDefinition, configType reflect.Type) (map[string][]string, error) {
+	index := make(map[string][]string)
+
+	for _, prop := range def.Properties {
+		if len(prop.SourceTypes) == 0 {
+			continue
+		}
+
+		if prop.LocalKey == "" {
+			return nil, fmt.Errorf("gated config property has no local key")
+		}
+
+		for _, sourceType := range prop.SourceTypes {
+			if !slices.Contains(def.SourceTypes, sourceType) {
+				return nil, fmt.Errorf("config key %q gated on unsupported source type %q", prop.LocalKey, sourceType)
+			}
+		}
+
+		if !configStructHasKeyPath(configType, prop.LocalKey) {
+			return nil, fmt.Errorf("gated config key %q does not resolve to a config model field", prop.LocalKey)
+		}
+
+		keyPath := localKeyToPointer(prop.LocalKey)
+		if _, exists := index[keyPath]; exists {
+			return nil, fmt.Errorf("duplicate gated config key %q", prop.LocalKey)
+		}
+		index[keyPath] = append([]string(nil), prop.SourceTypes...)
+	}
+
+	return index, nil
+}
+
+// localKeyToPointer converts a gjson dot path over local keys to the JSON
+// pointer form used by ConfigError paths ("a.b" -> "/a/b").
+func localKeyToPointer(localKey string) string {
+	return strings.ReplaceAll(localKey, ".", "/")
+}
+
+func configStructHasKeyPath(typ reflect.Type, localKey string) bool {
+	current := derefType(typ)
+	for _, segment := range strings.Split(localKey, ".") {
+		current = elemStructType(current)
+		if current == nil || current.Kind() != reflect.Struct {
+			return false
+		}
+		field, ok := structFieldsByMapstructureTag(current)[segment]
+		if !ok {
+			return false
+		}
+		current = derefType(field.Type)
+	}
+	return true
+}
+
+// elemStructType unwraps slice/array/map layers so keypaths address fields of
+// collection elements (e.g. "headers.to" on []webhookHeader).
+func elemStructType(typ reflect.Type) reflect.Type {
+	typ = derefType(typ)
+	for typ != nil && (typ.Kind() == reflect.Slice || typ.Kind() == reflect.Array || typ.Kind() == reflect.Map) {
+		typ = derefType(typ.Elem())
+	}
+	return typ
+}

--- a/cli/internal/providers/destination/definitions/gatedkeys.go
+++ b/cli/internal/providers/destination/definitions/gatedkeys.go
@@ -43,7 +43,7 @@ func buildGatedKeyPaths(def *DestinationDefinition, configType reflect.Type) (ma
 }
 
 // localKeyToPointer converts a gjson dot path over local keys to the JSON
-// pointer form used by ConfigError paths ("a.b" -> "/a/b").
+// pointer form used by ConfigError paths ("a.b" -> "a/b").
 func localKeyToPointer(localKey string) string {
 	return strings.ReplaceAll(localKey, ".", "/")
 }

--- a/cli/internal/providers/destination/definitions/gatedkeys_test.go
+++ b/cli/internal/providers/destination/definitions/gatedkeys_test.go
@@ -1,0 +1,145 @@
+package definitions
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions/converter"
+)
+
+func TestGatedKeyPaths(t *testing.T) {
+	t.Parallel()
+
+	def := GA4TestDefinition()
+	def.Properties = []converter.ConfigProperty{
+		converter.Simple("apiSecret", "api_secret"),
+		converter.Gated(converter.Simple("measurementId", "measurement_id"), "web"),
+		converter.Gated(converter.Simple("debugMode", "debug_mode"), "web", "android"),
+	}
+
+	registered, err := newRegisteredDefinition(def)
+	require.NoError(t, err)
+
+	assert.Equal(t, map[string][]string{
+		"measurement_id": {"web"},
+		"debug_mode":     {"web", "android"},
+	}, registered.GatedKeyPaths())
+}
+
+func TestGatedKeyPathsReturnsCopy(t *testing.T) {
+	t.Parallel()
+
+	def := GA4TestDefinition()
+	def.Properties = []converter.ConfigProperty{
+		converter.Gated(converter.Simple("measurementId", "measurement_id"), "web"),
+	}
+
+	registered, err := newRegisteredDefinition(def)
+	require.NoError(t, err)
+
+	mutated := registered.GatedKeyPaths()
+	mutated["measurement_id"][0] = "mutated"
+	delete(mutated, "measurement_id")
+
+	assert.Equal(t, map[string][]string{"measurement_id": {"web"}}, registered.GatedKeyPaths())
+}
+
+func TestGatedKeyPathsEmptyWithoutGatedProperties(t *testing.T) {
+	t.Parallel()
+
+	registered, err := newRegisteredDefinition(GA4TestDefinition())
+	require.NoError(t, err)
+	assert.Empty(t, registered.GatedKeyPaths())
+}
+
+func TestGatedKeyPathsNestedKey(t *testing.T) {
+	t.Parallel()
+
+	def := GA4TestDefinition()
+	def.Properties = []converter.ConfigProperty{
+		converter.Gated(converter.Simple("connectionMode.web", "connection_mode.web"), "web"),
+	}
+
+	registered, err := newRegisteredDefinition(def)
+	require.NoError(t, err)
+
+	assert.Equal(t, map[string][]string{
+		"connection_mode/web": {"web"},
+	}, registered.GatedKeyPaths())
+}
+
+func TestGatedKeyPathsErrors(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name       string
+		properties []converter.ConfigProperty
+		errMessage string
+	}{
+		{
+			name: "unsupported source type",
+			properties: []converter.ConfigProperty{
+				converter.Gated(converter.Simple("measurementId", "measurement_id"), "ios"),
+			},
+			errMessage: `config key "measurement_id" gated on unsupported source type "ios"`,
+		},
+		{
+			name: "key not on config model",
+			properties: []converter.ConfigProperty{
+				converter.Gated(converter.Simple("unknownKey", "unknown_key"), "web"),
+			},
+			errMessage: `gated config key "unknown_key" does not resolve to a config model field`,
+		},
+		{
+			name: "gated discriminator has no local key",
+			properties: []converter.ConfigProperty{
+				converter.Gated(converter.Discriminator("apiKey", converter.DiscriminatorValues{"k": "v"}), "web"),
+			},
+			errMessage: "gated config property has no local key",
+		},
+		{
+			name: "duplicate gated key",
+			properties: []converter.ConfigProperty{
+				converter.Gated(converter.Simple("measurementId", "measurement_id"), "web"),
+				converter.Gated(converter.Simple("measurementId", "measurement_id"), "android"),
+			},
+			errMessage: `duplicate gated config key "measurement_id"`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			def := GA4TestDefinition()
+			def.Properties = tc.properties
+
+			_, err := newRegisteredDefinition(def)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.errMessage)
+		})
+	}
+}
+
+func TestConfigStructHasKeyPathThroughCollections(t *testing.T) {
+	t.Parallel()
+
+	type header struct {
+		From string `mapstructure:"from"`
+		To   string `mapstructure:"to"`
+	}
+	type config struct {
+		Headers []header          `mapstructure:"headers"`
+		Labels  map[string]header `mapstructure:"labels"`
+	}
+
+	typ := reflect.TypeOf(config{})
+
+	assert.True(t, configStructHasKeyPath(typ, "headers.to"))
+	assert.True(t, configStructHasKeyPath(typ, "labels.from"))
+	assert.False(t, configStructHasKeyPath(typ, "headers.missing"))
+	assert.False(t, configStructHasKeyPath(typ, "missing"))
+}


### PR DESCRIPTION
Scanned-by: gitleaks 8.30.0

## 🔗 Ticket

Resolves [DEX-537](https://linear.app/rudderstack/issue/DEX-537/handle-gated-key-paths-by-source-types-on-the-destination-definition)

---

## Summary

Registering of config-properties on the destination definition now has ability to be gated by the source types meaning they only appear when destination is connected to  a valid source type. 

This relationship needs to be showcased in the destination definition in the registry.

