### PR TITLE
feat(cli): onboard Statsig destination definition

### DIFF
--- a/cli/internal/app/dependencies.go
+++ b/cli/internal/app/dependencies.go
@@ -17,6 +17,7 @@ import (
 	destProvider "github.com/rudderlabs/rudder-iac/cli/internal/providers/destination"
 	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions"
 	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions/s3"
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions/statsig"
 	esProvider "github.com/rudderlabs/rudder-iac/cli/internal/providers/event-stream"
 	"github.com/rudderlabs/rudder-iac/cli/internal/providers/retl"
 	"github.com/rudderlabs/rudder-iac/cli/internal/providers/transformations"
@@ -247,6 +248,9 @@ func newDestinationRegistry(cfg config.Config) (*definitions.Registry, error) {
 	}
 	if err := registry.Register(s3.NewDefinition()); err != nil {
 		return nil, fmt.Errorf("registering s3 destination definition: %w", err)
+	}
+	if err := registry.Register(statsig.NewDefinition()); err != nil {
+		return nil, fmt.Errorf("registering statsig destination definition: %w", err)
 	}
 	return registry, nil
 }

--- a/cli/internal/app/dependencies_test.go
+++ b/cli/internal/app/dependencies_test.go
@@ -40,7 +40,7 @@ func TestNewDestinationRegistryRegistersS3WhenFlagEnabled(t *testing.T) {
 
 	registry, err := newDestinationRegistry(config.GetConfig())
 	require.NoError(t, err)
-	assert.Equal(t, []string{"s3"}, registry.SupportedTypes())
+	assert.Equal(t, []string{"s3", "statsig"}, registry.SupportedTypes())
 }
 
 func TestNewDestinationRegistryEmptyWhenFlagDisabled(t *testing.T) {

--- a/cli/internal/providers/destination/definitions/statsig/definition.go
+++ b/cli/internal/providers/destination/definitions/statsig/definition.go
@@ -1,0 +1,64 @@
+package statsig
+
+import (
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions"
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions/common"
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions/converter"
+)
+
+// Source types from integrations-config destinations/statsig/db-config.json
+// supportedSourceTypes, restricted to types the CLI event-stream provider owns.
+var sourceTypes = []string{
+	common.SourceTypeAndroid,
+	common.SourceTypeAndroidKotlin,
+	common.SourceTypeIOS,
+	common.SourceTypeIOSSwift,
+	common.SourceTypeWeb,
+	common.SourceTypeUnity,
+	common.SourceTypeReactNative,
+	common.SourceTypeFlutter,
+	common.SourceTypeCordova,
+	common.SourceTypeCloud,
+}
+
+var connectionModes = map[string][]string{
+	common.SourceTypeAndroid:       {"cloud"},
+	common.SourceTypeAndroidKotlin: {"cloud"},
+	common.SourceTypeIOS:           {"cloud"},
+	common.SourceTypeIOSSwift:      {"cloud"},
+	common.SourceTypeWeb:           {"cloud"},
+	common.SourceTypeUnity:         {"cloud"},
+	common.SourceTypeReactNative:   {"cloud"},
+	common.SourceTypeFlutter:       {"cloud"},
+	common.SourceTypeCordova:       {"cloud"},
+	common.SourceTypeCloud:         {"cloud"},
+}
+
+// statsigConfig is the local YAML config model. Field set mirrors
+// integrations-config destinations/statsig defaultConfig; validation
+// constraints mirror schema.json (secretKey required, 1–200 chars).
+type statsigConfig struct {
+	SecretKey         string                   `mapstructure:"secret_key" validate:"required,min=1,max=200"`
+	ConsentManagement common.ConsentManagement `mapstructure:"consent_management"`
+}
+
+// NewDefinition returns the Statsig destination definition.
+func NewDefinition() *definitions.DestinationDefinition {
+	properties := []converter.ConfigProperty{
+		converter.Simple("secretKey", "secret_key"),
+	}
+	properties = append(properties, common.Properties(sourceTypes)...)
+
+	return &definitions.DestinationDefinition{
+		Type:       "statsig",
+		APIType:    "STATSIG",
+		Version:    1,
+		Properties: properties,
+		SecretKeys: []string{"secret_key"},
+		NewConfig: func() any {
+			return &statsigConfig{}
+		},
+		SourceTypes:     append([]string(nil), sourceTypes...),
+		ConnectionModes: connectionModes,
+	}
+}

--- a/cli/internal/providers/destination/definitions/statsig/definition_test.go
+++ b/cli/internal/providers/destination/definitions/statsig/definition_test.go
@@ -1,0 +1,231 @@
+package statsig_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions"
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions/statsig"
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions/testutil"
+)
+
+func TestNewDefinitionMetadata(t *testing.T) {
+	t.Parallel()
+
+	registry := definitions.NewRegistry()
+	require.NoError(t, registry.Register(statsig.NewDefinition()))
+
+	registered, err := registry.Get("statsig", 1)
+	require.NoError(t, err)
+
+	assert.Equal(t, "statsig", registered.Type)
+	assert.Equal(t, "STATSIG", registered.APIType)
+	assert.Equal(t, int64(1), registered.Version)
+	assert.Equal(t, []string{"secret_key"}, registered.SecretKeys())
+
+	expectedSourceTypes := []string{
+		"android", "android_kotlin", "ios", "ios_swift", "web",
+		"unity", "react_native", "flutter", "cordova", "cloud",
+	}
+	assert.Equal(t, expectedSourceTypes, registered.SupportedSourceTypes())
+
+	for _, sourceType := range expectedSourceTypes {
+		modes, err := registered.ConnectionModes(sourceType)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"cloud"}, modes)
+	}
+
+	assert.NotContains(t, registered.SupportedSourceTypes(), "amp")
+	assert.NotContains(t, registered.SupportedSourceTypes(), "shopify")
+	assert.NotContains(t, registered.SupportedSourceTypes(), "warehouse")
+
+	assert.Empty(t, registered.GatedKeyPaths())
+
+	byAPI, err := registry.GetByAPIType("STATSIG", 1)
+	require.NoError(t, err)
+	assert.Equal(t, registered, byAPI)
+}
+
+func TestStatsigConfigValidation(t *testing.T) {
+	t.Parallel()
+
+	registry := definitions.NewRegistry()
+	require.NoError(t, registry.Register(statsig.NewDefinition()))
+	registered, err := registry.Get("statsig", 1)
+	require.NoError(t, err)
+
+	t.Run("missing secret_key", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{})
+		require.NotEmpty(t, errors)
+		assert.Equal(t, "/secret_key", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "required")
+	})
+
+	t.Run("empty secret_key", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{
+			"secret_key": "",
+		})
+		require.NotEmpty(t, errors)
+		assert.Equal(t, "/secret_key", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "required")
+	})
+
+	t.Run("secret_key too long", func(t *testing.T) {
+		t.Parallel()
+		long := make([]byte, 201)
+		for i := range long {
+			long[i] = 'a'
+		}
+		errors := registered.ValidateConfig(map[string]any{
+			"secret_key": string(long),
+		})
+		require.NotEmpty(t, errors)
+		assert.Equal(t, "/secret_key", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "less than or equal to 200")
+	})
+
+	t.Run("valid minimal config", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{
+			"secret_key": "secret-server-key",
+		})
+		assert.Empty(t, errors)
+	})
+
+	t.Run("valid example config", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{
+			"secret_key": "secret-xxxxxxxxxxxxxxxx",
+		})
+		assert.Empty(t, errors)
+	})
+
+	t.Run("valid with consent", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{
+			"secret_key": "secret-server-key",
+			"consent_management": map[string]any{
+				"web": []any{
+					map[string]any{
+						"provider": "oneTrust",
+						"consents": []any{"analytics"},
+					},
+				},
+			},
+		})
+		assert.Empty(t, errors)
+	})
+
+	t.Run("unknown key rejected", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{
+			"secret_key":  "secret-server-key",
+			"not_a_field": true,
+		})
+		require.NotEmpty(t, errors)
+		assert.Equal(t, "/not_a_field", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "unknown config field")
+	})
+
+	t.Run("unsupported consent source rejected", func(t *testing.T) {
+		t.Parallel()
+
+		errors := registered.ValidateConfig(map[string]any{
+			"secret_key": "secret-server-key",
+			"consent_management": map[string]any{
+				"warehouse": []any{},
+			},
+		})
+
+		require.Len(t, errors, 1)
+		assert.Equal(t, "/consent_management/warehouse", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "source type 'warehouse' is not supported")
+	})
+
+	t.Run("invalid consent provider rejected", func(t *testing.T) {
+		t.Parallel()
+
+		errors := registered.ValidateConfig(map[string]any{
+			"secret_key": "secret-server-key",
+			"consent_management": map[string]any{
+				"ios_swift": []any{
+					map[string]any{"provider": "unknown"},
+				},
+			},
+		})
+
+		require.Len(t, errors, 1)
+		assert.Equal(t, "/consent_management/ios_swift/0/provider", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "'provider' must be one of")
+	})
+}
+
+func TestStatsigConversionRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	def := statsig.NewDefinition()
+	testutil.AssertConversion(t, def.Properties, []testutil.ConversionCase{
+		{
+			Name: "minimal secret key",
+			LocalJSON: `{
+				"secret_key": "secret-server-key"
+			}`,
+			APIJSON: `{
+				"secretKey": "secret-server-key"
+			}`,
+		},
+		{
+			Name: "consent for web",
+			LocalJSON: `{
+				"secret_key": "secret-server-key",
+				"consent_management": {
+					"web": [
+						{
+							"provider": "oneTrust",
+							"resolution_strategy": "and",
+							"consents": ["analytics", "marketing"]
+						}
+					]
+				}
+			}`,
+			APIJSON: `{
+				"secretKey": "secret-server-key",
+				"consentManagement": {
+					"web": [
+						{
+							"provider": "oneTrust",
+							"resolutionStrategy": "and",
+							"consents": [
+								{"consent": "analytics"},
+								{"consent": "marketing"}
+							]
+						}
+					]
+				}
+			}`,
+		},
+		{
+			Name: "consent source boundary mappings",
+			LocalJSON: `{
+				"secret_key": "secret-server-key",
+				"consent_management": {
+					"android_kotlin": [{"provider": "oneTrust"}],
+					"ios_swift": [{"provider": "ketch"}],
+					"react_native": [{"provider": "iubenda"}]
+				}
+			}`,
+			APIJSON: `{
+				"secretKey": "secret-server-key",
+				"consentManagement": {
+					"androidKotlin": [{"provider": "oneTrust"}],
+					"iosSwift": [{"provider": "ketch"}],
+					"reactnative": [{"provider": "iubenda"}]
+				}
+			}`,
+		},
+	})
+}


### PR DESCRIPTION
## 🔗 Ticket

Resolves [DEX-528](https://linear.app/rudderstack/issue/DEX-528/onboard-destination-statsig)

---

## Summary

Onboards the Statsig (`STATSIG`) destination into the CLI destination definition registry so users can declare and validate Statsig destinations in YAML projects (behind the destinationSupport experimental flag).

---

## Changes

- Added `definitions/statsig` with `definition.go` + `definition_test.go` (metadata, config validation, conversion round-trips)
- Registered Statsig in `newDestinationRegistry` (`dependencies.go`)
- Updated `dependencies_test.go` expected `SupportedTypes()` to `["s3", "statsig"]`

### DestinationDefinition onboarding notes

- **Type / APIType / Version**: `statsig` / `STATSIG` / `1` (from integrations-config `db-config.json` `name` + terraform `ConfigMeta`)
- **Mapped config**: `secret_key` ↔ `secretKey` (required, min 1 / max 200); `consent_management` via `common.Properties`
- **SecretKeys**: `secret_key` (from db-config `secretKeys: ["secretKey"]`)
- **Source types included** (CLI event-stream owned, S3 precedent): android, android_kotlin, ios, ios_swift, web, unity, react_native, flutter, cordova, cloud — all `cloud` connection mode
- **Dropped upstream source types**: `amp`, `shopify`, `warehouse` (not CLI-owned; same as S3)
- **Gated keys**: none (`secretKey` is in `defaultConfig` only)
- **Intentionally omitted**: terraform `connectionMode.*` Simple mappings — CLI handles connection modes via registry `ConnectionModes` + source-type-keyed config machinery (not per-property Simple ports). Consent/`oneTrust`/`ketch` boilerplate also via `common`.
- **Discrepancies flagged**:
  - Terraform `supportedSourceTypes` omits `androidKotlin` / `iosSwift`; db-config includes them — CLI follows db-config and includes both
  - Terraform lists `amp` / `shopify` / `warehouse`; CLI drops them (event-stream ownership)

### Example YAML (validated via `ValidateConfig`)

```yaml
version: rudder/v1
kind: destination
metadata:
  name: my-statsig-destination
spec:
  id: my-statsig-destination
  display_name: My Statsig Destination
  type: statsig
  enabled: true
  definition_version: 1
  config:
    secret_key: secret-xxxxxxxxxxxxxxxx
```

**Usage requires** `experimental: true` + `flags.destinationSupport: true` in the CLI config.

---

## Testing

- `go test ./cli/internal/providers/destination/... ./cli/internal/app/...`
- `make lint`
- `go build ./...`

---

## Risk / Impact

Low
Additive registry entry behind experimental flag; no change to existing destination apply paths when the flag is off.

---

## Checklist

- [x] Ticket linked
- [x] Tests added/updated
- [x] No breaking changes (or documented)

Made with [Cursor](https://cursor.com)