### PR TITLE
feat(cli): onboard adjust destination definition

### DIFF
--- a/cli/internal/app/dependencies.go
+++ b/cli/internal/app/dependencies.go
@@ -16,6 +16,7 @@ import (
 	dgProvider "github.com/rudderlabs/rudder-iac/cli/internal/providers/datagraph"
 	destProvider "github.com/rudderlabs/rudder-iac/cli/internal/providers/destination"
 	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions"
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions/adjust"
 	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions/s3"
 	esProvider "github.com/rudderlabs/rudder-iac/cli/internal/providers/event-stream"
 	"github.com/rudderlabs/rudder-iac/cli/internal/providers/retl"
@@ -247,6 +248,9 @@ func newDestinationRegistry(cfg config.Config) (*definitions.Registry, error) {
 	}
 	if err := registry.Register(s3.NewDefinition()); err != nil {
 		return nil, fmt.Errorf("registering s3 destination definition: %w", err)
+	}
+	if err := registry.Register(adjust.NewDefinition()); err != nil {
+		return nil, fmt.Errorf("registering adjust destination definition: %w", err)
 	}
 	return registry, nil
 }

--- a/cli/internal/app/dependencies_test.go
+++ b/cli/internal/app/dependencies_test.go
@@ -40,7 +40,7 @@ func TestNewDestinationRegistryRegistersS3WhenFlagEnabled(t *testing.T) {
 
 	registry, err := newDestinationRegistry(config.GetConfig())
 	require.NoError(t, err)
-	assert.Equal(t, []string{"s3"}, registry.SupportedTypes())
+	assert.Equal(t, []string{"adjust", "s3"}, registry.SupportedTypes())
 }
 
 func TestNewDestinationRegistryEmptyWhenFlagDisabled(t *testing.T) {

--- a/cli/internal/providers/destination/definitions/adjust/definition.go
+++ b/cli/internal/providers/destination/definitions/adjust/definition.go
@@ -1,0 +1,103 @@
+package adjust
+
+import (
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions"
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions/common"
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions/converter"
+)
+
+// Source types from integrations-config destinations/adj/db-config.json
+// supportedSourceTypes, restricted to types the CLI event-stream provider owns.
+var sourceTypes = []string{
+	common.SourceTypeAndroid,
+	common.SourceTypeAndroidKotlin,
+	common.SourceTypeIOS,
+	common.SourceTypeIOSSwift,
+	common.SourceTypeUnity,
+	common.SourceTypeReactNative,
+	common.SourceTypeFlutter,
+	common.SourceTypeCordova,
+	common.SourceTypeCloud,
+}
+
+var connectionModes = map[string][]string{
+	common.SourceTypeAndroid:       {"cloud", "device"},
+	common.SourceTypeAndroidKotlin: {"cloud", "device"},
+	common.SourceTypeIOS:           {"cloud", "device"},
+	common.SourceTypeIOSSwift:      {"cloud", "device"},
+	common.SourceTypeUnity:         {"cloud", "device"},
+	common.SourceTypeReactNative:   {"cloud"},
+	common.SourceTypeFlutter:       {"cloud", "device"},
+	common.SourceTypeCordova:       {"cloud"},
+	common.SourceTypeCloud:         {"cloud"},
+}
+
+type adjustMapping struct {
+	From string `mapstructure:"from" validate:"omitempty,max=100"`
+	To   string `mapstructure:"to" validate:"omitempty,max=100"`
+}
+
+type enableInstallAttributionTracking struct {
+	Android *bool `mapstructure:"android"`
+	IOS     *bool `mapstructure:"ios"`
+}
+
+// adjustConfig is the local YAML config model. Field set mirrors terraform
+// destination_adjust mappings; validation constraints mirror schema.json.
+type adjustConfig struct {
+	AppToken                         string                            `mapstructure:"app_token" validate:"required,max=100"`
+	Delay                            string                            `mapstructure:"delay" validate:"omitempty,max=100"`
+	Environment                      *bool                             `mapstructure:"environment"`
+	CustomMappings                   []adjustMapping                   `mapstructure:"custom_mappings" validate:"omitempty,dive"`
+	PartnerParamKeys                 []adjustMapping                   `mapstructure:"partner_param_keys" validate:"omitempty,dive"`
+	EnableInstallAttributionTracking *enableInstallAttributionTracking `mapstructure:"enable_install_attribution_tracking"`
+	EventFilteringWhitelist          []string                          `mapstructure:"event_filtering_whitelist"`
+	EventFilteringBlacklist          []string                          `mapstructure:"event_filtering_blacklist"`
+	ConsentManagement                common.ConsentManagement          `mapstructure:"consent_management"`
+}
+
+// NewDefinition returns the Adjust destination definition.
+func NewDefinition() *definitions.DestinationDefinition {
+	properties := []converter.ConfigProperty{
+		converter.Simple("appToken", "app_token"),
+		converter.Simple("delay", "delay", converter.SkipZeroValue),
+		converter.Simple("environment", "environment", converter.SkipZeroValue),
+		converter.ArrayWithObjects("customMappings", "custom_mappings", map[string]any{
+			"from": "from",
+			"to":   "to",
+		}),
+		converter.ArrayWithObjects("partnerParamKeys", "partner_param_keys", map[string]any{
+			"from": "from",
+			"to":   "to",
+		}),
+		converter.Gated(
+			converter.Simple("enableInstallAttributionTracking.android", "enable_install_attribution_tracking.android", converter.SkipZeroValue),
+			common.SourceTypeAndroid, common.SourceTypeAndroidKotlin,
+		),
+		converter.Gated(
+			converter.Simple("enableInstallAttributionTracking.ios", "enable_install_attribution_tracking.ios", converter.SkipZeroValue),
+			common.SourceTypeIOS, common.SourceTypeIOSSwift,
+		),
+		converter.ArrayWithStrings("whitelistedEvents", "eventName", "event_filtering_whitelist"),
+		converter.ArrayWithStrings("blacklistedEvents", "eventName", "event_filtering_blacklist"),
+		converter.Discriminator("eventFilteringOption", converter.DiscriminatorValues{
+			"event_filtering_whitelist": "whitelistedEvents",
+			"event_filtering_blacklist": "blacklistedEvents",
+		}),
+	}
+	properties = append(properties, common.Properties(sourceTypes)...)
+
+	return &definitions.DestinationDefinition{
+		Type:       "adjust",
+		APIType:    "ADJ",
+		Version:    1,
+		Properties: properties,
+		// db-config secretKeys is empty; terraform marks app_token Sensitive.
+		SecretKeys: []string{"app_token"},
+		NewConfig: func() any {
+			return &adjustConfig{}
+		},
+		SourceTypes:     append([]string(nil), sourceTypes...),
+		ConnectionModes: connectionModes,
+	}
+}

--- a/cli/internal/providers/destination/definitions/adjust/definition_test.go
+++ b/cli/internal/providers/destination/definitions/adjust/definition_test.go
@@ -1,0 +1,276 @@
+package adjust_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions"
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions/adjust"
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions/testutil"
+)
+
+func TestNewDefinitionMetadata(t *testing.T) {
+	t.Parallel()
+
+	registry := definitions.NewRegistry()
+	require.NoError(t, registry.Register(adjust.NewDefinition()))
+
+	registered, err := registry.Get("adjust", 1)
+	require.NoError(t, err)
+
+	assert.Equal(t, "adjust", registered.Type)
+	assert.Equal(t, "ADJ", registered.APIType)
+	assert.Equal(t, int64(1), registered.Version)
+	assert.Equal(t, []string{"app_token"}, registered.SecretKeys())
+
+	expectedSourceTypes := []string{
+		"android", "android_kotlin", "ios", "ios_swift",
+		"unity", "react_native", "flutter", "cordova", "cloud",
+	}
+	assert.Equal(t, expectedSourceTypes, registered.SupportedSourceTypes())
+
+	expectedModes := map[string][]string{
+		"android":        {"cloud", "device"},
+		"android_kotlin": {"cloud", "device"},
+		"ios":            {"cloud", "device"},
+		"ios_swift":      {"cloud", "device"},
+		"unity":          {"cloud", "device"},
+		"react_native":   {"cloud"},
+		"flutter":        {"cloud", "device"},
+		"cordova":        {"cloud"},
+		"cloud":          {"cloud"},
+	}
+	for sourceType, want := range expectedModes {
+		modes, err := registered.ConnectionModes(sourceType)
+		require.NoError(t, err)
+		assert.Equal(t, want, modes, sourceType)
+	}
+
+	assert.NotContains(t, registered.SupportedSourceTypes(), "shopify")
+	assert.NotContains(t, registered.SupportedSourceTypes(), "warehouse")
+
+	assert.Equal(t, map[string][]string{
+		"enable_install_attribution_tracking/android": {"android", "android_kotlin"},
+		"enable_install_attribution_tracking/ios":     {"ios", "ios_swift"},
+	}, registered.GatedKeyPaths())
+
+	byAPI, err := registry.GetByAPIType("ADJ", 1)
+	require.NoError(t, err)
+	assert.Equal(t, registered, byAPI)
+}
+
+func TestAdjustConfigValidation(t *testing.T) {
+	t.Parallel()
+
+	registry := definitions.NewRegistry()
+	require.NoError(t, registry.Register(adjust.NewDefinition()))
+	registered, err := registry.Get("adjust", 1)
+	require.NoError(t, err)
+
+	t.Run("missing app_token", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{})
+		require.NotEmpty(t, errors)
+		assert.Equal(t, "/app_token", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "required")
+	})
+
+	t.Run("valid minimal config", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{
+			"app_token": "abc123",
+		})
+		assert.Empty(t, errors)
+	})
+
+	t.Run("valid full config", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{
+			"app_token":   "abc123",
+			"delay":       "5",
+			"environment": true,
+			"custom_mappings": []any{
+				map[string]any{"from": "Product Purchased", "to": "tok1"},
+			},
+			"partner_param_keys": []any{
+				map[string]any{"from": "userId", "to": "user_id"},
+			},
+			"enable_install_attribution_tracking": map[string]any{
+				"android": true,
+				"ios":     true,
+			},
+			"event_filtering_whitelist": []any{"Purchase", "Signup"},
+			"consent_management": map[string]any{
+				"android": []any{
+					map[string]any{
+						"provider": "oneTrust",
+						"consents": []any{"analytics"},
+					},
+				},
+			},
+		})
+		assert.Empty(t, errors)
+	})
+
+	t.Run("example yaml config", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{
+			"app_token":   "YOUR_ADJUST_APP_TOKEN",
+			"delay":       "5",
+			"environment": true,
+			"custom_mappings": []any{
+				map[string]any{"from": "Product Purchased", "to": "abc123"},
+				map[string]any{"from": "Signup", "to": "def456"},
+			},
+			"partner_param_keys": []any{
+				map[string]any{"from": "userId", "to": "user_id"},
+			},
+			"enable_install_attribution_tracking": map[string]any{
+				"android": true,
+				"ios":     true,
+			},
+			"event_filtering_whitelist": []any{"Product Purchased", "Signup"},
+			"consent_management": map[string]any{
+				"android": []any{
+					map[string]any{
+						"provider": "oneTrust",
+						"consents": []any{"analytics"},
+					},
+				},
+			},
+		})
+		assert.Empty(t, errors)
+	})
+
+	t.Run("unknown key rejected", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{
+			"app_token":   "abc123",
+			"not_a_field": true,
+		})
+		require.NotEmpty(t, errors)
+		assert.Equal(t, "/not_a_field", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "unknown config field")
+	})
+
+	t.Run("unsupported consent source rejected", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{
+			"app_token": "abc123",
+			"consent_management": map[string]any{
+				"warehouse": []any{},
+			},
+		})
+		require.Len(t, errors, 1)
+		assert.Equal(t, "/consent_management/warehouse", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "source type 'warehouse' is not supported")
+	})
+
+	t.Run("invalid consent provider rejected", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{
+			"app_token": "abc123",
+			"consent_management": map[string]any{
+				"ios_swift": []any{
+					map[string]any{"provider": "unknown"},
+				},
+			},
+		})
+		require.Len(t, errors, 1)
+		assert.Equal(t, "/consent_management/ios_swift/0/provider", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "'provider' must be one of")
+	})
+}
+
+func TestAdjustConversionRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	def := adjust.NewDefinition()
+	testutil.AssertConversion(t, def.Properties, []testutil.ConversionCase{
+		{
+			Name: "minimal app token",
+			LocalJSON: `{
+				"app_token": "abc123"
+			}`,
+			APIJSON: `{
+				"appToken": "abc123"
+			}`,
+		},
+		{
+			Name: "full fields",
+			LocalJSON: `{
+				"app_token": "abc123",
+				"delay": "5",
+				"environment": true,
+				"custom_mappings": [
+					{"from": "Product Purchased", "to": "tok1"},
+					{"from": "Signup", "to": "tok2"}
+				],
+				"partner_param_keys": [
+					{"from": "userId", "to": "user_id"}
+				],
+				"enable_install_attribution_tracking": {
+					"android": true,
+					"ios": true
+				},
+				"event_filtering_whitelist": ["one", "two"]
+			}`,
+			APIJSON: `{
+				"appToken": "abc123",
+				"delay": "5",
+				"environment": true,
+				"customMappings": [
+					{"from": "Product Purchased", "to": "tok1"},
+					{"from": "Signup", "to": "tok2"}
+				],
+				"partnerParamKeys": [
+					{"from": "userId", "to": "user_id"}
+				],
+				"enableInstallAttributionTracking": {
+					"android": true,
+					"ios": true
+				},
+				"eventFilteringOption": "whitelistedEvents",
+				"whitelistedEvents": [
+					{"eventName": "one"},
+					{"eventName": "two"}
+				]
+			}`,
+		},
+		{
+			Name: "event filtering blacklist",
+			LocalJSON: `{
+				"app_token": "abc123",
+				"event_filtering_blacklist": ["noise"]
+			}`,
+			APIJSON: `{
+				"appToken": "abc123",
+				"eventFilteringOption": "blacklistedEvents",
+				"blacklistedEvents": [
+					{"eventName": "noise"}
+				]
+			}`,
+		},
+		{
+			Name: "consent source boundary mappings",
+			LocalJSON: `{
+				"app_token": "abc123",
+				"consent_management": {
+					"android_kotlin": [{"provider": "oneTrust"}],
+					"ios_swift": [{"provider": "ketch"}],
+					"react_native": [{"provider": "iubenda"}]
+				}
+			}`,
+			APIJSON: `{
+				"appToken": "abc123",
+				"consentManagement": {
+					"androidKotlin": [{"provider": "oneTrust"}],
+					"iosSwift": [{"provider": "ketch"}],
+					"reactnative": [{"provider": "iubenda"}]
+				}
+			}`,
+		},
+	})
+}


### PR DESCRIPTION
## 🔗 Ticket

Resolves [DEX-489](https://linear.app/rudderstack/issue/DEX-489/onboard-destination-adjust)

---

## Summary

Onboards the Adjust (`adjust`) destination into the CLI destination definition registry so it can be managed via YAML specs under the destination-support experimental flag.

---

## Changes

- Added `adjust` destination definition (`Type: adjust`, `APIType: ADJ`, `Version: 1`) with terraform-ported property mappings:
  - `app_token` (required, secret), `delay`, `environment`
  - `custom_mappings`, `partner_param_keys` (array-of-objects)
  - `event_filtering_whitelist` / `event_filtering_blacklist` + `eventFilteringOption` discriminator
  - gated `enable_install_attribution_tracking.{android,ios}`
  - consent management via `common.Properties`
- Registered definition in `newDestinationRegistry` and updated `SupportedTypes` expectation (`adjust`, `s3`)
- Unit tests for metadata (incl. gated keypaths), config validation, and local↔API conversion round-trips

### Onboarding notes / discrepancies

- **Naming**: integrations-config directory is `adj` (`db-config.json` `name: ADJ`); terraform registers as `adjust` with `APIType: ADJ`. CLI uses `Type: adjust` (user/terraform name) and `APIType: ADJ` — not `lowercase(APIType)` (`adj`)
- **Dropped source types** (CLI event-stream ownership, S3 precedent): `shopify`, `warehouse`
- **Gated keys**:
  - `enable_install_attribution_tracking.android` → `android`, `android_kotlin`
  - `enable_install_attribution_tracking.ios` → `ios`, `ios_swift`
  - Parent key listed under those source types in `destConfig` (not in `defaultConfig`)
- **SecretKeys**: `app_token` included because terraform marks it `Sensitive`. db-config `secretKeys` is empty — flagged discrepancy; CLI treats the token as a secret
- **partnerParamKeys naming**: terraform API key is `partnerParamKeys`; schema/db-config use typo `partnerParamsKeys`. Mapping follows terraform (`partnerParamKeys` ↔ `partner_param_keys`)
- **Omitted terraform mappings**: `connectionMode.*` — handled by definition `ConnectionModes` + source-type config keys, not per-property converters
- **Omitted schema-only fields** (no terraform mapping): `enableInstallAttributionTracking.androidKotlin` / `.iosSwift`
- **schema.json**: required `appToken`; `delay`/`appToken` max 100; `environment` optional bool; event filtering enum via discriminator

### Example YAML

```yaml
version: rudder/v1
kind: destination
metadata:
  name: my-adjust-destination
spec:
  id: my-adjust-destination
  display_name: My Adjust Destination
  type: adjust
  enabled: true
  definition_version: 1
  config:
    app_token: YOUR_ADJUST_APP_TOKEN
    delay: "5"
    environment: true
    custom_mappings:
      - from: Product Purchased
        to: abc123
      - from: Signup
        to: def456
    partner_param_keys:
      - from: userId
        to: user_id
    enable_install_attribution_tracking:
      android: true
      ios: true
    event_filtering_whitelist:
      - Product Purchased
      - Signup
    consent_management:
      android:
        - provider: oneTrust
          consents:
            - analytics
```

Requires `experimental: true` + `flags.destinationSupport: true` in CLI config.

---

## Testing

- `go build ./...`
- `go test ./cli/internal/providers/destination/... ./cli/internal/app/...`
- `make lint`

---

## Risk / Impact

Low
Notes: additive registry entry behind experimental destination-support flag; no change to existing destination behavior.

---

## Checklist

- [x] Ticket linked
- [x] Tests added/updated
- [x] No breaking changes (or documented)

Made with [Cursor](https://cursor.com)