### PR TITLE
feat(cli): onboard bqstream destination definition

### DIFF
--- a/cli/internal/app/dependencies.go
+++ b/cli/internal/app/dependencies.go
@@ -16,6 +16,7 @@ import (
 	dgProvider "github.com/rudderlabs/rudder-iac/cli/internal/providers/datagraph"
 	destProvider "github.com/rudderlabs/rudder-iac/cli/internal/providers/destination"
 	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions"
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions/bqstream"
 	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions/s3"
 	esProvider "github.com/rudderlabs/rudder-iac/cli/internal/providers/event-stream"
 	"github.com/rudderlabs/rudder-iac/cli/internal/providers/retl"
@@ -247,6 +248,9 @@ func newDestinationRegistry(cfg config.Config) (*definitions.Registry, error) {
 	}
 	if err := registry.Register(s3.NewDefinition()); err != nil {
 		return nil, fmt.Errorf("registering s3 destination definition: %w", err)
+	}
+	if err := registry.Register(bqstream.NewDefinition()); err != nil {
+		return nil, fmt.Errorf("registering bqstream destination definition: %w", err)
 	}
 	return registry, nil
 }

--- a/cli/internal/app/dependencies_test.go
+++ b/cli/internal/app/dependencies_test.go
@@ -40,7 +40,7 @@ func TestNewDestinationRegistryRegistersS3WhenFlagEnabled(t *testing.T) {
 
 	registry, err := newDestinationRegistry(config.GetConfig())
 	require.NoError(t, err)
-	assert.Equal(t, []string{"s3"}, registry.SupportedTypes())
+	assert.Equal(t, []string{"bqstream", "s3"}, registry.SupportedTypes())
 }
 
 func TestNewDestinationRegistryEmptyWhenFlagDisabled(t *testing.T) {

--- a/cli/internal/providers/destination/definitions/bqstream/definition.go
+++ b/cli/internal/providers/destination/definitions/bqstream/definition.go
@@ -1,0 +1,72 @@
+package bqstream
+
+import (
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions"
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions/common"
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions/converter"
+)
+
+// Source types from integrations-config destinations/bqstream/db-config.json
+// supportedSourceTypes, restricted to types the CLI event-stream provider owns.
+var sourceTypes = []string{
+	common.SourceTypeAndroid,
+	common.SourceTypeAndroidKotlin,
+	common.SourceTypeIOS,
+	common.SourceTypeIOSSwift,
+	common.SourceTypeWeb,
+	common.SourceTypeUnity,
+	common.SourceTypeReactNative,
+	common.SourceTypeFlutter,
+	common.SourceTypeCordova,
+	common.SourceTypeCloud,
+}
+
+var connectionModes = map[string][]string{
+	common.SourceTypeAndroid:       {"cloud"},
+	common.SourceTypeAndroidKotlin: {"cloud"},
+	common.SourceTypeIOS:           {"cloud"},
+	common.SourceTypeIOSSwift:      {"cloud"},
+	common.SourceTypeWeb:           {"cloud"},
+	common.SourceTypeUnity:         {"cloud"},
+	common.SourceTypeReactNative:   {"cloud"},
+	common.SourceTypeFlutter:       {"cloud"},
+	common.SourceTypeCordova:       {"cloud"},
+	common.SourceTypeCloud:         {"cloud"},
+}
+
+// bqstreamConfig is the local YAML config model. Field set mirrors
+// integrations-config destinations/bqstream defaultConfig; validation
+// constraints mirror schema.json required fields.
+type bqstreamConfig struct {
+	ProjectID         string                   `mapstructure:"project_id" validate:"required"`
+	DatasetID         string                   `mapstructure:"dataset_id" validate:"required"`
+	TableID           string                   `mapstructure:"table_id" validate:"required"`
+	InsertID          string                   `mapstructure:"insert_id"`
+	Credentials       string                   `mapstructure:"credentials" validate:"required"`
+	ConsentManagement common.ConsentManagement `mapstructure:"consent_management"`
+}
+
+// NewDefinition returns the BigQuery Stream destination definition.
+func NewDefinition() *definitions.DestinationDefinition {
+	properties := []converter.ConfigProperty{
+		converter.Simple("projectId", "project_id"),
+		converter.Simple("datasetId", "dataset_id"),
+		converter.Simple("tableId", "table_id"),
+		converter.Simple("insertId", "insert_id", converter.SkipZeroValue),
+		converter.Simple("credentials", "credentials"),
+	}
+	properties = append(properties, common.Properties(sourceTypes)...)
+
+	return &definitions.DestinationDefinition{
+		Type:       "bqstream",
+		APIType:    "BQSTREAM",
+		Version:    1,
+		Properties: properties,
+		SecretKeys: []string{"credentials"},
+		NewConfig: func() any {
+			return &bqstreamConfig{}
+		},
+		SourceTypes:     append([]string(nil), sourceTypes...),
+		ConnectionModes: connectionModes,
+	}
+}

--- a/cli/internal/providers/destination/definitions/bqstream/definition_test.go
+++ b/cli/internal/providers/destination/definitions/bqstream/definition_test.go
@@ -1,0 +1,287 @@
+package bqstream_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions"
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions/bqstream"
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions/testutil"
+)
+
+func TestNewDefinitionMetadata(t *testing.T) {
+	t.Parallel()
+
+	registry := definitions.NewRegistry()
+	require.NoError(t, registry.Register(bqstream.NewDefinition()))
+
+	registered, err := registry.Get("bqstream", 1)
+	require.NoError(t, err)
+
+	assert.Equal(t, "bqstream", registered.Type)
+	assert.Equal(t, "BQSTREAM", registered.APIType)
+	assert.Equal(t, int64(1), registered.Version)
+	assert.Equal(t, []string{"credentials"}, registered.SecretKeys())
+
+	expectedSourceTypes := []string{
+		"android", "android_kotlin", "ios", "ios_swift", "web",
+		"unity", "react_native", "flutter", "cordova", "cloud",
+	}
+	assert.Equal(t, expectedSourceTypes, registered.SupportedSourceTypes())
+
+	for _, sourceType := range expectedSourceTypes {
+		modes, err := registered.ConnectionModes(sourceType)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"cloud"}, modes)
+	}
+
+	assert.NotContains(t, registered.SupportedSourceTypes(), "amp")
+	assert.NotContains(t, registered.SupportedSourceTypes(), "shopify")
+	assert.NotContains(t, registered.SupportedSourceTypes(), "warehouse")
+
+	byAPI, err := registry.GetByAPIType("BQSTREAM", 1)
+	require.NoError(t, err)
+	assert.Equal(t, registered, byAPI)
+}
+
+func TestBQStreamConfigValidation(t *testing.T) {
+	t.Parallel()
+
+	registry := definitions.NewRegistry()
+	require.NoError(t, registry.Register(bqstream.NewDefinition()))
+	registered, err := registry.Get("bqstream", 1)
+	require.NoError(t, err)
+
+	minimalValid := map[string]any{
+		"project_id":  "my-gcp-project",
+		"dataset_id":  "my_dataset",
+		"table_id":    "my_table",
+		"credentials": `{"type":"service_account"}`,
+	}
+
+	t.Run("missing project_id", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{
+			"dataset_id":  "my_dataset",
+			"table_id":    "my_table",
+			"credentials": `{"type":"service_account"}`,
+		})
+		require.NotEmpty(t, errors)
+		assert.Equal(t, "/project_id", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "required")
+	})
+
+	t.Run("missing dataset_id", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{
+			"project_id":  "my-gcp-project",
+			"table_id":    "my_table",
+			"credentials": `{"type":"service_account"}`,
+		})
+		require.NotEmpty(t, errors)
+		assert.Equal(t, "/dataset_id", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "required")
+	})
+
+	t.Run("missing table_id", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{
+			"project_id":  "my-gcp-project",
+			"dataset_id":  "my_dataset",
+			"credentials": `{"type":"service_account"}`,
+		})
+		require.NotEmpty(t, errors)
+		assert.Equal(t, "/table_id", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "required")
+	})
+
+	t.Run("missing credentials", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{
+			"project_id": "my-gcp-project",
+			"dataset_id": "my_dataset",
+			"table_id":   "my_table",
+		})
+		require.NotEmpty(t, errors)
+		assert.Equal(t, "/credentials", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "required")
+	})
+
+	t.Run("valid minimal config", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(minimalValid)
+		assert.Empty(t, errors)
+	})
+
+	t.Run("valid full config with example values", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{
+			"project_id":  "my-gcp-project",
+			"dataset_id":  "my_dataset",
+			"table_id":    "my_table",
+			"insert_id":   "messageId",
+			"credentials": `{"type":"service_account","project_id":"my-gcp-project"}`,
+			"consent_management": map[string]any{
+				"web": []any{
+					map[string]any{
+						"provider": "oneTrust",
+						"consents": []any{"analytics"},
+					},
+				},
+			},
+		})
+		assert.Empty(t, errors)
+	})
+
+	t.Run("unknown key rejected", func(t *testing.T) {
+		t.Parallel()
+		cfg := map[string]any{
+			"project_id":  "my-gcp-project",
+			"dataset_id":  "my_dataset",
+			"table_id":    "my_table",
+			"credentials": `{"type":"service_account"}`,
+			"not_a_field": true,
+		}
+		errors := registered.ValidateConfig(cfg)
+		require.NotEmpty(t, errors)
+		assert.Equal(t, "/not_a_field", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "unknown config field")
+	})
+
+	t.Run("unsupported consent source rejected", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{
+			"project_id":  "my-gcp-project",
+			"dataset_id":  "my_dataset",
+			"table_id":    "my_table",
+			"credentials": `{"type":"service_account"}`,
+			"consent_management": map[string]any{
+				"warehouse": []any{},
+			},
+		})
+		require.Len(t, errors, 1)
+		assert.Equal(t, "/consent_management/warehouse", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "source type 'warehouse' is not supported")
+	})
+
+	t.Run("invalid consent provider rejected", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{
+			"project_id":  "my-gcp-project",
+			"dataset_id":  "my_dataset",
+			"table_id":    "my_table",
+			"credentials": `{"type":"service_account"}`,
+			"consent_management": map[string]any{
+				"ios_swift": []any{
+					map[string]any{"provider": "unknown"},
+				},
+			},
+		})
+		require.Len(t, errors, 1)
+		assert.Equal(t, "/consent_management/ios_swift/0/provider", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "'provider' must be one of")
+	})
+}
+
+func TestBQStreamConversionRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	def := bqstream.NewDefinition()
+	testutil.AssertConversion(t, def.Properties, []testutil.ConversionCase{
+		{
+			Name: "minimal required fields",
+			LocalJSON: `{
+				"project_id": "my-gcp-project",
+				"dataset_id": "my_dataset",
+				"table_id": "my_table",
+				"credentials": "{\"type\":\"service_account\"}"
+			}`,
+			APIJSON: `{
+				"projectId": "my-gcp-project",
+				"datasetId": "my_dataset",
+				"tableId": "my_table",
+				"credentials": "{\"type\":\"service_account\"}"
+			}`,
+		},
+		{
+			Name: "full TF fields",
+			LocalJSON: `{
+				"project_id": "my-gcp-project",
+				"dataset_id": "my_dataset",
+				"table_id": "my_table",
+				"insert_id": "messageId",
+				"credentials": "{\"type\":\"service_account\"}"
+			}`,
+			APIJSON: `{
+				"projectId": "my-gcp-project",
+				"datasetId": "my_dataset",
+				"tableId": "my_table",
+				"insertId": "messageId",
+				"credentials": "{\"type\":\"service_account\"}"
+			}`,
+		},
+		{
+			Name: "consent for web",
+			LocalJSON: `{
+				"project_id": "my-gcp-project",
+				"dataset_id": "my_dataset",
+				"table_id": "my_table",
+				"credentials": "{\"type\":\"service_account\"}",
+				"consent_management": {
+					"web": [
+						{
+							"provider": "oneTrust",
+							"resolution_strategy": "and",
+							"consents": ["analytics", "marketing"]
+						}
+					]
+				}
+			}`,
+			APIJSON: `{
+				"projectId": "my-gcp-project",
+				"datasetId": "my_dataset",
+				"tableId": "my_table",
+				"credentials": "{\"type\":\"service_account\"}",
+				"consentManagement": {
+					"web": [
+						{
+							"provider": "oneTrust",
+							"resolutionStrategy": "and",
+							"consents": [
+								{"consent": "analytics"},
+								{"consent": "marketing"}
+							]
+						}
+					]
+				}
+			}`,
+		},
+		{
+			Name: "consent source boundary mappings",
+			LocalJSON: `{
+				"project_id": "my-gcp-project",
+				"dataset_id": "my_dataset",
+				"table_id": "my_table",
+				"credentials": "{\"type\":\"service_account\"}",
+				"consent_management": {
+					"android_kotlin": [{"provider": "oneTrust"}],
+					"ios_swift": [{"provider": "ketch"}],
+					"react_native": [{"provider": "iubenda"}]
+				}
+			}`,
+			APIJSON: `{
+				"projectId": "my-gcp-project",
+				"datasetId": "my_dataset",
+				"tableId": "my_table",
+				"credentials": "{\"type\":\"service_account\"}",
+				"consentManagement": {
+					"androidKotlin": [{"provider": "oneTrust"}],
+					"iosSwift": [{"provider": "ketch"}],
+					"reactnative": [{"provider": "iubenda"}]
+				}
+			}`,
+		},
+	})
+}


### PR DESCRIPTION
## 🔗 Ticket

Resolves [DEX-495](https://linear.app/rudderstack/issue/DEX-495)

---

## Summary

Onboards the BigQuery Stream (`bqstream`) destination into the CLI destination definition registry so it can be managed via YAML specs under the destination-support experimental flag.

---

## Changes

- Added `bqstream` destination definition (`Type: bqstream`, `APIType: BQSTREAM`, `Version: 1`) with terraform-ported property mappings:
  - `project_id`, `dataset_id`, `table_id`, `insert_id` (optional), `credentials` (secret)
  - consent management via `common.Properties`
- Registered definition in `newDestinationRegistry` and updated `SupportedTypes` expectation (`bqstream`, `s3`)
- Unit tests for metadata, config validation (required fields, unknown keys, consent), and local↔API conversion round-trips

### Onboarding notes / discrepancies

- **Dropped source types** (CLI event-stream ownership, S3 precedent): `amp`, `shopify`, `warehouse`
- **Gated keys**: none — all mapped fields live in `defaultConfig`
- **SecretKeys**: `credentials` only (from db-config). Terraform also marks `project_id` as `Sensitive`; not treated as a CLI secret because it is absent from db-config `secretKeys`
- **Omitted terraform mappings**: `connectionMode.*` — handled by definition `ConnectionModes` + `common`, not per-property converters
- **schema.json**: required `projectId` / `datasetId` / `tableId` / `credentials`; `insertId` optional; no extra length/enum constraints beyond consent (via `common`)

### Example YAML

```yaml
version: rudder/v1
kind: destination
metadata:
  name: my-bqstream-destination
spec:
  id: my-bqstream-destination
  display_name: My BigQuery Stream Destination
  type: bqstream
  enabled: true
  definition_version: 1
  config:
    project_id: my-gcp-project
    dataset_id: my_dataset
    table_id: my_table
    insert_id: messageId
    credentials: '{"type":"service_account","project_id":"my-gcp-project"}'
```

Requires `experimental: true` + `flags.destinationSupport: true` in CLI config.

---

## Testing

- `go build ./...`
- `go test ./cli/internal/providers/destination/... ./cli/internal/app/...`
- `make lint`

---

## Risk / Impact

Low
Notes: additive registry entry behind experimental destination-support flag; no change to existing destination behavior.

---

## Checklist

- [x] Ticket linked
- [x] Tests added/updated
- [x] No breaking changes (or documented)


Made with [Cursor](https://cursor.com)