### PR TITLE
feat(cli): onboard snowflake destination definition

### DIFF
--- a/cli/internal/app/dependencies.go
+++ b/cli/internal/app/dependencies.go
@@ -17,6 +17,7 @@ import (
 	destProvider "github.com/rudderlabs/rudder-iac/cli/internal/providers/destination"
 	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions"
 	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions/s3"
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions/snowflake"
 	esProvider "github.com/rudderlabs/rudder-iac/cli/internal/providers/event-stream"
 	"github.com/rudderlabs/rudder-iac/cli/internal/providers/retl"
 	"github.com/rudderlabs/rudder-iac/cli/internal/providers/transformations"
@@ -247,6 +248,9 @@ func newDestinationRegistry(cfg config.Config) (*definitions.Registry, error) {
 	}
 	if err := registry.Register(s3.NewDefinition()); err != nil {
 		return nil, fmt.Errorf("registering s3 destination definition: %w", err)
+	}
+	if err := registry.Register(snowflake.NewDefinition()); err != nil {
+		return nil, fmt.Errorf("registering snowflake destination definition: %w", err)
 	}
 	return registry, nil
 }

--- a/cli/internal/app/dependencies_test.go
+++ b/cli/internal/app/dependencies_test.go
@@ -40,7 +40,7 @@ func TestNewDestinationRegistryRegistersS3WhenFlagEnabled(t *testing.T) {
 
 	registry, err := newDestinationRegistry(config.GetConfig())
 	require.NoError(t, err)
-	assert.Equal(t, []string{"s3"}, registry.SupportedTypes())
+	assert.Equal(t, []string{"s3", "snowflake"}, registry.SupportedTypes())
 }
 
 func TestNewDestinationRegistryEmptyWhenFlagDisabled(t *testing.T) {

--- a/cli/internal/providers/destination/definitions/snowflake/definition.go
+++ b/cli/internal/providers/destination/definitions/snowflake/definition.go
@@ -1,0 +1,166 @@
+package snowflake
+
+import (
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions"
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions/common"
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions/converter"
+)
+
+// Source types from integrations-config destinations/snowflake/db-config.json
+// supportedSourceTypes, restricted to types the CLI event-stream provider owns
+// (same set as S3).
+var sourceTypes = []string{
+	common.SourceTypeAndroid,
+	common.SourceTypeAndroidKotlin,
+	common.SourceTypeIOS,
+	common.SourceTypeIOSSwift,
+	common.SourceTypeWeb,
+	common.SourceTypeUnity,
+	common.SourceTypeReactNative,
+	common.SourceTypeFlutter,
+	common.SourceTypeCordova,
+	common.SourceTypeCloud,
+}
+
+var connectionModes = map[string][]string{
+	common.SourceTypeAndroid:       {"cloud"},
+	common.SourceTypeAndroidKotlin: {"cloud"},
+	common.SourceTypeIOS:           {"cloud"},
+	common.SourceTypeIOSSwift:      {"cloud"},
+	common.SourceTypeWeb:           {"cloud"},
+	common.SourceTypeUnity:         {"cloud"},
+	common.SourceTypeReactNative:   {"cloud"},
+	common.SourceTypeFlutter:       {"cloud"},
+	common.SourceTypeCordova:       {"cloud"},
+	common.SourceTypeCloud:         {"cloud"},
+}
+
+type syncConfig struct {
+	Frequency              string `mapstructure:"frequency" validate:"required,dynamic_or_oneof=5 15 30 60 180 360 720 1440"`
+	StartAt                string `mapstructure:"start_at" validate:"omitempty"`
+	ExcludeWindowStartTime string `mapstructure:"exclude_window_start_time" validate:"omitempty"`
+	ExcludeWindowEndTime   string `mapstructure:"exclude_window_end_time" validate:"omitempty"`
+}
+
+type roleBasedAuthConfig struct {
+	// Terraform local key is i_am_role_arn (not iam_role_arn).
+	IAMRoleARN string `mapstructure:"i_am_role_arn" validate:"required,min=1,max=100"`
+}
+
+type s3StorageConfig struct {
+	BucketName              string               `mapstructure:"bucket_name" validate:"required,min=1,max=100"`
+	AccessKeyID             string               `mapstructure:"access_key_id" validate:"required_with=AccessKey,excluded_with=RoleBasedAuthentication,omitempty,max=100"`
+	AccessKey               string               `mapstructure:"access_key" validate:"required_with=AccessKeyID,excluded_with=RoleBasedAuthentication,omitempty,max=100"`
+	EnableSSE               *bool                `mapstructure:"enable_sse"`
+	RoleBasedAuthentication *roleBasedAuthConfig `mapstructure:"role_based_authentication" validate:"excluded_with=AccessKeyID"`
+	StorageIntegration      string               `mapstructure:"storage_integration" validate:"omitempty,max=100"`
+}
+
+type gcpStorageConfig struct {
+	BucketName         string `mapstructure:"bucket_name" validate:"required,min=1,max=100"`
+	Credentials        string `mapstructure:"credentials" validate:"required,min=1"`
+	StorageIntegration string `mapstructure:"storage_integration" validate:"required,min=1,max=100"`
+}
+
+type azureStorageConfig struct {
+	ContainerName      string `mapstructure:"container_name" validate:"required,min=1,max=100"`
+	AccountName        string `mapstructure:"account_name" validate:"required,min=1,max=100"`
+	AccountKey         string `mapstructure:"account_key" validate:"required,min=1,max=100"`
+	StorageIntegration string `mapstructure:"storage_integration" validate:"required,min=1,max=100"`
+}
+
+// snowflakeConfig is the local YAML config model. Nested s3/gcp/azure/sync
+// blocks mirror terraform-provider-rudderstack destination_snowflake.go shape
+// (without TF list indices). Validation constraints come from schema.json.
+type snowflakeConfig struct {
+	Account              string                   `mapstructure:"account" validate:"required,min=1,max=100"`
+	Database             string                   `mapstructure:"database" validate:"required,min=1,max=100"`
+	Warehouse            string                   `mapstructure:"warehouse" validate:"required,min=1,max=100"`
+	User                 string                   `mapstructure:"user" validate:"required,min=1,max=100"`
+	UseKeyPairAuth       *bool                    `mapstructure:"use_key_pair_auth" validate:"required"`
+	Password             string                   `mapstructure:"password" validate:"required_if=UseKeyPairAuth false"`
+	PrivateKey           string                   `mapstructure:"private_key" validate:"required_if=UseKeyPairAuth true"`
+	PrivateKeyPassphrase string                   `mapstructure:"private_key_passphrase" validate:"omitempty,max=100"`
+	Role                 string                   `mapstructure:"role" validate:"omitempty,max=100"`
+	Namespace            string                   `mapstructure:"namespace" validate:"omitempty,max=64"`
+	Sync                 syncConfig               `mapstructure:"sync"`
+	SkipTracksTable      *bool                    `mapstructure:"skip_tracks_table"`
+	SkipUsersTable       *bool                    `mapstructure:"skip_users_table"`
+	PreferAppend         *bool                    `mapstructure:"prefer_append"`
+	JSONPaths            string                   `mapstructure:"json_paths" validate:"omitempty"`
+	ManualSync           *bool                    `mapstructure:"manual_sync"`
+	UseRudderStorage     *bool                    `mapstructure:"use_rudder_storage" validate:"required"`
+	AdditionalProperties *bool                    `mapstructure:"additional_properties"`
+	Prefix               string                   `mapstructure:"prefix" validate:"omitempty,max=100"`
+	S3                   *s3StorageConfig         `mapstructure:"s3"`
+	GCP                  *gcpStorageConfig        `mapstructure:"gcp"`
+	Azure                *azureStorageConfig      `mapstructure:"azure"`
+	ConsentManagement    common.ConsentManagement `mapstructure:"consent_management"`
+}
+
+// NewDefinition returns the Snowflake warehouse destination definition.
+func NewDefinition() *definitions.DestinationDefinition {
+	properties := []converter.ConfigProperty{
+		converter.Simple("account", "account"),
+		converter.Simple("database", "database"),
+		converter.Simple("warehouse", "warehouse"),
+		converter.Simple("user", "user"),
+		converter.Simple("useKeyPairAuth", "use_key_pair_auth"),
+		converter.Simple("password", "password", converter.SkipZeroValue),
+		converter.Simple("privateKey", "private_key", converter.SkipZeroValue),
+		converter.Simple("privateKeyPassphrase", "private_key_passphrase", converter.SkipZeroValue),
+		converter.Simple("role", "role", converter.SkipZeroValue),
+		converter.Simple("namespace", "namespace", converter.SkipZeroValue),
+		converter.Simple("syncFrequency", "sync.frequency"),
+		converter.Simple("syncStartAt", "sync.start_at", converter.SkipZeroValue),
+		converter.Simple("excludeWindow.excludeWindowStartTime", "sync.exclude_window_start_time", converter.SkipZeroValue),
+		converter.Simple("excludeWindow.excludeWindowEndTime", "sync.exclude_window_end_time", converter.SkipZeroValue),
+		converter.Simple("skipTracksTable", "skip_tracks_table", converter.SkipZeroValue),
+		converter.Simple("skipUsersTable", "skip_users_table", converter.SkipZeroValue),
+		converter.Simple("preferAppend", "prefer_append", converter.SkipZeroValue),
+		converter.Simple("jsonPaths", "json_paths", converter.SkipZeroValue),
+		converter.Simple("manualSync", "manual_sync", converter.SkipZeroValue),
+		converter.Simple("useRudderStorage", "use_rudder_storage"),
+		converter.Discriminator("cloudProvider", converter.DiscriminatorValues{
+			"s3":    "AWS",
+			"gcp":   "GCP",
+			"azure": "AZURE",
+		}),
+		converter.Simple("additionalProperties", "additional_properties", converter.SkipZeroValue),
+		converter.Conditional("bucketName", "s3.bucket_name", converter.Equals("cloudProvider", "AWS")),
+		converter.Simple("accessKeyID", "s3.access_key_id", converter.SkipZeroValue),
+		converter.Simple("accessKey", "s3.access_key", converter.SkipZeroValue),
+		converter.Simple("enableSSE", "s3.enable_sse", converter.SkipZeroValue),
+		converter.Simple("iamRoleARN", "s3.role_based_authentication.i_am_role_arn", converter.SkipZeroValue),
+		converter.Discriminator("roleBasedAuth", converter.DiscriminatorValues{
+			"s3.access_key":                false,
+			"s3.access_key_id":             false,
+			"s3.role_based_authentication": true,
+		}),
+		converter.Conditional("storageIntegration", "s3.storage_integration", converter.Equals("cloudProvider", "AWS")),
+		converter.Conditional("bucketName", "gcp.bucket_name", converter.Equals("cloudProvider", "GCP")),
+		converter.Simple("credentials", "gcp.credentials", converter.SkipZeroValue),
+		converter.Conditional("storageIntegration", "gcp.storage_integration", converter.Equals("cloudProvider", "GCP")),
+		converter.Simple("containerName", "azure.container_name", converter.SkipZeroValue),
+		converter.Simple("accountName", "azure.account_name", converter.SkipZeroValue),
+		converter.Simple("accountKey", "azure.account_key", converter.SkipZeroValue),
+		converter.Conditional("storageIntegration", "azure.storage_integration", converter.Equals("cloudProvider", "AZURE")),
+		converter.Simple("prefix", "prefix", converter.SkipZeroValue),
+	}
+	properties = append(properties, common.Properties(sourceTypes)...)
+
+	return &definitions.DestinationDefinition{
+		Type:       "snowflake",
+		APIType:    "SNOWFLAKE",
+		Version:    1,
+		Properties: properties,
+		// Only top-level string secrets; nested s3/gcp/azure secrets cannot be
+		// modeled by the CLI secret machinery (see onboarding report).
+		SecretKeys: []string{"password", "private_key", "private_key_passphrase"},
+		NewConfig: func() any {
+			return &snowflakeConfig{}
+		},
+		SourceTypes:     append([]string(nil), sourceTypes...),
+		ConnectionModes: connectionModes,
+	}
+}

--- a/cli/internal/providers/destination/definitions/snowflake/definition_test.go
+++ b/cli/internal/providers/destination/definitions/snowflake/definition_test.go
@@ -1,0 +1,634 @@
+package snowflake_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions"
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions/snowflake"
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions/testutil"
+)
+
+func TestNewDefinitionMetadata(t *testing.T) {
+	t.Parallel()
+
+	registry := definitions.NewRegistry()
+	require.NoError(t, registry.Register(snowflake.NewDefinition()))
+
+	registered, err := registry.Get("snowflake", 1)
+	require.NoError(t, err)
+
+	assert.Equal(t, "snowflake", registered.Type)
+	assert.Equal(t, "SNOWFLAKE", registered.APIType)
+	assert.Equal(t, int64(1), registered.Version)
+	assert.Equal(t, []string{"password", "private_key", "private_key_passphrase"}, registered.SecretKeys())
+
+	expectedSourceTypes := []string{
+		"android", "android_kotlin", "ios", "ios_swift", "web",
+		"unity", "react_native", "flutter", "cordova", "cloud",
+	}
+	assert.Equal(t, expectedSourceTypes, registered.SupportedSourceTypes())
+
+	for _, sourceType := range expectedSourceTypes {
+		modes, err := registered.ConnectionModes(sourceType)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"cloud"}, modes)
+	}
+
+	assert.NotContains(t, registered.SupportedSourceTypes(), "amp")
+	assert.NotContains(t, registered.SupportedSourceTypes(), "shopify")
+	assert.NotContains(t, registered.SupportedSourceTypes(), "cloud_source")
+	assert.NotContains(t, registered.SupportedSourceTypes(), "warehouse")
+	assert.Empty(t, registered.GatedKeyPaths())
+
+	byAPI, err := registry.GetByAPIType("SNOWFLAKE", 1)
+	require.NoError(t, err)
+	assert.Equal(t, registered, byAPI)
+}
+
+func TestSnowflakeConfigValidation(t *testing.T) {
+	t.Parallel()
+
+	registry := definitions.NewRegistry()
+	require.NoError(t, registry.Register(snowflake.NewDefinition()))
+	registered, err := registry.Get("snowflake", 1)
+	require.NoError(t, err)
+
+	minimalValid := map[string]any{
+		"account":            "xy12345.us-east-1",
+		"database":           "ANALYTICS",
+		"warehouse":          "COMPUTE_WH",
+		"user":               "rudder_user",
+		"use_key_pair_auth":  false,
+		"password":           "secret-password",
+		"use_rudder_storage": true,
+		"sync": map[string]any{
+			"frequency": "180",
+		},
+	}
+
+	t.Run("missing account", func(t *testing.T) {
+		t.Parallel()
+		cfg := copyConfig(minimalValid)
+		delete(cfg, "account")
+		errors := registered.ValidateConfig(cfg)
+		require.NotEmpty(t, errors)
+		assert.Equal(t, "/account", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "required")
+	})
+
+	t.Run("missing database", func(t *testing.T) {
+		t.Parallel()
+		cfg := copyConfig(minimalValid)
+		delete(cfg, "database")
+		errors := registered.ValidateConfig(cfg)
+		require.NotEmpty(t, errors)
+		assert.Equal(t, "/database", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "required")
+	})
+
+	t.Run("missing warehouse", func(t *testing.T) {
+		t.Parallel()
+		cfg := copyConfig(minimalValid)
+		delete(cfg, "warehouse")
+		errors := registered.ValidateConfig(cfg)
+		require.NotEmpty(t, errors)
+		assert.Equal(t, "/warehouse", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "required")
+	})
+
+	t.Run("missing user", func(t *testing.T) {
+		t.Parallel()
+		cfg := copyConfig(minimalValid)
+		delete(cfg, "user")
+		errors := registered.ValidateConfig(cfg)
+		require.NotEmpty(t, errors)
+		assert.Equal(t, "/user", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "required")
+	})
+
+	t.Run("missing sync frequency", func(t *testing.T) {
+		t.Parallel()
+		cfg := copyConfig(minimalValid)
+		cfg["sync"] = map[string]any{}
+		errors := registered.ValidateConfig(cfg)
+		require.NotEmpty(t, errors)
+		assert.Equal(t, "/sync/frequency", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "required")
+	})
+
+	t.Run("invalid sync frequency", func(t *testing.T) {
+		t.Parallel()
+		cfg := copyConfig(minimalValid)
+		cfg["sync"] = map[string]any{"frequency": "10"}
+		errors := registered.ValidateConfig(cfg)
+		require.NotEmpty(t, errors)
+		assert.Equal(t, "/sync/frequency", errors[0].Path)
+	})
+
+	t.Run("use_rudder_storage required", func(t *testing.T) {
+		t.Parallel()
+		cfg := copyConfig(minimalValid)
+		delete(cfg, "use_rudder_storage")
+		errors := registered.ValidateConfig(cfg)
+		require.NotEmpty(t, errors)
+		assert.Equal(t, "/use_rudder_storage", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "required")
+	})
+
+	t.Run("use_key_pair_auth required", func(t *testing.T) {
+		t.Parallel()
+		cfg := copyConfig(minimalValid)
+		delete(cfg, "use_key_pair_auth")
+		errors := registered.ValidateConfig(cfg)
+		require.NotEmpty(t, errors)
+		assert.Equal(t, "/use_key_pair_auth", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "required")
+	})
+
+	t.Run("password required when use_key_pair_auth false", func(t *testing.T) {
+		t.Parallel()
+		cfg := copyConfig(minimalValid)
+		delete(cfg, "password")
+		errors := registered.ValidateConfig(cfg)
+		require.NotEmpty(t, errors)
+		assert.Equal(t, "/password", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "required")
+	})
+
+	t.Run("private_key required when use_key_pair_auth true", func(t *testing.T) {
+		t.Parallel()
+		cfg := copyConfig(minimalValid)
+		cfg["use_key_pair_auth"] = true
+		delete(cfg, "password")
+		errors := registered.ValidateConfig(cfg)
+		require.NotEmpty(t, errors)
+		assert.Equal(t, "/private_key", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "required")
+	})
+
+	t.Run("valid minimal rudder storage password auth", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(copyConfig(minimalValid))
+		assert.Empty(t, errors)
+	})
+
+	t.Run("valid key pair auth", func(t *testing.T) {
+		t.Parallel()
+		cfg := copyConfig(minimalValid)
+		cfg["use_key_pair_auth"] = true
+		delete(cfg, "password")
+		cfg["private_key"] = "-----BEGIN PRIVATE KEY-----\nMIIE...\n-----END PRIVATE KEY-----"
+		cfg["private_key_passphrase"] = "pass"
+		errors := registered.ValidateConfig(cfg)
+		assert.Empty(t, errors)
+	})
+
+	t.Run("valid s3 role based auth", func(t *testing.T) {
+		t.Parallel()
+		cfg := copyConfig(minimalValid)
+		cfg["use_rudder_storage"] = false
+		cfg["s3"] = map[string]any{
+			"bucket_name": "my-snowflake-bucket",
+			"role_based_authentication": map[string]any{
+				"i_am_role_arn": "arn:aws:iam::123456789012:role/SnowflakeAccess",
+			},
+		}
+		errors := registered.ValidateConfig(cfg)
+		assert.Empty(t, errors)
+	})
+
+	t.Run("valid s3 access key auth", func(t *testing.T) {
+		t.Parallel()
+		cfg := copyConfig(minimalValid)
+		cfg["use_rudder_storage"] = false
+		cfg["s3"] = map[string]any{
+			"bucket_name":   "my-snowflake-bucket",
+			"access_key_id": "AKIAEXAMPLE",
+			"access_key":    "secret-value",
+			"enable_sse":    true,
+		}
+		errors := registered.ValidateConfig(cfg)
+		assert.Empty(t, errors)
+	})
+
+	t.Run("s3 access keys excluded with role based auth", func(t *testing.T) {
+		t.Parallel()
+		cfg := copyConfig(minimalValid)
+		cfg["use_rudder_storage"] = false
+		cfg["s3"] = map[string]any{
+			"bucket_name":   "my-snowflake-bucket",
+			"access_key_id": "AKIAEXAMPLE",
+			"access_key":    "secret-value",
+			"role_based_authentication": map[string]any{
+				"i_am_role_arn": "arn:aws:iam::123456789012:role/SnowflakeAccess",
+			},
+		}
+		errors := registered.ValidateConfig(cfg)
+		require.NotEmpty(t, errors)
+		paths := map[string]bool{}
+		for _, err := range errors {
+			paths[err.Path] = true
+		}
+		assert.True(t, paths["/s3/access_key_id"] || paths["/s3/access_key"] || paths["/s3/role_based_authentication"])
+	})
+
+	t.Run("valid gcp storage", func(t *testing.T) {
+		t.Parallel()
+		cfg := copyConfig(minimalValid)
+		cfg["use_rudder_storage"] = false
+		cfg["gcp"] = map[string]any{
+			"bucket_name":         "my-gcs-bucket",
+			"credentials":         `{"type":"service_account"}`,
+			"storage_integration": "gcs_int",
+		}
+		errors := registered.ValidateConfig(cfg)
+		assert.Empty(t, errors)
+	})
+
+	t.Run("gcp missing credentials", func(t *testing.T) {
+		t.Parallel()
+		cfg := copyConfig(minimalValid)
+		cfg["use_rudder_storage"] = false
+		cfg["gcp"] = map[string]any{
+			"bucket_name":         "my-gcs-bucket",
+			"storage_integration": "gcs_int",
+		}
+		errors := registered.ValidateConfig(cfg)
+		require.NotEmpty(t, errors)
+		assert.Equal(t, "/gcp/credentials", errors[0].Path)
+	})
+
+	t.Run("valid azure storage", func(t *testing.T) {
+		t.Parallel()
+		cfg := copyConfig(minimalValid)
+		cfg["use_rudder_storage"] = false
+		cfg["azure"] = map[string]any{
+			"container_name":      "my-container",
+			"account_name":        "mystorageaccount",
+			"account_key":         "account-key",
+			"storage_integration": "azure_int",
+		}
+		errors := registered.ValidateConfig(cfg)
+		assert.Empty(t, errors)
+	})
+
+	t.Run("valid full config with consent", func(t *testing.T) {
+		t.Parallel()
+		cfg := copyConfig(minimalValid)
+		cfg["role"] = "RUDDER_ROLE"
+		cfg["namespace"] = "RUDDER"
+		cfg["prefix"] = "rudder/"
+		cfg["skip_tracks_table"] = true
+		cfg["skip_users_table"] = false
+		cfg["prefer_append"] = true
+		cfg["manual_sync"] = false
+		cfg["json_paths"] = "properties.cart"
+		cfg["sync"] = map[string]any{
+			"frequency":                 "60",
+			"start_at":                  "10:00",
+			"exclude_window_start_time": "11:00",
+			"exclude_window_end_time":   "12:00",
+		}
+		cfg["consent_management"] = map[string]any{
+			"web": []any{
+				map[string]any{
+					"provider": "oneTrust",
+					"consents": []any{"analytics"},
+				},
+			},
+		}
+		errors := registered.ValidateConfig(cfg)
+		assert.Empty(t, errors)
+	})
+
+	t.Run("example yaml config", func(t *testing.T) {
+		t.Parallel()
+		// Exact config from the onboarding example YAML.
+		errors := registered.ValidateConfig(map[string]any{
+			"account":            "xy12345.us-east-1",
+			"database":           "ANALYTICS",
+			"warehouse":          "COMPUTE_WH",
+			"user":               "rudder_user",
+			"use_key_pair_auth":  false,
+			"password":           "secret-password",
+			"role":               "RUDDER_ROLE",
+			"namespace":          "RUDDER",
+			"use_rudder_storage": true,
+			"sync": map[string]any{
+				"frequency": "180",
+			},
+		})
+		assert.Empty(t, errors)
+	})
+
+	t.Run("unknown key rejected", func(t *testing.T) {
+		t.Parallel()
+		cfg := copyConfig(minimalValid)
+		cfg["not_a_field"] = true
+		errors := registered.ValidateConfig(cfg)
+		require.NotEmpty(t, errors)
+		assert.Equal(t, "/not_a_field", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "unknown config field")
+	})
+
+	t.Run("unsupported consent source rejected", func(t *testing.T) {
+		t.Parallel()
+		cfg := copyConfig(minimalValid)
+		cfg["consent_management"] = map[string]any{
+			"warehouse": []any{},
+		}
+		errors := registered.ValidateConfig(cfg)
+		require.Len(t, errors, 1)
+		assert.Equal(t, "/consent_management/warehouse", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "source type 'warehouse' is not supported")
+	})
+
+	t.Run("invalid consent provider rejected", func(t *testing.T) {
+		t.Parallel()
+		cfg := copyConfig(minimalValid)
+		cfg["consent_management"] = map[string]any{
+			"ios_swift": []any{
+				map[string]any{"provider": "unknown"},
+			},
+		}
+		errors := registered.ValidateConfig(cfg)
+		require.Len(t, errors, 1)
+		assert.Equal(t, "/consent_management/ios_swift/0/provider", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "'provider' must be one of")
+	})
+}
+
+func TestSnowflakeConversionRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	def := snowflake.NewDefinition()
+	testutil.AssertConversion(t, def.Properties, []testutil.ConversionCase{
+		{
+			Name: "minimal rudder storage",
+			LocalJSON: `{
+				"account": "xy12345.us-east-1",
+				"database": "ANALYTICS",
+				"warehouse": "COMPUTE_WH",
+				"user": "rudder_user",
+				"use_key_pair_auth": false,
+				"password": "secret-password",
+				"use_rudder_storage": true,
+				"sync": {"frequency": "180"}
+			}`,
+			APIJSON: `{
+				"account": "xy12345.us-east-1",
+				"database": "ANALYTICS",
+				"warehouse": "COMPUTE_WH",
+				"user": "rudder_user",
+				"useKeyPairAuth": false,
+				"password": "secret-password",
+				"useRudderStorage": true,
+				"syncFrequency": "180"
+			}`,
+		},
+		{
+			Name: "key pair auth",
+			LocalJSON: `{
+				"account": "xy12345.us-east-1",
+				"database": "ANALYTICS",
+				"warehouse": "COMPUTE_WH",
+				"user": "rudder_user",
+				"use_key_pair_auth": true,
+				"private_key": "-----BEGIN PRIVATE KEY-----\nKEY\n-----END PRIVATE KEY-----",
+				"private_key_passphrase": "pass",
+				"use_rudder_storage": true,
+				"sync": {"frequency": "30"}
+			}`,
+			APIJSON: `{
+				"account": "xy12345.us-east-1",
+				"database": "ANALYTICS",
+				"warehouse": "COMPUTE_WH",
+				"user": "rudder_user",
+				"useKeyPairAuth": true,
+				"privateKey": "-----BEGIN PRIVATE KEY-----\nKEY\n-----END PRIVATE KEY-----",
+				"privateKeyPassphrase": "pass",
+				"useRudderStorage": true,
+				"syncFrequency": "30"
+			}`,
+		},
+		{
+			Name: "s3 access key auth",
+			LocalJSON: `{
+				"account": "xy12345.us-east-1",
+				"database": "ANALYTICS",
+				"warehouse": "COMPUTE_WH",
+				"user": "rudder_user",
+				"use_key_pair_auth": false,
+				"password": "secret-password",
+				"use_rudder_storage": false,
+				"sync": {"frequency": "60"},
+				"prefix": "rudder/",
+				"s3": {
+					"bucket_name": "example-bucket",
+					"access_key_id": "AKIAEXAMPLE",
+					"access_key": "secret-value",
+					"enable_sse": true
+				}
+			}`,
+			APIJSON: `{
+				"account": "xy12345.us-east-1",
+				"database": "ANALYTICS",
+				"warehouse": "COMPUTE_WH",
+				"user": "rudder_user",
+				"useKeyPairAuth": false,
+				"password": "secret-password",
+				"useRudderStorage": false,
+				"syncFrequency": "60",
+				"prefix": "rudder/",
+				"cloudProvider": "AWS",
+				"roleBasedAuth": false,
+				"bucketName": "example-bucket",
+				"accessKeyID": "AKIAEXAMPLE",
+				"accessKey": "secret-value",
+				"enableSSE": true
+			}`,
+		},
+		{
+			Name: "s3 role based auth",
+			LocalJSON: `{
+				"account": "xy12345.us-east-1",
+				"database": "ANALYTICS",
+				"warehouse": "COMPUTE_WH",
+				"user": "rudder_user",
+				"use_key_pair_auth": false,
+				"password": "secret-password",
+				"use_rudder_storage": false,
+				"sync": {"frequency": "60"},
+				"s3": {
+					"bucket_name": "example-bucket",
+					"role_based_authentication": {
+						"i_am_role_arn": "arn:aws:iam::123456789012:role/SnowflakeAccess"
+					},
+					"storage_integration": "s3_int"
+				}
+			}`,
+			APIJSON: `{
+				"account": "xy12345.us-east-1",
+				"database": "ANALYTICS",
+				"warehouse": "COMPUTE_WH",
+				"user": "rudder_user",
+				"useKeyPairAuth": false,
+				"password": "secret-password",
+				"useRudderStorage": false,
+				"syncFrequency": "60",
+				"cloudProvider": "AWS",
+				"roleBasedAuth": true,
+				"bucketName": "example-bucket",
+				"iamRoleARN": "arn:aws:iam::123456789012:role/SnowflakeAccess",
+				"storageIntegration": "s3_int"
+			}`,
+		},
+		{
+			Name: "gcp storage",
+			LocalJSON: `{
+				"account": "xy12345.us-east-1",
+				"database": "ANALYTICS",
+				"warehouse": "COMPUTE_WH",
+				"user": "rudder_user",
+				"use_key_pair_auth": false,
+				"password": "secret-password",
+				"use_rudder_storage": false,
+				"sync": {"frequency": "60"},
+				"gcp": {
+					"bucket_name": "example-gcs-bucket",
+					"credentials": "{\"type\":\"service_account\"}",
+					"storage_integration": "gcs_int"
+				}
+			}`,
+			APIJSON: `{
+				"account": "xy12345.us-east-1",
+				"database": "ANALYTICS",
+				"warehouse": "COMPUTE_WH",
+				"user": "rudder_user",
+				"useKeyPairAuth": false,
+				"password": "secret-password",
+				"useRudderStorage": false,
+				"syncFrequency": "60",
+				"cloudProvider": "GCP",
+				"bucketName": "example-gcs-bucket",
+				"credentials": "{\"type\":\"service_account\"}",
+				"storageIntegration": "gcs_int"
+			}`,
+		},
+		{
+			Name: "azure storage",
+			LocalJSON: `{
+				"account": "xy12345.us-east-1",
+				"database": "ANALYTICS",
+				"warehouse": "COMPUTE_WH",
+				"user": "rudder_user",
+				"use_key_pair_auth": false,
+				"password": "secret-password",
+				"use_rudder_storage": false,
+				"sync": {"frequency": "60"},
+				"azure": {
+					"container_name": "example-container",
+					"account_name": "mystorageaccount",
+					"account_key": "account-key",
+					"storage_integration": "azure_int"
+				}
+			}`,
+			APIJSON: `{
+				"account": "xy12345.us-east-1",
+				"database": "ANALYTICS",
+				"warehouse": "COMPUTE_WH",
+				"user": "rudder_user",
+				"useKeyPairAuth": false,
+				"password": "secret-password",
+				"useRudderStorage": false,
+				"syncFrequency": "60",
+				"cloudProvider": "AZURE",
+				"containerName": "example-container",
+				"accountName": "mystorageaccount",
+				"accountKey": "account-key",
+				"storageIntegration": "azure_int"
+			}`,
+		},
+		{
+			Name: "sync exclude window reshape",
+			LocalJSON: `{
+				"account": "xy12345.us-east-1",
+				"database": "ANALYTICS",
+				"warehouse": "COMPUTE_WH",
+				"user": "rudder_user",
+				"use_key_pair_auth": false,
+				"password": "secret-password",
+				"use_rudder_storage": true,
+				"sync": {
+					"frequency": "60",
+					"start_at": "10:00",
+					"exclude_window_start_time": "11:00",
+					"exclude_window_end_time": "12:00"
+				}
+			}`,
+			APIJSON: `{
+				"account": "xy12345.us-east-1",
+				"database": "ANALYTICS",
+				"warehouse": "COMPUTE_WH",
+				"user": "rudder_user",
+				"useKeyPairAuth": false,
+				"password": "secret-password",
+				"useRudderStorage": true,
+				"syncFrequency": "60",
+				"syncStartAt": "10:00",
+				"excludeWindow": {
+					"excludeWindowStartTime": "11:00",
+					"excludeWindowEndTime": "12:00"
+				}
+			}`,
+		},
+		{
+			Name: "consent source boundary mappings",
+			LocalJSON: `{
+				"account": "xy12345.us-east-1",
+				"database": "ANALYTICS",
+				"warehouse": "COMPUTE_WH",
+				"user": "rudder_user",
+				"use_key_pair_auth": false,
+				"password": "secret-password",
+				"use_rudder_storage": true,
+				"sync": {"frequency": "180"},
+				"consent_management": {
+					"android_kotlin": [{"provider": "oneTrust"}],
+					"ios_swift": [{"provider": "ketch"}],
+					"react_native": [{"provider": "iubenda"}]
+				}
+			}`,
+			APIJSON: `{
+				"account": "xy12345.us-east-1",
+				"database": "ANALYTICS",
+				"warehouse": "COMPUTE_WH",
+				"user": "rudder_user",
+				"useKeyPairAuth": false,
+				"password": "secret-password",
+				"useRudderStorage": true,
+				"syncFrequency": "180",
+				"consentManagement": {
+					"androidKotlin": [{"provider": "oneTrust"}],
+					"iosSwift": [{"provider": "ketch"}],
+					"reactnative": [{"provider": "iubenda"}]
+				}
+			}`,
+		},
+	})
+}
+
+func copyConfig(in map[string]any) map[string]any {
+	out := make(map[string]any, len(in))
+	for k, v := range in {
+		if nested, ok := v.(map[string]any); ok {
+			out[k] = copyConfig(nested)
+			continue
+		}
+		out[k] = v
+	}
+	return out
+}


### PR DESCRIPTION
## 🔗 Ticket

Resolves [DEX-526](https://linear.app/rudderstack/issue/DEX-526/onboard-destination-snowflake)

---

## Summary

Onboards the Snowflake (`snowflake`) warehouse destination into the CLI destination definition registry so it can be managed via YAML specs under the destination-support experimental flag.

---

## Changes

- Added `snowflake` destination definition (`Type: snowflake`, `APIType: SNOWFLAKE`, `Version: 1`) with terraform-ported property mappings:
  - Core: `account`, `database`, `warehouse`, `user`, password / key-pair auth, `role`, `namespace`
  - Sync: `sync.frequency` ↔ `syncFrequency`, start-at + exclude-window reshape
  - Storage discriminators: nested `s3` / `gcp` / `azure` blocks → `cloudProvider` + storage fields
  - S3 auth discriminator: access keys vs `role_based_authentication.i_am_role_arn` → `roleBasedAuth`
  - Consent management via `common.Properties`
- Registered definition in `newDestinationRegistry` and updated `SupportedTypes` expectation (`s3`, `snowflake`)
- Unit tests for metadata, config validation (required fields, auth conditionals, storage blocks, unknown keys, consent), and local↔API conversion round-trips

### Onboarding notes / discrepancies

- **Dropped source types** (CLI event-stream ownership, S3 precedent): `amp`, `shopify`, `cloudSource` (mapped but not CLI-owned like S3), upstream has no `warehouse`
- **Gated keys**: none — all destination-specific keys live in `defaultConfig`; per-source-type lists only consent/connectionMode boilerplate
- **SecretKeys** (top-level only): `password`, `private_key`, `private_key_passphrase`
  - Nested secrets **omitted** from `SecretKeys` (CLI secret machinery is top-level only): `s3.access_key_id`, `s3.access_key`, `gcp.credentials`, `azure.account_key`
- **Omitted upstream fields** (in db-config `defaultConfig` / schema, no terraform mapping): `cleanupObjectStorageFiles`, `underscoreDivideNumbers`, `allowUsersContextTraits`, `useSASTokens`, `sasToken`
- **Omitted terraform mappings**: `connectionMode.*` — handled by definition `ConnectionModes` + `common`, not per-property converters
- **Terraform-only behavior omitted**: raw base64 private-key PEM auto-wrap (`privateKeyProperty`); CLI expects PEM (or already-wrapped) `private_key`
- **schema.json vs terraform validation**:
  - `syncFrequency` enum includes `5` / `15` in schema; terraform regex only allows `30|60|180|360|720|1440` — CLI follows schema (`dynamic_or_oneof=5 15 30 60 180 360 720 1440`)
  - `namespace` `pg_` prefix ban from schema is **unenforced** (no validate-tag equivalent)
  - Cloud-storage `anyOf` (must pick s3/gcp/azure when `use_rudder_storage: false`) is **partially** enforced — nested block fields validate when present, but “exactly one storage block required” is not a struct-tag rule
- **Terraform field not in schema.json properties**: `additionalProperties` (bool) — mapped optionally with `SkipZeroValue`
- Local YAML uses nested terraform-aligned shape (`sync`, `s3` / `gcp` / `azure`) without TF list indices (`.0.`)

### Example YAML

```yaml
version: rudder/v1
kind: destination
metadata:
  name: my-snowflake-destination
spec:
  id: my-snowflake-destination
  display_name: My Snowflake Destination
  type: snowflake
  enabled: true
  definition_version: 1
  config:
    account: xy12345.us-east-1
    database: ANALYTICS
    warehouse: COMPUTE_WH
    user: rudder_user
    use_key_pair_auth: false
    password: secret-password
    role: RUDDER_ROLE
    namespace: RUDDER
    use_rudder_storage: true
    sync:
      frequency: "180"
```

Requires `experimental: true` + `flags.destinationSupport: true` in CLI config.

---

## Testing

- `go build ./...`
- `go test ./cli/internal/providers/destination/... ./cli/internal/app/...`
- `make lint`

---

## Risk / Impact

Low
Notes: additive registry entry behind experimental destination-support flag; no change to existing destination behavior.

---

## Checklist

- [x] Ticket linked
- [x] Tests added/updated
- [x] No breaking changes (or documented)

Made with [Cursor](https://cursor.com)