### PR TITLE
feat(cli): onboard zendesk destination definition

### DIFF
--- a/cli/internal/app/dependencies.go
+++ b/cli/internal/app/dependencies.go
@@ -17,6 +17,7 @@ import (
 	destProvider "github.com/rudderlabs/rudder-iac/cli/internal/providers/destination"
 	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions"
 	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions/s3"
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions/zendesk"
 	esProvider "github.com/rudderlabs/rudder-iac/cli/internal/providers/event-stream"
 	"github.com/rudderlabs/rudder-iac/cli/internal/providers/retl"
 	"github.com/rudderlabs/rudder-iac/cli/internal/providers/transformations"
@@ -247,6 +248,9 @@ func newDestinationRegistry(cfg config.Config) (*definitions.Registry, error) {
 	}
 	if err := registry.Register(s3.NewDefinition()); err != nil {
 		return nil, fmt.Errorf("registering s3 destination definition: %w", err)
+	}
+	if err := registry.Register(zendesk.NewDefinition()); err != nil {
+		return nil, fmt.Errorf("registering zendesk destination definition: %w", err)
 	}
 	return registry, nil
 }

--- a/cli/internal/app/dependencies_test.go
+++ b/cli/internal/app/dependencies_test.go
@@ -40,7 +40,7 @@ func TestNewDestinationRegistryRegistersS3WhenFlagEnabled(t *testing.T) {
 
 	registry, err := newDestinationRegistry(config.GetConfig())
 	require.NoError(t, err)
-	assert.Equal(t, []string{"s3"}, registry.SupportedTypes())
+	assert.Equal(t, []string{"s3", "zendesk"}, registry.SupportedTypes())
 }
 
 func TestNewDestinationRegistryEmptyWhenFlagDisabled(t *testing.T) {

--- a/cli/internal/providers/destination/definitions/zendesk/definition.go
+++ b/cli/internal/providers/destination/definitions/zendesk/definition.go
@@ -1,0 +1,75 @@
+package zendesk
+
+import (
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions"
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions/common"
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions/converter"
+)
+
+// Source types from integrations-config destinations/zendesk/db-config.json
+// supportedSourceTypes, restricted to types the CLI event-stream provider owns.
+var sourceTypes = []string{
+	common.SourceTypeAndroid,
+	common.SourceTypeAndroidKotlin,
+	common.SourceTypeIOS,
+	common.SourceTypeIOSSwift,
+	common.SourceTypeWeb,
+	common.SourceTypeUnity,
+	common.SourceTypeReactNative,
+	common.SourceTypeFlutter,
+	common.SourceTypeCordova,
+	common.SourceTypeCloud,
+}
+
+var connectionModes = map[string][]string{
+	common.SourceTypeAndroid:       {"cloud"},
+	common.SourceTypeAndroidKotlin: {"cloud"},
+	common.SourceTypeIOS:           {"cloud"},
+	common.SourceTypeIOSSwift:      {"cloud"},
+	common.SourceTypeWeb:           {"cloud"},
+	common.SourceTypeUnity:         {"cloud"},
+	common.SourceTypeReactNative:   {"cloud"},
+	common.SourceTypeFlutter:       {"cloud"},
+	common.SourceTypeCordova:       {"cloud"},
+	common.SourceTypeCloud:         {"cloud"},
+}
+
+// zendeskConfig is the local YAML config model. Field set mirrors terraform
+// destination_zendesk mappings; validation constraints mirror schema.json.
+type zendeskConfig struct {
+	Email                       string                   `mapstructure:"email" validate:"required,min=1,max=100"`
+	APIToken                    string                   `mapstructure:"api_token" validate:"required,min=1,max=100"`
+	Domain                      string                   `mapstructure:"domain" validate:"required,min=1,max=100"`
+	CreateUsersAsVerified       *bool                    `mapstructure:"create_users_as_verified"`
+	SendGroupCallsWithoutUserID *bool                    `mapstructure:"send_group_calls_without_user_id"`
+	RemoveUsersFromOrganization *bool                    `mapstructure:"remove_users_from_organization"`
+	SearchByExternalID          *bool                    `mapstructure:"search_by_external_id"`
+	ConsentManagement           common.ConsentManagement `mapstructure:"consent_management"`
+}
+
+// NewDefinition returns the Zendesk destination definition.
+func NewDefinition() *definitions.DestinationDefinition {
+	properties := []converter.ConfigProperty{
+		converter.Simple("email", "email"),
+		converter.Simple("apiToken", "api_token"),
+		converter.Simple("domain", "domain"),
+		converter.Simple("createUsersAsVerified", "create_users_as_verified", converter.SkipZeroValue),
+		converter.Simple("sendGroupCallsWithoutUserId", "send_group_calls_without_user_id", converter.SkipZeroValue),
+		converter.Simple("removeUsersFromOrganization", "remove_users_from_organization", converter.SkipZeroValue),
+		converter.Simple("searchByExternalId", "search_by_external_id", converter.SkipZeroValue),
+	}
+	properties = append(properties, common.Properties(sourceTypes)...)
+
+	return &definitions.DestinationDefinition{
+		Type:       "zendesk",
+		APIType:    "ZENDESK",
+		Version:    1,
+		Properties: properties,
+		SecretKeys: []string{"api_token"},
+		NewConfig: func() any {
+			return &zendeskConfig{}
+		},
+		SourceTypes:     append([]string(nil), sourceTypes...),
+		ConnectionModes: connectionModes,
+	}
+}

--- a/cli/internal/providers/destination/definitions/zendesk/definition_test.go
+++ b/cli/internal/providers/destination/definitions/zendesk/definition_test.go
@@ -1,0 +1,281 @@
+package zendesk_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions"
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions/testutil"
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions/zendesk"
+)
+
+func TestNewDefinitionMetadata(t *testing.T) {
+	t.Parallel()
+
+	registry := definitions.NewRegistry()
+	require.NoError(t, registry.Register(zendesk.NewDefinition()))
+
+	registered, err := registry.Get("zendesk", 1)
+	require.NoError(t, err)
+
+	assert.Equal(t, "zendesk", registered.Type)
+	assert.Equal(t, "ZENDESK", registered.APIType)
+	assert.Equal(t, int64(1), registered.Version)
+	assert.Equal(t, []string{"api_token"}, registered.SecretKeys())
+
+	expectedSourceTypes := []string{
+		"android", "android_kotlin", "ios", "ios_swift", "web",
+		"unity", "react_native", "flutter", "cordova", "cloud",
+	}
+	assert.Equal(t, expectedSourceTypes, registered.SupportedSourceTypes())
+
+	for _, sourceType := range expectedSourceTypes {
+		modes, err := registered.ConnectionModes(sourceType)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"cloud"}, modes)
+	}
+
+	assert.NotContains(t, registered.SupportedSourceTypes(), "amp")
+	assert.NotContains(t, registered.SupportedSourceTypes(), "shopify")
+	assert.NotContains(t, registered.SupportedSourceTypes(), "warehouse")
+
+	byAPI, err := registry.GetByAPIType("ZENDESK", 1)
+	require.NoError(t, err)
+	assert.Equal(t, registered, byAPI)
+}
+
+func TestZendeskConfigValidation(t *testing.T) {
+	t.Parallel()
+
+	registry := definitions.NewRegistry()
+	require.NoError(t, registry.Register(zendesk.NewDefinition()))
+	registered, err := registry.Get("zendesk", 1)
+	require.NoError(t, err)
+
+	t.Run("missing email", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{
+			"api_token": "zendesk-api-token",
+			"domain":    "mycompany",
+		})
+		require.NotEmpty(t, errors)
+		assert.Equal(t, "/email", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "required")
+	})
+
+	t.Run("missing api_token", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{
+			"email":  "admin@example.com",
+			"domain": "mycompany",
+		})
+		require.NotEmpty(t, errors)
+		assert.Equal(t, "/api_token", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "required")
+	})
+
+	t.Run("missing domain", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{
+			"email":     "admin@example.com",
+			"api_token": "zendesk-api-token",
+		})
+		require.NotEmpty(t, errors)
+		assert.Equal(t, "/domain", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "required")
+	})
+
+	t.Run("valid minimal config", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{
+			"email":     "admin@example.com",
+			"api_token": "zendesk-api-token",
+			"domain":    "mycompany",
+		})
+		assert.Empty(t, errors)
+	})
+
+	t.Run("valid full config", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{
+			"email":                            "admin@example.com",
+			"api_token":                        "zendesk-api-token",
+			"domain":                           "mycompany",
+			"create_users_as_verified":         true,
+			"send_group_calls_without_user_id": true,
+			"remove_users_from_organization":   false,
+			"search_by_external_id":            true,
+			"consent_management": map[string]any{
+				"web": []any{
+					map[string]any{
+						"provider": "oneTrust",
+						"consents": []any{"analytics"},
+					},
+				},
+			},
+		})
+		assert.Empty(t, errors)
+	})
+
+	t.Run("valid example yaml config", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{
+			"email":                    "admin@example.com",
+			"api_token":                "zendesk-api-token",
+			"domain":                   "mycompany",
+			"create_users_as_verified": true,
+			"search_by_external_id":    true,
+		})
+		assert.Empty(t, errors)
+	})
+
+	t.Run("unknown key rejected", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{
+			"email":       "admin@example.com",
+			"api_token":   "zendesk-api-token",
+			"domain":      "mycompany",
+			"source_name": "rudder",
+		})
+		require.NotEmpty(t, errors)
+		assert.Equal(t, "/source_name", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "unknown config field")
+	})
+
+	t.Run("unsupported consent source rejected", func(t *testing.T) {
+		t.Parallel()
+
+		errors := registered.ValidateConfig(map[string]any{
+			"email":     "admin@example.com",
+			"api_token": "zendesk-api-token",
+			"domain":    "mycompany",
+			"consent_management": map[string]any{
+				"warehouse": []any{},
+			},
+		})
+
+		require.Len(t, errors, 1)
+		assert.Equal(t, "/consent_management/warehouse", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "source type 'warehouse' is not supported")
+	})
+
+	t.Run("invalid consent provider rejected", func(t *testing.T) {
+		t.Parallel()
+
+		errors := registered.ValidateConfig(map[string]any{
+			"email":     "admin@example.com",
+			"api_token": "zendesk-api-token",
+			"domain":    "mycompany",
+			"consent_management": map[string]any{
+				"ios_swift": []any{
+					map[string]any{"provider": "unknown"},
+				},
+			},
+		})
+
+		require.Len(t, errors, 1)
+		assert.Equal(t, "/consent_management/ios_swift/0/provider", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "'provider' must be one of")
+	})
+}
+
+func TestZendeskConversionRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	def := zendesk.NewDefinition()
+	testutil.AssertConversion(t, def.Properties, []testutil.ConversionCase{
+		{
+			Name: "minimal required fields",
+			LocalJSON: `{
+				"email": "admin@example.com",
+				"api_token": "zendesk-api-token",
+				"domain": "mycompany"
+			}`,
+			APIJSON: `{
+				"email": "admin@example.com",
+				"apiToken": "zendesk-api-token",
+				"domain": "mycompany"
+			}`,
+		},
+		{
+			Name: "full TF fields",
+			LocalJSON: `{
+				"email": "admin@example.com",
+				"api_token": "zendesk-api-token",
+				"domain": "mycompany",
+				"create_users_as_verified": true,
+				"send_group_calls_without_user_id": true,
+				"remove_users_from_organization": true,
+				"search_by_external_id": true
+			}`,
+			APIJSON: `{
+				"email": "admin@example.com",
+				"apiToken": "zendesk-api-token",
+				"domain": "mycompany",
+				"createUsersAsVerified": true,
+				"sendGroupCallsWithoutUserId": true,
+				"removeUsersFromOrganization": true,
+				"searchByExternalId": true
+			}`,
+		},
+		{
+			Name: "consent for web",
+			LocalJSON: `{
+				"email": "admin@example.com",
+				"api_token": "zendesk-api-token",
+				"domain": "mycompany",
+				"consent_management": {
+					"web": [
+						{
+							"provider": "oneTrust",
+							"resolution_strategy": "and",
+							"consents": ["analytics", "marketing"]
+						}
+					]
+				}
+			}`,
+			APIJSON: `{
+				"email": "admin@example.com",
+				"apiToken": "zendesk-api-token",
+				"domain": "mycompany",
+				"consentManagement": {
+					"web": [
+						{
+							"provider": "oneTrust",
+							"resolutionStrategy": "and",
+							"consents": [
+								{"consent": "analytics"},
+								{"consent": "marketing"}
+							]
+						}
+					]
+				}
+			}`,
+		},
+		{
+			Name: "consent source boundary mappings",
+			LocalJSON: `{
+				"email": "admin@example.com",
+				"api_token": "zendesk-api-token",
+				"domain": "mycompany",
+				"consent_management": {
+					"android_kotlin": [{"provider": "oneTrust"}],
+					"ios_swift": [{"provider": "ketch"}],
+					"react_native": [{"provider": "iubenda"}]
+				}
+			}`,
+			APIJSON: `{
+				"email": "admin@example.com",
+				"apiToken": "zendesk-api-token",
+				"domain": "mycompany",
+				"consentManagement": {
+					"androidKotlin": [{"provider": "oneTrust"}],
+					"iosSwift": [{"provider": "ketch"}],
+					"reactnative": [{"provider": "iubenda"}]
+				}
+			}`,
+		},
+	})
+}


### PR DESCRIPTION
## 🔗 Ticket

Resolves [DEX-532](https://linear.app/rudderstack/issue/DEX-532/onboard-destination-zendesk)

---

## Summary

Onboards the Zendesk destination into the CLI destination definition registry so it can be managed via YAML specs under the experimental destination support flag.

---

## Changes

- Added `definitions/zendesk` with property mappings from terraform `destination_zendesk.go` and validations from integrations-config `schema.json`
- Registered Zendesk in `newDestinationRegistry` (`APIType: ZENDESK`, `Version: 1`)
- Updated registry supported-types expectation in `dependencies_test.go`
- Unit coverage for metadata, config validation, and local↔API conversion round-trips

### DestinationDefinition onboard report

| Item | Value |
| --- | --- |
| localType / Type | `zendesk` |
| APIType | `ZENDESK` |
| Version | `1` |
| SecretKeys | `api_token` |
| Mapped properties | `email`, `api_token`, `domain`, `create_users_as_verified`, `send_group_calls_without_user_id`, `remove_users_from_organization`, `search_by_external_id`, `consent_management` |
| Gated keys | none (all terraform-mapped keys are in `defaultConfig`) |

**Source types included (S3 precedent):** `android`, `android_kotlin`, `ios`, `ios_swift`, `web`, `unity`, `react_native`, `flutter`, `cordova`, `cloud` — all `cloud` connection mode.

**Dropped upstream source types:** `amp`, `shopify`, `warehouse` (not CLI event-stream owned; same as S3).

**Omitted upstream fields (no terraform mapping):** `sourceName` / `source_name` (present in db-config `defaultConfig` + schema.json, absent from terraform properties).

**Terraform vs db-config note:** terraform `supportedSourceTypes` omits `androidKotlin` / `iosSwift`; CLI follows db-config and includes them (with consent support).

**Unenforced schema patterns:** length-only patterns (`^(.{1,100})$`) translated to `min=1,max=100` / `max=100`; template/env escape prefixes handled outside validate tags.

### Example YAML (validated via `ValidateConfig`)

```yaml
version: rudder/v1
kind: destination
metadata:
  name: my-zendesk-destination
spec:
  id: my-zendesk-destination
  display_name: My Zendesk Destination
  type: zendesk
  enabled: true
  definition_version: 1
  config:
    email: admin@example.com
    api_token: zendesk-api-token
    domain: mycompany
    create_users_as_verified: true
    search_by_external_id: true
```

**Usage requires** `experimental: true` + `flags.destinationSupport: true` in the CLI config.

---

## Testing

- `go test ./cli/internal/providers/destination/... ./cli/internal/app/...`
- `go build ./...`
- `make lint`

---

## Risk / Impact

Low
Additive registry entry behind experimental flag; no changes to existing destination apply behavior.

---

## Checklist

- [x] Ticket linked
- [x] Tests added/updated
- [x] No breaking changes (or documented)

Made with [Cursor](https://cursor.com)