### PR TITLE
feat(cli): onboard googleads destination definition

### DIFF
--- a/cli/internal/app/dependencies.go
+++ b/cli/internal/app/dependencies.go
@@ -16,6 +16,7 @@ import (
 	dgProvider "github.com/rudderlabs/rudder-iac/cli/internal/providers/datagraph"
 	destProvider "github.com/rudderlabs/rudder-iac/cli/internal/providers/destination"
 	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions"
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions/googleads"
 	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions/s3"
 	esProvider "github.com/rudderlabs/rudder-iac/cli/internal/providers/event-stream"
 	"github.com/rudderlabs/rudder-iac/cli/internal/providers/retl"
@@ -247,6 +248,9 @@ func newDestinationRegistry(cfg config.Config) (*definitions.Registry, error) {
 	}
 	if err := registry.Register(s3.NewDefinition()); err != nil {
 		return nil, fmt.Errorf("registering s3 destination definition: %w", err)
+	}
+	if err := registry.Register(googleads.NewDefinition()); err != nil {
+		return nil, fmt.Errorf("registering googleads destination definition: %w", err)
 	}
 	return registry, nil
 }

--- a/cli/internal/app/dependencies_test.go
+++ b/cli/internal/app/dependencies_test.go
@@ -40,7 +40,7 @@ func TestNewDestinationRegistryRegistersS3WhenFlagEnabled(t *testing.T) {
 
 	registry, err := newDestinationRegistry(config.GetConfig())
 	require.NoError(t, err)
-	assert.Equal(t, []string{"s3"}, registry.SupportedTypes())
+	assert.Equal(t, []string{"googleads", "s3"}, registry.SupportedTypes())
 }
 
 func TestNewDestinationRegistryEmptyWhenFlagDisabled(t *testing.T) {

--- a/cli/internal/providers/destination/definitions/googleads/definition.go
+++ b/cli/internal/providers/destination/definitions/googleads/definition.go
@@ -34,7 +34,7 @@ type webBoolConfig struct {
 // terraform-provider destination_google_ads.go; validation constraints mirror
 // overlapping schema.json rules for those mapped fields.
 type googleAdsConfig struct {
-	ConversionID             string                   `mapstructure:"conversion_id" validate:"required,min=1,max=103"`
+	ConversionID             string                   `mapstructure:"conversion_id" validate:"required,pattern=googleads_conversion_id"`
 	PageLoadConversions      []conversionEntry        `mapstructure:"page_load_conversions" validate:"omitempty,dive"`
 	ClickEventConversions    []conversionEntry        `mapstructure:"click_event_conversions" validate:"omitempty,dive"`
 	DefaultPageConversion    string                   `mapstructure:"default_page_conversion" validate:"omitempty,max=100"`

--- a/cli/internal/providers/destination/definitions/googleads/definition.go
+++ b/cli/internal/providers/destination/definitions/googleads/definition.go
@@ -1,0 +1,88 @@
+package googleads
+
+import (
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions"
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions/common"
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions/converter"
+)
+
+// Source types from integrations-config destinations/googleads/db-config.json
+// supportedSourceTypes (web only).
+var sourceTypes = []string{
+	common.SourceTypeWeb,
+}
+
+var connectionModes = map[string][]string{
+	common.SourceTypeWeb: {"device"},
+}
+
+type conversionEntry struct {
+	Label string `mapstructure:"label" validate:"required,max=100"`
+	Name  string `mapstructure:"name" validate:"required,max=100"`
+}
+
+type eventFilteringConfig struct {
+	Whitelist []string `mapstructure:"whitelist" validate:"omitempty,dive,max=100"`
+	Blacklist []string `mapstructure:"blacklist" validate:"omitempty,dive,max=100"`
+}
+
+type webBoolConfig struct {
+	Web *bool `mapstructure:"web"`
+}
+
+// googleAdsConfig is the local YAML config model. Field set mirrors
+// terraform-provider destination_google_ads.go; validation constraints mirror
+// overlapping schema.json rules for those mapped fields.
+type googleAdsConfig struct {
+	ConversionID             string                   `mapstructure:"conversion_id" validate:"required,min=1,max=103"`
+	PageLoadConversions      []conversionEntry        `mapstructure:"page_load_conversions" validate:"omitempty,dive"`
+	ClickEventConversions    []conversionEntry        `mapstructure:"click_event_conversions" validate:"omitempty,dive"`
+	DefaultPageConversion    string                   `mapstructure:"default_page_conversion" validate:"omitempty,max=100"`
+	DynamicRemarketing       *webBoolConfig           `mapstructure:"dynamic_remarketing"`
+	ConversionLinker         *bool                    `mapstructure:"conversion_linker"`
+	SendPageView             *bool                    `mapstructure:"send_page_view"`
+	DisableAdPersonalization *bool                    `mapstructure:"disable_ad_personalization"`
+	EventFiltering           *eventFilteringConfig    `mapstructure:"event_filtering"`
+	UseNativeSDK             *webBoolConfig           `mapstructure:"use_native_sdk"`
+	ConsentManagement        common.ConsentManagement `mapstructure:"consent_management"`
+}
+
+// NewDefinition returns the Google Ads (API type GOOGLEADS) destination definition.
+func NewDefinition() *definitions.DestinationDefinition {
+	properties := []converter.ConfigProperty{
+		converter.Simple("conversionID", "conversion_id"),
+		converter.ArrayWithObjects("pageLoadConversions", "page_load_conversions", map[string]any{
+			"conversionLabel": "label",
+			"name":            "name",
+		}),
+		converter.ArrayWithObjects("clickEventConversions", "click_event_conversions", map[string]any{
+			"conversionLabel": "label",
+			"name":            "name",
+		}),
+		converter.Simple("defaultPageConversion", "default_page_conversion", converter.SkipZeroValue),
+		converter.Simple("dynamicRemarketing.web", "dynamic_remarketing.web"),
+		converter.Simple("conversionLinker", "conversion_linker"),
+		converter.Simple("sendPageView", "send_page_view"),
+		converter.Simple("disableAdPersonalization", "disable_ad_personalization", converter.SkipZeroValue),
+		converter.ArrayWithStrings("whitelistedEvents", "eventName", "event_filtering.whitelist"),
+		converter.ArrayWithStrings("blacklistedEvents", "eventName", "event_filtering.blacklist"),
+		converter.Discriminator("eventFilteringOption", converter.DiscriminatorValues{
+			"event_filtering.whitelist": "whitelistedEvents",
+			"event_filtering.blacklist": "blacklistedEvents",
+		}),
+		converter.Simple("useNativeSDK.web", "use_native_sdk.web"),
+	}
+	properties = append(properties, common.Properties(sourceTypes)...)
+
+	return &definitions.DestinationDefinition{
+		Type:       "googleads",
+		APIType:    "GOOGLEADS",
+		Version:    1,
+		Properties: properties,
+		NewConfig: func() any {
+			return &googleAdsConfig{}
+		},
+		SourceTypes:     append([]string(nil), sourceTypes...),
+		ConnectionModes: connectionModes,
+	}
+}

--- a/cli/internal/providers/destination/definitions/googleads/definition_test.go
+++ b/cli/internal/providers/destination/definitions/googleads/definition_test.go
@@ -1,0 +1,317 @@
+package googleads_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions"
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions/googleads"
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions/testutil"
+)
+
+func TestNewDefinitionMetadata(t *testing.T) {
+	t.Parallel()
+
+	registry := definitions.NewRegistry()
+	require.NoError(t, registry.Register(googleads.NewDefinition()))
+
+	registered, err := registry.Get("googleads", 1)
+	require.NoError(t, err)
+
+	assert.Equal(t, "googleads", registered.Type)
+	assert.Equal(t, "GOOGLEADS", registered.APIType)
+	assert.Equal(t, int64(1), registered.Version)
+	assert.Equal(t, []string{}, registered.SecretKeys())
+
+	expectedSourceTypes := []string{"web"}
+	assert.Equal(t, expectedSourceTypes, registered.SupportedSourceTypes())
+
+	modes, err := registered.ConnectionModes("web")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"device"}, modes)
+
+	assert.Empty(t, registered.GatedKeyPaths())
+
+	byAPI, err := registry.GetByAPIType("GOOGLEADS", 1)
+	require.NoError(t, err)
+	assert.Equal(t, registered, byAPI)
+}
+
+func TestGoogleAdsConfigValidation(t *testing.T) {
+	t.Parallel()
+
+	registry := definitions.NewRegistry()
+	require.NoError(t, registry.Register(googleads.NewDefinition()))
+	registered, err := registry.Get("googleads", 1)
+	require.NoError(t, err)
+
+	t.Run("missing conversion_id", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{})
+		require.NotEmpty(t, errors)
+		assert.Equal(t, "/conversion_id", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "required")
+	})
+
+	t.Run("valid minimal config", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{
+			"conversion_id": "AW-123456789",
+		})
+		assert.Empty(t, errors)
+	})
+
+	t.Run("valid full config", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{
+			"conversion_id": "AW-123456789",
+			"page_load_conversions": []any{
+				map[string]any{"label": "page-label", "name": "home"},
+			},
+			"click_event_conversions": []any{
+				map[string]any{"label": "click-label", "name": "Purchase"},
+			},
+			"default_page_conversion": "default-label",
+			"dynamic_remarketing": map[string]any{
+				"web": true,
+			},
+			"conversion_linker":          true,
+			"send_page_view":             true,
+			"disable_ad_personalization": true,
+			"event_filtering": map[string]any{
+				"whitelist": []any{"Product Viewed", "Order Completed"},
+			},
+			"use_native_sdk": map[string]any{
+				"web": true,
+			},
+			"consent_management": map[string]any{
+				"web": []any{
+					map[string]any{
+						"provider": "oneTrust",
+						"consents": []any{"analytics"},
+					},
+				},
+			},
+		})
+		assert.Empty(t, errors)
+	})
+
+	t.Run("valid example yaml config", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{
+			"conversion_id": "AW-123456789",
+			"page_load_conversions": []any{
+				map[string]any{"label": "abcDEF123", "name": "home"},
+			},
+			"click_event_conversions": []any{
+				map[string]any{"label": "xyzABC456", "name": "Purchase"},
+			},
+			"default_page_conversion": "defaultLabel",
+			"dynamic_remarketing": map[string]any{
+				"web": true,
+			},
+			"conversion_linker":          true,
+			"send_page_view":             true,
+			"disable_ad_personalization": false,
+			"event_filtering": map[string]any{
+				"blacklist": []any{"Application Opened"},
+			},
+			"use_native_sdk": map[string]any{
+				"web": true,
+			},
+			"consent_management": map[string]any{
+				"web": []any{
+					map[string]any{
+						"provider":            "oneTrust",
+						"resolution_strategy": "and",
+						"consents":            []any{"analytics", "marketing"},
+					},
+				},
+			},
+		})
+		assert.Empty(t, errors)
+	})
+
+	t.Run("page_load_conversions label required", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{
+			"conversion_id": "AW-123456789",
+			"page_load_conversions": []any{
+				map[string]any{"name": "home"},
+			},
+		})
+		require.NotEmpty(t, errors)
+		assert.Equal(t, "/page_load_conversions/0/label", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "required")
+	})
+
+	t.Run("unknown key rejected", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{
+			"conversion_id": "AW-123456789",
+			"not_a_field":   true,
+		})
+		require.NotEmpty(t, errors)
+		assert.Equal(t, "/not_a_field", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "unknown config field")
+	})
+
+	t.Run("unsupported consent source rejected", func(t *testing.T) {
+		t.Parallel()
+
+		errors := registered.ValidateConfig(map[string]any{
+			"conversion_id": "AW-123456789",
+			"consent_management": map[string]any{
+				"android": []any{},
+			},
+		})
+
+		require.Len(t, errors, 1)
+		assert.Equal(t, "/consent_management/android", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "source type 'android' is not supported")
+	})
+
+	t.Run("invalid consent provider rejected", func(t *testing.T) {
+		t.Parallel()
+
+		errors := registered.ValidateConfig(map[string]any{
+			"conversion_id": "AW-123456789",
+			"consent_management": map[string]any{
+				"web": []any{
+					map[string]any{"provider": "unknown"},
+				},
+			},
+		})
+
+		require.Len(t, errors, 1)
+		assert.Equal(t, "/consent_management/web/0/provider", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "'provider' must be one of")
+	})
+}
+
+func TestGoogleAdsConversionRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	def := googleads.NewDefinition()
+	testutil.AssertConversion(t, def.Properties, []testutil.ConversionCase{
+		{
+			Name: "minimal conversion id only",
+			LocalJSON: `{
+				"conversion_id": "AW-123456789"
+			}`,
+			APIJSON: `{
+				"conversionID": "AW-123456789"
+			}`,
+		},
+		{
+			Name: "full TF fields with whitelist",
+			LocalJSON: `{
+				"conversion_id": "AW-123456789",
+				"page_load_conversions": [
+					{"label": "page-label", "name": "home"}
+				],
+				"click_event_conversions": [
+					{"label": "click-label", "name": "Purchase"}
+				],
+				"default_page_conversion": "default-label",
+				"dynamic_remarketing": {"web": true},
+				"conversion_linker": true,
+				"send_page_view": true,
+				"disable_ad_personalization": true,
+				"event_filtering": {
+					"whitelist": ["Product Viewed", "Order Completed"]
+				},
+				"use_native_sdk": {"web": true}
+			}`,
+			APIJSON: `{
+				"conversionID": "AW-123456789",
+				"pageLoadConversions": [
+					{"conversionLabel": "page-label", "name": "home"}
+				],
+				"clickEventConversions": [
+					{"conversionLabel": "click-label", "name": "Purchase"}
+				],
+				"defaultPageConversion": "default-label",
+				"dynamicRemarketing": {"web": true},
+				"conversionLinker": true,
+				"sendPageView": true,
+				"disableAdPersonalization": true,
+				"whitelistedEvents": [
+					{"eventName": "Product Viewed"},
+					{"eventName": "Order Completed"}
+				],
+				"eventFilteringOption": "whitelistedEvents",
+				"useNativeSDK": {"web": true}
+			}`,
+		},
+		{
+			Name: "event filtering blacklist reshape",
+			LocalJSON: `{
+				"conversion_id": "AW-123456789",
+				"event_filtering": {
+					"blacklist": ["Application Opened"]
+				}
+			}`,
+			APIJSON: `{
+				"conversionID": "AW-123456789",
+				"blacklistedEvents": [
+					{"eventName": "Application Opened"}
+				],
+				"eventFilteringOption": "blacklistedEvents"
+			}`,
+		},
+		{
+			Name: "conversion arrays reshape",
+			LocalJSON: `{
+				"conversion_id": "AW-123456789",
+				"page_load_conversions": [
+					{"label": "lbl1", "name": "Page Viewed"}
+				],
+				"click_event_conversions": [
+					{"label": "lbl2", "name": "Signed Up"}
+				]
+			}`,
+			APIJSON: `{
+				"conversionID": "AW-123456789",
+				"pageLoadConversions": [
+					{"conversionLabel": "lbl1", "name": "Page Viewed"}
+				],
+				"clickEventConversions": [
+					{"conversionLabel": "lbl2", "name": "Signed Up"}
+				]
+			}`,
+		},
+		{
+			Name: "consent for web",
+			LocalJSON: `{
+				"conversion_id": "AW-123456789",
+				"consent_management": {
+					"web": [
+						{
+							"provider": "oneTrust",
+							"resolution_strategy": "and",
+							"consents": ["analytics", "marketing"]
+						}
+					]
+				}
+			}`,
+			APIJSON: `{
+				"conversionID": "AW-123456789",
+				"consentManagement": {
+					"web": [
+						{
+							"provider": "oneTrust",
+							"resolutionStrategy": "and",
+							"consents": [
+								{"consent": "analytics"},
+								{"consent": "marketing"}
+							]
+						}
+					]
+				}
+			}`,
+		},
+	})
+}

--- a/cli/internal/providers/destination/definitions/googleads/definition_test.go
+++ b/cli/internal/providers/destination/definitions/googleads/definition_test.go
@@ -55,6 +55,26 @@ func TestGoogleAdsConfigValidation(t *testing.T) {
 		assert.Contains(t, errors[0].Message, "required")
 	})
 
+	t.Run("invalid conversion_id rejected", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{
+			"conversion_id": "123456789",
+		})
+		require.Len(t, errors, 1)
+		assert.Equal(t, "/conversion_id", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "must be a Google Ads conversion ID starting with AW-")
+	})
+
+	t.Run("env-style conversion_id rejected", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{
+			"conversion_id": "env.CONVERSION_ID",
+		})
+		require.Len(t, errors, 1)
+		assert.Equal(t, "/conversion_id", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "must be a Google Ads conversion ID starting with AW-")
+	})
+
 	t.Run("valid minimal config", func(t *testing.T) {
 		t.Parallel()
 		errors := registered.ValidateConfig(map[string]any{

--- a/cli/internal/providers/destination/definitions/googleads/patterns.go
+++ b/cli/internal/providers/destination/definitions/googleads/patterns.go
@@ -1,0 +1,18 @@
+package googleads
+
+import (
+	"github.com/rudderlabs/rudder-iac/cli/internal/provider/rules/funcs"
+)
+
+const (
+	// conversionIDPattern is the real value constraint from integrations-config
+	// googleads schema.json / terraform StringMatchesRegexp, with upstream
+	// env./{{…}} alternations stripped.
+	conversionIDPattern      = `^AW-(.{0,100})$`
+	conversionIDPatternTag   = "googleads_conversion_id"
+	conversionIDErrorMessage = "must be a Google Ads conversion ID starting with AW-"
+)
+
+func init() {
+	funcs.NewPattern(conversionIDPatternTag, conversionIDPattern, conversionIDErrorMessage)
+}


### PR DESCRIPTION
## 🔗 Ticket

Resolves [DEX-501](https://linear.app/rudderstack/issue/DEX-501/onboard-destination-google-ads)

---

## Summary

Onboards the Google Ads destination (`GOOGLEADS`) into the CLI destination definition registry so it can be managed via YAML specs when destination support is enabled.

---

## Changes

- Added `definitions/googleads/` with `definition.go` and `definition_test.go`
- Registered the definition in `newDestinationRegistry`
- Updated registry supported-types expectation in `dependencies_test.go`

### Naming

| Source | Value |
| --- | --- |
| integrations-config directory | `googleads` |
| db-config `name` / CLI `APIType` | `GOOGLEADS` |
| CLI local `Type` | `googleads` (`lowercase(APIType)`) |
| terraform resource name | `google_ads` (flagged mismatch; not used as CLI type) |

### Mapped config surface (from terraform)

- `conversion_id` (required)
- `page_load_conversions` / `click_event_conversions` (label + name arrays)
- `default_page_conversion`
- `dynamic_remarketing.web`
- `conversion_linker`, `send_page_view`, `disable_ad_personalization`
- `event_filtering` whitelist/blacklist + discriminator
- `use_native_sdk.web`
- `consent_management` via `common.Properties`

### Omitted upstream fields (no terraform mapping)

- `v2`, `allowIdentify`, `sdkBaseUrl`, `eventMappingFromConfig`
- `trackConversions`, `enableConversionEventsFiltering`, `eventsToTrackConversions`
- `trackDynamicRemarketing`, `enableDynamicRemarketingEventsFiltering`, `eventsToTrackDynamicRemarketing`
- `allowEnhancedConversions`, `enableConversionLabel`

### Discrepancies / notes

- `conversionID` schema pattern requires `AW-…` prefix — not enforced via validate tags (length capped at 103); flagged as unenforced regex
- Terraform maps `dynamicRemarketing.web`; db-config lists flat `dynamicRemarketing` in `defaultConfig` — followed terraform mapping
- No gated keys: terraform-mapped keys are either in `defaultConfig` or are boilerplate (`useNativeSDK` / consent) skipped for gating
- `secretKeys`: empty upstream and in definition
- Source types: web only (`device` connection mode)

### Example YAML (validated via `ValidateConfig`)

```yaml
version: rudder/v1
kind: destination
metadata:
  name: my-googleads-destination
spec:
  id: my-googleads-destination
  display_name: My Google Ads Destination
  type: googleads
  enabled: true
  definition_version: 1
  config:
    conversion_id: AW-123456789
    page_load_conversions:
      - label: abcDEF123
        name: home
    click_event_conversions:
      - label: xyzABC456
        name: Purchase
    default_page_conversion: defaultLabel
    dynamic_remarketing:
      web: true
    conversion_linker: true
    send_page_view: true
    disable_ad_personalization: false
    event_filtering:
      blacklist:
        - Application Opened
    use_native_sdk:
      web: true
    consent_management:
      web:
        - provider: oneTrust
          resolution_strategy: and
          consents:
            - analytics
            - marketing
```

### Usage reminder

Requires `experimental: true` and `flags.destinationSupport: true` in the CLI config.

---

## Testing

- `go build ./...`
- `go test ./cli/internal/providers/destination/... ./cli/internal/app/...`
- `make lint`

---

## Risk / Impact

Low
Additive registry entry behind the existing destinationSupport experimental flag; no change to apply behavior for existing projects.

---

## Checklist

- [x] Ticket linked
- [x] Tests added/updated
- [x] No breaking changes (or documented)

Made with [Cursor](https://cursor.com)