### PR TITLE
feat(cli): onboard adobe_analytics destination definition

### DIFF
--- a/cli/internal/app/dependencies.go
+++ b/cli/internal/app/dependencies.go
@@ -16,6 +16,7 @@ import (
 	dgProvider "github.com/rudderlabs/rudder-iac/cli/internal/providers/datagraph"
 	destProvider "github.com/rudderlabs/rudder-iac/cli/internal/providers/destination"
 	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions"
+	adobeanalytics "github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions/adobe_analytics"
 	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions/s3"
 	esProvider "github.com/rudderlabs/rudder-iac/cli/internal/providers/event-stream"
 	"github.com/rudderlabs/rudder-iac/cli/internal/providers/retl"
@@ -247,6 +248,9 @@ func newDestinationRegistry(cfg config.Config) (*definitions.Registry, error) {
 	}
 	if err := registry.Register(s3.NewDefinition()); err != nil {
 		return nil, fmt.Errorf("registering s3 destination definition: %w", err)
+	}
+	if err := registry.Register(adobeanalytics.NewDefinition()); err != nil {
+		return nil, fmt.Errorf("registering adobe_analytics destination definition: %w", err)
 	}
 	return registry, nil
 }

--- a/cli/internal/app/dependencies_test.go
+++ b/cli/internal/app/dependencies_test.go
@@ -40,7 +40,7 @@ func TestNewDestinationRegistryRegistersS3WhenFlagEnabled(t *testing.T) {
 
 	registry, err := newDestinationRegistry(config.GetConfig())
 	require.NoError(t, err)
-	assert.Equal(t, []string{"s3"}, registry.SupportedTypes())
+	assert.Equal(t, []string{"adobe_analytics", "s3"}, registry.SupportedTypes())
 }
 
 func TestNewDestinationRegistryEmptyWhenFlagDisabled(t *testing.T) {

--- a/cli/internal/providers/destination/definitions/adobe_analytics/definition.go
+++ b/cli/internal/providers/destination/definitions/adobe_analytics/definition.go
@@ -1,0 +1,211 @@
+package adobeanalytics
+
+import (
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions"
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions/common"
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions/converter"
+)
+
+// Source types from integrations-config destinations/adobe_analytics/db-config.json
+// supportedSourceTypes, restricted to types the CLI event-stream provider owns.
+var sourceTypes = []string{
+	common.SourceTypeAndroid,
+	common.SourceTypeAndroidKotlin,
+	common.SourceTypeIOS,
+	common.SourceTypeIOSSwift,
+	common.SourceTypeWeb,
+	common.SourceTypeUnity,
+	common.SourceTypeReactNative,
+	common.SourceTypeFlutter,
+	common.SourceTypeCordova,
+	common.SourceTypeCloud,
+}
+
+var connectionModes = map[string][]string{
+	common.SourceTypeAndroid:       {"cloud", "device"},
+	common.SourceTypeAndroidKotlin: {"cloud"},
+	common.SourceTypeIOS:           {"cloud", "device"},
+	common.SourceTypeIOSSwift:      {"cloud"},
+	common.SourceTypeWeb:           {"cloud", "device"},
+	common.SourceTypeUnity:         {"cloud"},
+	common.SourceTypeReactNative:   {"cloud"},
+	common.SourceTypeFlutter:       {"cloud"},
+	common.SourceTypeCordova:       {"cloud"},
+	common.SourceTypeCloud:         {"cloud"},
+}
+
+type mappingEntry struct {
+	From string `mapstructure:"from" validate:"required,max=100"`
+	To   string `mapstructure:"to" validate:"required,max=100"`
+}
+
+type eventToTypeEntry struct {
+	From string `mapstructure:"from" validate:"required,max=100"`
+	To   string `mapstructure:"to" validate:"required,dynamic_or_oneof=initHeartbeat heartbeatPlaybackStarted heartbeatPlaybackPaused heartbeatPlaybackResumed heartbeatPlaybackCompleted heartbeatPlaybackInterrupted heartbeatContentStarted heartbeatContentComplete heartbeatAdBreakStarted heartbeatAdBreakCompleted heartbeatAdStarted heartbeatAdCompleted heartbeatAdSkipped heartbeatSeekStarted heartbeatSeekCompleted heartbeatBufferStarted heartbeatBufferCompleted heartbeatQualityUpdated heartbeatUpdatePlayhead"`
+}
+
+type delimiterEntry struct {
+	From string `mapstructure:"from" validate:"required,max=100"`
+	To   string `mapstructure:"to" validate:"required,pattern=adobe_analytics_delimiter"`
+}
+
+type eventFiltering struct {
+	Whitelist []string `mapstructure:"whitelist" validate:"omitempty,dive,max=100"`
+	Blacklist []string `mapstructure:"blacklist" validate:"omitempty,dive,max=100"`
+}
+
+type useNativeSDK struct {
+	Web         *bool `mapstructure:"web"`
+	IOS         *bool `mapstructure:"ios"`
+	Android     *bool `mapstructure:"android"`
+	ReactNative *bool `mapstructure:"react_native"`
+}
+
+// adobeAnalyticsConfig is the local YAML config model. Field set mirrors
+// terraform-provider destination_adobe_analytics.go; validation constraints
+// mirror overlapping schema.json rules for those mapped fields.
+type adobeAnalyticsConfig struct {
+	TrackingServerUrl             string                   `mapstructure:"tracking_server_url" validate:"omitempty,max=100"`
+	TrackingServerSecureUrl       string                   `mapstructure:"tracking_server_secure_url" validate:"omitempty,max=100"`
+	ReportSuiteIDs                string                   `mapstructure:"report_suite_ids" validate:"required,min=1,max=300"`
+	SSLHeartbeat                  *bool                    `mapstructure:"ssl_heartbeat"`
+	HeartbeatTrackingServerUrl    string                   `mapstructure:"heartbeat_tracking_server_url" validate:"omitempty,max=100"`
+	UseUTF8Charset                *bool                    `mapstructure:"use_utf8_charset"`
+	UseSecureServerSide           *bool                    `mapstructure:"use_secure_server_side"`
+	ProxyNormalUrl                string                   `mapstructure:"proxy_normal_url" validate:"omitempty,max=100"`
+	ProxyHeartbeatUrl             string                   `mapstructure:"proxy_heartbeat_url" validate:"omitempty,max=100"`
+	EventsToTypes                 []eventToTypeEntry       `mapstructure:"events_to_types" validate:"omitempty,dive"`
+	MarketingCloudOrgID           string                   `mapstructure:"marketing_cloud_org_id" validate:"omitempty,max=100"`
+	DropVisitorID                 *bool                    `mapstructure:"drop_visitor_id"`
+	TimestampOption               string                   `mapstructure:"timestamp_option" validate:"omitempty,dynamic_or_oneof=disabled hybrid optional enabled"`
+	TimestampOptionalReporting    *bool                    `mapstructure:"timestamp_optional_reporting"`
+	NoFallbackVisitorID           *bool                    `mapstructure:"no_fallback_visitor_id"`
+	PreferVisitorID               *bool                    `mapstructure:"prefer_visitor_id"`
+	RudderEventsToAdobeEvents     []mappingEntry           `mapstructure:"rudder_events_to_adobe_events" validate:"omitempty,dive"`
+	TrackPageName                 *bool                    `mapstructure:"track_page_name"`
+	ContextDataMapping            []mappingEntry           `mapstructure:"context_data_mapping" validate:"omitempty,dive"`
+	ContextDataPrefix             string                   `mapstructure:"context_data_prefix" validate:"omitempty,max=100"`
+	UseLegacyLinkName             *bool                    `mapstructure:"use_legacy_link_name"`
+	PageNameFallbackToString      *bool                    `mapstructure:"page_name_fallback_tostring"`
+	MobileEventMapping            []mappingEntry           `mapstructure:"mobile_event_mapping" validate:"omitempty,dive"`
+	SendFalseValues               *bool                    `mapstructure:"send_false_values"`
+	EVarMapping                   []mappingEntry           `mapstructure:"e_var_mapping" validate:"omitempty,dive"`
+	HierMapping                   []mappingEntry           `mapstructure:"hier_mapping" validate:"omitempty,dive"`
+	ListMapping                   []mappingEntry           `mapstructure:"list_mapping" validate:"omitempty,dive"`
+	ListDelimiter                 []delimiterEntry         `mapstructure:"list_delimiter" validate:"omitempty,dive"`
+	CustomPropsMapping            []mappingEntry           `mapstructure:"custom_props_mapping" validate:"omitempty,dive"`
+	PropsDelimiter                []delimiterEntry         `mapstructure:"props_delimiter" validate:"omitempty,dive"`
+	EventMerchEventToAdobeEvent   []mappingEntry           `mapstructure:"event_merch_event_to_adobe_event" validate:"omitempty,dive"`
+	EventMerchProperties          []string                 `mapstructure:"event_merch_properties" validate:"omitempty,dive,max=100"`
+	ProductMerchEventToAdobeEvent []mappingEntry           `mapstructure:"product_merch_event_to_adobe_event" validate:"omitempty,dive"`
+	ProductMerchProperties        []string                 `mapstructure:"product_merch_properties" validate:"omitempty,dive,max=100"`
+	ProductMerchEvarsMap          []mappingEntry           `mapstructure:"product_merch_evars_map" validate:"omitempty,dive"`
+	ProductIdentifier             string                   `mapstructure:"product_identifier" validate:"omitempty,dynamic_or_oneof=name id sku"`
+	EventFiltering                *eventFiltering          `mapstructure:"event_filtering"`
+	UseNativeSDK                  *useNativeSDK            `mapstructure:"use_native_sdk"`
+	ConsentManagement             common.ConsentManagement `mapstructure:"consent_management"`
+}
+
+// NewDefinition returns the Adobe Analytics destination definition.
+func NewDefinition() *definitions.DestinationDefinition {
+	properties := []converter.ConfigProperty{
+		converter.Simple("trackingServerUrl", "tracking_server_url", converter.SkipZeroValue),
+		converter.Simple("trackingServerSecureUrl", "tracking_server_secure_url", converter.SkipZeroValue),
+		converter.Simple("reportSuiteIds", "report_suite_ids"),
+		converter.Simple("sslHeartbeat", "ssl_heartbeat"),
+		converter.Simple("heartbeatTrackingServerUrl", "heartbeat_tracking_server_url", converter.SkipZeroValue),
+		converter.Simple("useUtf8Charset", "use_utf8_charset"),
+		converter.Simple("useSecureServerSide", "use_secure_server_side"),
+		converter.Simple("proxyNormalUrl", "proxy_normal_url", converter.SkipZeroValue),
+		converter.Simple("proxyHeartbeatUrl", "proxy_heartbeat_url", converter.SkipZeroValue),
+		converter.ArrayWithObjects("eventsToTypes", "events_to_types", map[string]any{
+			"from": "from",
+			"to":   "to",
+		}),
+		converter.Simple("marketingCloudOrgId", "marketing_cloud_org_id", converter.SkipZeroValue),
+		converter.Simple("dropVisitorId", "drop_visitor_id"),
+		converter.Simple("timestampOption", "timestamp_option"),
+		converter.Simple("timestampOptionalReporting", "timestamp_optional_reporting"),
+		converter.Simple("noFallbackVisitorId", "no_fallback_visitor_id"),
+		converter.Simple("preferVisitorId", "prefer_visitor_id"),
+		converter.ArrayWithObjects("rudderEventsToAdobeEvents", "rudder_events_to_adobe_events", map[string]any{
+			"from": "from",
+			"to":   "to",
+		}),
+		converter.Simple("trackPageName", "track_page_name"),
+		converter.ArrayWithObjects("contextDataMapping", "context_data_mapping", map[string]any{
+			"from": "from",
+			"to":   "to",
+		}),
+		converter.Simple("contextDataPrefix", "context_data_prefix", converter.SkipZeroValue),
+		converter.Simple("useLegacyLinkName", "use_legacy_link_name"),
+		converter.Simple("pageNameFallbackTostring", "page_name_fallback_tostring"),
+		converter.ArrayWithObjects("mobileEventMapping", "mobile_event_mapping", map[string]any{
+			"from": "from",
+			"to":   "to",
+		}),
+		converter.Simple("sendFalseValues", "send_false_values"),
+		converter.ArrayWithObjects("eVarMapping", "e_var_mapping", map[string]any{
+			"from": "from",
+			"to":   "to",
+		}),
+		converter.ArrayWithObjects("hierMapping", "hier_mapping", map[string]any{
+			"from": "from",
+			"to":   "to",
+		}),
+		converter.ArrayWithObjects("listMapping", "list_mapping", map[string]any{
+			"from": "from",
+			"to":   "to",
+		}),
+		converter.ArrayWithObjects("listDelimiter", "list_delimiter", map[string]any{
+			"from": "from",
+			"to":   "to",
+		}),
+		converter.ArrayWithObjects("customPropsMapping", "custom_props_mapping", map[string]any{
+			"from": "from",
+			"to":   "to",
+		}),
+		converter.ArrayWithObjects("propsDelimiter", "props_delimiter", map[string]any{
+			"from": "from",
+			"to":   "to",
+		}),
+		converter.ArrayWithObjects("eventMerchEventToAdobeEvent", "event_merch_event_to_adobe_event", map[string]any{
+			"from": "from",
+			"to":   "to",
+		}),
+		converter.ArrayWithStrings("eventMerchProperties", "eventMerchProperties", "event_merch_properties"),
+		converter.ArrayWithObjects("productMerchEventToAdobeEvent", "product_merch_event_to_adobe_event", map[string]any{
+			"from": "from",
+			"to":   "to",
+		}),
+		converter.ArrayWithStrings("productMerchProperties", "productMerchProperties", "product_merch_properties"),
+		converter.ArrayWithObjects("productMerchEvarsMap", "product_merch_evars_map", map[string]any{
+			"from": "from",
+			"to":   "to",
+		}),
+		converter.Simple("productIdentifier", "product_identifier"),
+		converter.Simple("useNativeSDK.web", "use_native_sdk.web"),
+		converter.Simple("useNativeSDK.ios", "use_native_sdk.ios"),
+		converter.Simple("useNativeSDK.android", "use_native_sdk.android"),
+		converter.Simple("useNativeSDK.reactnative", "use_native_sdk.react_native"),
+		converter.ArrayWithStrings("whitelistedEvents", "eventName", "event_filtering.whitelist"),
+		converter.ArrayWithStrings("blacklistedEvents", "eventName", "event_filtering.blacklist"),
+		converter.Discriminator("eventFilteringOption", converter.DiscriminatorValues{
+			"event_filtering.whitelist": "whitelistedEvents",
+			"event_filtering.blacklist": "blacklistedEvents",
+		}),
+	}
+	properties = append(properties, common.Properties(sourceTypes)...)
+
+	return &definitions.DestinationDefinition{
+		Type:       "adobe_analytics",
+		APIType:    "ADOBE_ANALYTICS",
+		Version:    1,
+		Properties: properties,
+		NewConfig: func() any {
+			return &adobeAnalyticsConfig{}
+		},
+		SourceTypes:     append([]string(nil), sourceTypes...),
+		ConnectionModes: connectionModes,
+	}
+}

--- a/cli/internal/providers/destination/definitions/adobe_analytics/definition.go
+++ b/cli/internal/providers/destination/definitions/adobe_analytics/definition.go
@@ -65,15 +65,15 @@ type useNativeSDK struct {
 // terraform-provider destination_adobe_analytics.go; validation constraints
 // mirror overlapping schema.json rules for those mapped fields.
 type adobeAnalyticsConfig struct {
-	TrackingServerUrl             string                   `mapstructure:"tracking_server_url" validate:"omitempty,max=100"`
-	TrackingServerSecureUrl       string                   `mapstructure:"tracking_server_secure_url" validate:"omitempty,max=100"`
+	TrackingServerUrl             string                   `mapstructure:"tracking_server_url" validate:"omitempty,pattern=adobe_analytics_url"`
+	TrackingServerSecureUrl       string                   `mapstructure:"tracking_server_secure_url" validate:"omitempty,pattern=adobe_analytics_url"`
 	ReportSuiteIDs                string                   `mapstructure:"report_suite_ids" validate:"required,min=1,max=300"`
 	SSLHeartbeat                  *bool                    `mapstructure:"ssl_heartbeat"`
-	HeartbeatTrackingServerUrl    string                   `mapstructure:"heartbeat_tracking_server_url" validate:"omitempty,max=100"`
+	HeartbeatTrackingServerUrl    string                   `mapstructure:"heartbeat_tracking_server_url" validate:"omitempty,pattern=adobe_analytics_url"`
 	UseUTF8Charset                *bool                    `mapstructure:"use_utf8_charset"`
 	UseSecureServerSide           *bool                    `mapstructure:"use_secure_server_side"`
-	ProxyNormalUrl                string                   `mapstructure:"proxy_normal_url" validate:"omitempty,max=100"`
-	ProxyHeartbeatUrl             string                   `mapstructure:"proxy_heartbeat_url" validate:"omitempty,max=100"`
+	ProxyNormalUrl                string                   `mapstructure:"proxy_normal_url" validate:"omitempty,pattern=adobe_analytics_url"`
+	ProxyHeartbeatUrl             string                   `mapstructure:"proxy_heartbeat_url" validate:"omitempty,pattern=adobe_analytics_url"`
 	EventsToTypes                 []eventToTypeEntry       `mapstructure:"events_to_types" validate:"omitempty,dive"`
 	MarketingCloudOrgID           string                   `mapstructure:"marketing_cloud_org_id" validate:"omitempty,max=100"`
 	DropVisitorID                 *bool                    `mapstructure:"drop_visitor_id"`

--- a/cli/internal/providers/destination/definitions/adobe_analytics/definition_test.go
+++ b/cli/internal/providers/destination/definitions/adobe_analytics/definition_test.go
@@ -1,0 +1,545 @@
+package adobeanalytics_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions"
+	adobeanalytics "github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions/adobe_analytics"
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions/testutil"
+)
+
+func TestNewDefinitionMetadata(t *testing.T) {
+	t.Parallel()
+
+	registry := definitions.NewRegistry()
+	require.NoError(t, registry.Register(adobeanalytics.NewDefinition()))
+
+	registered, err := registry.Get("adobe_analytics", 1)
+	require.NoError(t, err)
+
+	assert.Equal(t, "adobe_analytics", registered.Type)
+	assert.Equal(t, "ADOBE_ANALYTICS", registered.APIType)
+	assert.Equal(t, int64(1), registered.Version)
+	assert.Equal(t, []string{}, registered.SecretKeys())
+
+	expectedSourceTypes := []string{
+		"android", "android_kotlin", "ios", "ios_swift", "web",
+		"unity", "react_native", "flutter", "cordova", "cloud",
+	}
+	assert.Equal(t, expectedSourceTypes, registered.SupportedSourceTypes())
+
+	expectedModes := map[string][]string{
+		"android":        {"cloud", "device"},
+		"android_kotlin": {"cloud"},
+		"ios":            {"cloud", "device"},
+		"ios_swift":      {"cloud"},
+		"web":            {"cloud", "device"},
+		"unity":          {"cloud"},
+		"react_native":   {"cloud"},
+		"flutter":        {"cloud"},
+		"cordova":        {"cloud"},
+		"cloud":          {"cloud"},
+	}
+	for sourceType, want := range expectedModes {
+		modes, err := registered.ConnectionModes(sourceType)
+		require.NoError(t, err)
+		assert.Equal(t, want, modes, sourceType)
+	}
+
+	assert.NotContains(t, registered.SupportedSourceTypes(), "amp")
+	assert.NotContains(t, registered.SupportedSourceTypes(), "shopify")
+	assert.NotContains(t, registered.SupportedSourceTypes(), "warehouse")
+
+	assert.Empty(t, registered.GatedKeyPaths())
+
+	byAPI, err := registry.GetByAPIType("ADOBE_ANALYTICS", 1)
+	require.NoError(t, err)
+	assert.Equal(t, registered, byAPI)
+}
+
+func TestAdobeAnalyticsConfigValidation(t *testing.T) {
+	t.Parallel()
+
+	registry := definitions.NewRegistry()
+	require.NoError(t, registry.Register(adobeanalytics.NewDefinition()))
+	registered, err := registry.Get("adobe_analytics", 1)
+	require.NoError(t, err)
+
+	t.Run("missing report_suite_ids", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{})
+		require.NotEmpty(t, errors)
+		assert.Equal(t, "/report_suite_ids", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "required")
+	})
+
+	t.Run("valid minimal config", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{
+			"report_suite_ids": "rsid1",
+		})
+		assert.Empty(t, errors)
+	})
+
+	t.Run("valid full config", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{
+			"tracking_server_url":           "metrics.example.com",
+			"tracking_server_secure_url":    "smetrics.example.com",
+			"report_suite_ids":              "rsid1,rsid2",
+			"ssl_heartbeat":                 true,
+			"heartbeat_tracking_server_url": "heartbeat.example.com",
+			"use_utf8_charset":              true,
+			"use_secure_server_side":        true,
+			"proxy_normal_url":              "cdn.example.com/aa.js",
+			"proxy_heartbeat_url":           "cdn.example.com/hb.js",
+			"events_to_types": []any{
+				map[string]any{"from": "Video Start", "to": "initHeartbeat"},
+			},
+			"marketing_cloud_org_id":       "1234567890ABC@AdobeOrg",
+			"drop_visitor_id":              true,
+			"timestamp_option":             "disabled",
+			"timestamp_optional_reporting": false,
+			"no_fallback_visitor_id":       false,
+			"prefer_visitor_id":            false,
+			"rudder_events_to_adobe_events": []any{
+				map[string]any{"from": "Product Viewed", "to": "event1"},
+			},
+			"track_page_name": true,
+			"context_data_mapping": []any{
+				map[string]any{"from": "traits.email", "to": "email"},
+			},
+			"context_data_prefix":         "rudder_",
+			"use_legacy_link_name":        true,
+			"page_name_fallback_tostring": true,
+			"mobile_event_mapping": []any{
+				map[string]any{"from": "screen.name", "to": "pageName"},
+			},
+			"send_false_values": true,
+			"e_var_mapping": []any{
+				map[string]any{"from": "category", "to": "1"},
+			},
+			"hier_mapping": []any{
+				map[string]any{"from": "path", "to": "1"},
+			},
+			"list_mapping": []any{
+				map[string]any{"from": "tags", "to": "1"},
+			},
+			"list_delimiter": []any{
+				map[string]any{"from": "tags", "to": ","},
+			},
+			"custom_props_mapping": []any{
+				map[string]any{"from": "plan", "to": "1"},
+			},
+			"props_delimiter": []any{
+				map[string]any{"from": "plan", "to": "|"},
+			},
+			"event_merch_event_to_adobe_event": []any{
+				map[string]any{"from": "Order Completed", "to": "purchase"},
+			},
+			"event_merch_properties": []any{"revenue", "currency"},
+			"product_merch_event_to_adobe_event": []any{
+				map[string]any{"from": "Product Added", "to": "scAdd"},
+			},
+			"product_merch_properties": []any{"price", "quantity"},
+			"product_merch_evars_map": []any{
+				map[string]any{"from": "sku", "to": "1"},
+			},
+			"product_identifier": "sku",
+			"event_filtering": map[string]any{
+				"whitelist": []any{"Product Viewed", "Order Completed"},
+			},
+			"use_native_sdk": map[string]any{
+				"web":          true,
+				"ios":          true,
+				"android":      true,
+				"react_native": false,
+			},
+			"consent_management": map[string]any{
+				"web": []any{
+					map[string]any{
+						"provider": "oneTrust",
+						"consents": []any{"analytics"},
+					},
+				},
+			},
+		})
+		assert.Empty(t, errors)
+	})
+
+	t.Run("valid example yaml config", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{
+			"tracking_server_url":           "metrics.example.com",
+			"tracking_server_secure_url":    "smetrics.example.com",
+			"report_suite_ids":              "rsid1,rsid2",
+			"ssl_heartbeat":                 true,
+			"heartbeat_tracking_server_url": "heartbeat.example.com",
+			"marketing_cloud_org_id":        "1234567890ABC@AdobeOrg",
+			"drop_visitor_id":               true,
+			"timestamp_option":              "disabled",
+			"prefer_visitor_id":             false,
+			"rudder_events_to_adobe_events": []any{
+				map[string]any{"from": "Product Viewed", "to": "event1"},
+			},
+			"track_page_name": true,
+			"context_data_mapping": []any{
+				map[string]any{"from": "traits.email", "to": "email"},
+			},
+			"context_data_prefix": "rudder_",
+			"e_var_mapping": []any{
+				map[string]any{"from": "category", "to": "1"},
+			},
+			"product_identifier": "name",
+			"event_filtering": map[string]any{
+				"blacklist": []any{"Application Opened"},
+			},
+			"use_native_sdk": map[string]any{
+				"web": true,
+			},
+			"consent_management": map[string]any{
+				"android_kotlin": []any{
+					map[string]any{
+						"provider":            "oneTrust",
+						"resolution_strategy": "and",
+						"consents":            []any{"analytics", "marketing"},
+					},
+				},
+			},
+		})
+		assert.Empty(t, errors)
+	})
+
+	t.Run("invalid timestamp_option rejected", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{
+			"report_suite_ids": "rsid1",
+			"timestamp_option": "bogus",
+		})
+		require.NotEmpty(t, errors)
+		assert.Equal(t, "/timestamp_option", errors[0].Path)
+	})
+
+	t.Run("invalid product_identifier rejected", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{
+			"report_suite_ids":   "rsid1",
+			"product_identifier": "bogus",
+		})
+		require.NotEmpty(t, errors)
+		assert.Equal(t, "/product_identifier", errors[0].Path)
+	})
+
+	t.Run("invalid events_to_types to rejected", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{
+			"report_suite_ids": "rsid1",
+			"events_to_types": []any{
+				map[string]any{"from": "Video Start", "to": "notAHeartbeat"},
+			},
+		})
+		require.NotEmpty(t, errors)
+		assert.Equal(t, "/events_to_types/0/to", errors[0].Path)
+	})
+
+	t.Run("invalid list_delimiter to rejected", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{
+			"report_suite_ids": "rsid1",
+			"list_delimiter": []any{
+				map[string]any{"from": "tags", "to": "#"},
+			},
+		})
+		require.NotEmpty(t, errors)
+		assert.Equal(t, "/list_delimiter/0/to", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "must be one of")
+	})
+
+	t.Run("report_suite_ids max length rejected", func(t *testing.T) {
+		t.Parallel()
+		long := make([]byte, 301)
+		for i := range long {
+			long[i] = 'a'
+		}
+		errors := registered.ValidateConfig(map[string]any{
+			"report_suite_ids": string(long),
+		})
+		require.NotEmpty(t, errors)
+		assert.Equal(t, "/report_suite_ids", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "300")
+	})
+
+	t.Run("unknown key rejected", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{
+			"report_suite_ids": "rsid1",
+			"not_a_field":      true,
+		})
+		require.NotEmpty(t, errors)
+		assert.Equal(t, "/not_a_field", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "unknown config field")
+	})
+
+	t.Run("unsupported consent source rejected", func(t *testing.T) {
+		t.Parallel()
+
+		errors := registered.ValidateConfig(map[string]any{
+			"report_suite_ids": "rsid1",
+			"consent_management": map[string]any{
+				"warehouse": []any{},
+			},
+		})
+
+		require.Len(t, errors, 1)
+		assert.Equal(t, "/consent_management/warehouse", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "source type 'warehouse' is not supported")
+	})
+
+	t.Run("invalid consent provider rejected", func(t *testing.T) {
+		t.Parallel()
+
+		errors := registered.ValidateConfig(map[string]any{
+			"report_suite_ids": "rsid1",
+			"consent_management": map[string]any{
+				"ios_swift": []any{
+					map[string]any{"provider": "unknown"},
+				},
+			},
+		})
+
+		require.Len(t, errors, 1)
+		assert.Equal(t, "/consent_management/ios_swift/0/provider", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "'provider' must be one of")
+	})
+}
+
+func TestAdobeAnalyticsConversionRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	def := adobeanalytics.NewDefinition()
+	testutil.AssertConversion(t, def.Properties, []testutil.ConversionCase{
+		{
+			Name: "minimal report suite ids only",
+			LocalJSON: `{
+				"report_suite_ids": "rsid1"
+			}`,
+			APIJSON: `{
+				"reportSuiteIds": "rsid1"
+			}`,
+		},
+		{
+			Name: "full TF fields with whitelist",
+			LocalJSON: `{
+				"tracking_server_url": "metrics.example.com",
+				"tracking_server_secure_url": "smetrics.example.com",
+				"report_suite_ids": "rsid1,rsid2",
+				"ssl_heartbeat": true,
+				"heartbeat_tracking_server_url": "heartbeat.example.com",
+				"use_utf8_charset": true,
+				"use_secure_server_side": true,
+				"proxy_normal_url": "cdn.example.com/aa.js",
+				"proxy_heartbeat_url": "cdn.example.com/hb.js",
+				"events_to_types": [
+					{"from": "Video Start", "to": "initHeartbeat"}
+				],
+				"marketing_cloud_org_id": "1234567890ABC@AdobeOrg",
+				"drop_visitor_id": true,
+				"timestamp_option": "disabled",
+				"timestamp_optional_reporting": false,
+				"no_fallback_visitor_id": false,
+				"prefer_visitor_id": false,
+				"rudder_events_to_adobe_events": [
+					{"from": "Product Viewed", "to": "event1"}
+				],
+				"track_page_name": true,
+				"context_data_mapping": [
+					{"from": "traits.email", "to": "email"}
+				],
+				"context_data_prefix": "rudder_",
+				"use_legacy_link_name": true,
+				"page_name_fallback_tostring": true,
+				"mobile_event_mapping": [
+					{"from": "screen.name", "to": "pageName"}
+				],
+				"send_false_values": true,
+				"e_var_mapping": [
+					{"from": "category", "to": "1"}
+				],
+				"hier_mapping": [
+					{"from": "path", "to": "1"}
+				],
+				"list_mapping": [
+					{"from": "tags", "to": "1"}
+				],
+				"list_delimiter": [
+					{"from": "tags", "to": ","}
+				],
+				"custom_props_mapping": [
+					{"from": "plan", "to": "1"}
+				],
+				"props_delimiter": [
+					{"from": "plan", "to": "|"}
+				],
+				"event_merch_event_to_adobe_event": [
+					{"from": "Order Completed", "to": "purchase"}
+				],
+				"event_merch_properties": ["revenue", "currency"],
+				"product_merch_event_to_adobe_event": [
+					{"from": "Product Added", "to": "scAdd"}
+				],
+				"product_merch_properties": ["price", "quantity"],
+				"product_merch_evars_map": [
+					{"from": "sku", "to": "1"}
+				],
+				"product_identifier": "sku",
+				"event_filtering": {
+					"whitelist": ["Product Viewed", "Order Completed"]
+				},
+				"use_native_sdk": {
+					"web": true,
+					"ios": true,
+					"android": true,
+					"react_native": false
+				}
+			}`,
+			APIJSON: `{
+				"trackingServerUrl": "metrics.example.com",
+				"trackingServerSecureUrl": "smetrics.example.com",
+				"reportSuiteIds": "rsid1,rsid2",
+				"sslHeartbeat": true,
+				"heartbeatTrackingServerUrl": "heartbeat.example.com",
+				"useUtf8Charset": true,
+				"useSecureServerSide": true,
+				"proxyNormalUrl": "cdn.example.com/aa.js",
+				"proxyHeartbeatUrl": "cdn.example.com/hb.js",
+				"eventsToTypes": [
+					{"from": "Video Start", "to": "initHeartbeat"}
+				],
+				"marketingCloudOrgId": "1234567890ABC@AdobeOrg",
+				"dropVisitorId": true,
+				"timestampOption": "disabled",
+				"timestampOptionalReporting": false,
+				"noFallbackVisitorId": false,
+				"preferVisitorId": false,
+				"rudderEventsToAdobeEvents": [
+					{"from": "Product Viewed", "to": "event1"}
+				],
+				"trackPageName": true,
+				"contextDataMapping": [
+					{"from": "traits.email", "to": "email"}
+				],
+				"contextDataPrefix": "rudder_",
+				"useLegacyLinkName": true,
+				"pageNameFallbackTostring": true,
+				"mobileEventMapping": [
+					{"from": "screen.name", "to": "pageName"}
+				],
+				"sendFalseValues": true,
+				"eVarMapping": [
+					{"from": "category", "to": "1"}
+				],
+				"hierMapping": [
+					{"from": "path", "to": "1"}
+				],
+				"listMapping": [
+					{"from": "tags", "to": "1"}
+				],
+				"listDelimiter": [
+					{"from": "tags", "to": ","}
+				],
+				"customPropsMapping": [
+					{"from": "plan", "to": "1"}
+				],
+				"propsDelimiter": [
+					{"from": "plan", "to": "|"}
+				],
+				"eventMerchEventToAdobeEvent": [
+					{"from": "Order Completed", "to": "purchase"}
+				],
+				"eventMerchProperties": [
+					{"eventMerchProperties": "revenue"},
+					{"eventMerchProperties": "currency"}
+				],
+				"productMerchEventToAdobeEvent": [
+					{"from": "Product Added", "to": "scAdd"}
+				],
+				"productMerchProperties": [
+					{"productMerchProperties": "price"},
+					{"productMerchProperties": "quantity"}
+				],
+				"productMerchEvarsMap": [
+					{"from": "sku", "to": "1"}
+				],
+				"productIdentifier": "sku",
+				"whitelistedEvents": [
+					{"eventName": "Product Viewed"},
+					{"eventName": "Order Completed"}
+				],
+				"eventFilteringOption": "whitelistedEvents",
+				"useNativeSDK": {
+					"web": true,
+					"ios": true,
+					"android": true,
+					"reactnative": false
+				}
+			}`,
+		},
+		{
+			Name: "event filtering blacklist reshape",
+			LocalJSON: `{
+				"report_suite_ids": "rsid1",
+				"event_filtering": {
+					"blacklist": ["Application Opened"]
+				}
+			}`,
+			APIJSON: `{
+				"reportSuiteIds": "rsid1",
+				"blacklistedEvents": [
+					{"eventName": "Application Opened"}
+				],
+				"eventFilteringOption": "blacklistedEvents"
+			}`,
+		},
+		{
+			Name: "mapping arrays reshape",
+			LocalJSON: `{
+				"report_suite_ids": "rsid1",
+				"e_var_mapping": [
+					{"from": "category", "to": "1"}
+				],
+				"event_merch_properties": ["revenue"]
+			}`,
+			APIJSON: `{
+				"reportSuiteIds": "rsid1",
+				"eVarMapping": [
+					{"from": "category", "to": "1"}
+				],
+				"eventMerchProperties": [
+					{"eventMerchProperties": "revenue"}
+				]
+			}`,
+		},
+		{
+			Name: "consent source boundary mappings",
+			LocalJSON: `{
+				"report_suite_ids": "rsid1",
+				"consent_management": {
+					"android_kotlin": [{"provider": "oneTrust"}],
+					"ios_swift": [{"provider": "ketch"}],
+					"react_native": [{"provider": "iubenda"}]
+				}
+			}`,
+			APIJSON: `{
+				"reportSuiteIds": "rsid1",
+				"consentManagement": {
+					"androidKotlin": [{"provider": "oneTrust"}],
+					"iosSwift": [{"provider": "ketch"}],
+					"reactnative": [{"provider": "iubenda"}]
+				}
+			}`,
+		},
+	})
+}

--- a/cli/internal/providers/destination/definitions/adobe_analytics/definition_test.go
+++ b/cli/internal/providers/destination/definitions/adobe_analytics/definition_test.go
@@ -272,6 +272,32 @@ func TestAdobeAnalyticsConfigValidation(t *testing.T) {
 		assert.Contains(t, errors[0].Message, "300")
 	})
 
+	t.Run("tracking_server_url with ngrok rejected", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{
+			"report_suite_ids":    "rsid1",
+			"tracking_server_url": "https://example.ngrok.io",
+		})
+		require.NotEmpty(t, errors)
+		assert.Equal(t, "/tracking_server_url", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "ngrok")
+	})
+
+	t.Run("tracking_server_url too long rejected", func(t *testing.T) {
+		t.Parallel()
+		long := make([]byte, 101)
+		for i := range long {
+			long[i] = 'a'
+		}
+		errors := registered.ValidateConfig(map[string]any{
+			"report_suite_ids":    "rsid1",
+			"tracking_server_url": string(long),
+		})
+		require.NotEmpty(t, errors)
+		assert.Equal(t, "/tracking_server_url", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "100")
+	})
+
 	t.Run("unknown key rejected", func(t *testing.T) {
 		t.Parallel()
 		errors := registered.ValidateConfig(map[string]any{

--- a/cli/internal/providers/destination/definitions/adobe_analytics/patterns.go
+++ b/cli/internal/providers/destination/definitions/adobe_analytics/patterns.go
@@ -1,0 +1,13 @@
+package adobeanalytics
+
+import "github.com/rudderlabs/rudder-iac/cli/internal/provider/rules/funcs"
+
+func init() {
+	// Delimiter enums cannot use dynamic_or_oneof because `|` is the
+	// go-playground/validator tag separator.
+	funcs.NewPattern(
+		"adobe_analytics_delimiter",
+		`^(\||:|,|;|/)$`,
+		"must be one of | : , ; /",
+	)
+}

--- a/cli/internal/providers/destination/definitions/adobe_analytics/patterns.go
+++ b/cli/internal/providers/destination/definitions/adobe_analytics/patterns.go
@@ -10,4 +10,12 @@ func init() {
 		`^(\||:|,|;|/)$`,
 		"must be one of | : , ; /",
 	)
+
+	// schema.json URL fields: (?!.*\.ngrok\.io)^(.{0,100})$ — allow length, reject ngrok.
+	funcs.NewPatternWithReject(
+		"adobe_analytics_url",
+		`^(.{0,100})$`,
+		`\.ngrok\.io`,
+		"must be at most 100 characters and must not contain .ngrok.io",
+	)
 }


### PR DESCRIPTION
## 🔗 Ticket

Resolves [DEX-488](https://linear.app/rudderstack/issue/DEX-488/onboard-destination-adobe-analytics)

---

## Summary

Onboards the Adobe Analytics destination (`ADOBE_ANALYTICS`) into the CLI destination definition registry so it can be managed via YAML specs when destination support is enabled.

---

## Changes

- Added `definitions/adobe_analytics/` with `definition.go`, `definition_test.go`, and `patterns.go`
- Registered the definition in `newDestinationRegistry`
- Updated registry supported-types expectation in `dependencies_test.go`
- Registered `adobe_analytics_url` via `NewPatternWithReject` — allow `^(.{0,100})$`, reject `\.ngrok\.io` (schema negative-lookahead equivalent for URL fields)

### Naming

| Source | Value |
| --- | --- |
| integrations-config directory | `adobe_analytics` |
| db-config `name` / CLI `APIType` | `ADOBE_ANALYTICS` |
| CLI local `Type` | `adobe_analytics` (`lowercase(APIType)`) |
| terraform resource name | `adobe_analytics` |

### Mapped config surface (from terraform)

- `report_suite_ids` (required)
- Tracking / proxy URLs: `tracking_server_url`, `tracking_server_secure_url`, `heartbeat_tracking_server_url`, `proxy_normal_url`, `proxy_heartbeat_url` (validated with `pattern=adobe_analytics_url`)
- Flags: `ssl_heartbeat`, `use_utf8_charset`, `use_secure_server_side`, `drop_visitor_id`, `timestamp_optional_reporting`, `no_fallback_visitor_id`, `prefer_visitor_id`, `track_page_name`, `use_legacy_link_name`, `page_name_fallback_tostring`, `send_false_values`
- Enums: `timestamp_option`, `product_identifier`
- Mapping arrays (`from`/`to`): `events_to_types`, `rudder_events_to_adobe_events`, `context_data_mapping`, `mobile_event_mapping`, `e_var_mapping`, `hier_mapping`, `list_mapping`, `list_delimiter`, `custom_props_mapping`, `props_delimiter`, merchandising maps
- String lists (API reshape): `event_merch_properties`, `product_merch_properties`
- `event_filtering` whitelist/blacklist + discriminator
- `use_native_sdk` for `web` / `ios` / `android` / `react_native`
- `consent_management` via `common.Properties`

### Omitted upstream fields (no terraform mapping)

- Nested `delimiter` on `listMapping` / `customPropsMapping` objects in schema.json (terraform models delimiters as separate `listDelimiter` / `propsDelimiter` arrays instead — followed terraform)
- Boilerplate handled by `common` / source-type blocks: `connectionMode`, `consentManagement`, `oneTrustCookieCategories`, `ketchConsentPurposes`

### Discrepancies / notes

- Terraform maps fields absent from schema.json properties: `useUtf8Charset`, `useSecureServerSide`, `useLegacyLinkName`, `pageNameFallbackTostring`, `sendFalseValues`, plus separate `listDelimiter` / `propsDelimiter` arrays — included per terraform mapping source
- schema.json nests `delimiter` on list/custom-prop mappings; terraform uses parallel delimiter arrays — followed terraform
- `useNativeSDK.reactnative` mapped in terraform; schema.json `useNativeSDK` only lists `web`/`android`/`ios` — included react_native per terraform
- URL fields: schema forbids `.ngrok.io` via negative lookahead (`(?!.*\.ngrok\.io)^(.{0,100})$`); Go RE2 cannot express lookahead, so CLI uses `NewPatternWithReject` (`adobe_analytics_url`: allow length ≤100, reject `\.ngrok\.io`) on `tracking_server_url`, `tracking_server_secure_url`, `heartbeat_tracking_server_url`, `proxy_normal_url`, `proxy_heartbeat_url`. env/`{{…}}` branches stripped per skill.
- `list_delimiter` / `props_delimiter` `to` values use named pattern `adobe_analytics_delimiter` (`|` cannot live in `dynamic_or_oneof` tags)
- No gated keys: terraform-mapped destination keys are in `defaultConfig`; `useNativeSDK` / consent are boilerplate skipped for gating
- `secretKeys`: empty upstream and in definition
- Dropped upstream source types (S3 precedent): `amp`, `shopify`, `warehouse`
- Included `android_kotlin` / `ios_swift` from db-config (terraform's supportedSourceTypes omitted them; db-config wins for capabilities)
- Connection modes: `web`/`android`/`ios` support `cloud`+`device`; others `cloud` only

### Example YAML (validated via `ValidateConfig`)

```yaml
version: rudder/v1
kind: destination
metadata:
  name: my-adobe-analytics-destination
spec:
  id: my-adobe-analytics-destination
  display_name: My Adobe Analytics Destination
  type: adobe_analytics
  enabled: true
  definition_version: 1
  config:
    tracking_server_url: metrics.example.com
    tracking_server_secure_url: smetrics.example.com
    report_suite_ids: rsid1,rsid2
    ssl_heartbeat: true
    heartbeat_tracking_server_url: heartbeat.example.com
    marketing_cloud_org_id: 1234567890ABC@AdobeOrg
    drop_visitor_id: true
    timestamp_option: disabled
    prefer_visitor_id: false
    rudder_events_to_adobe_events:
      - from: Product Viewed
        to: event1
    track_page_name: true
    context_data_mapping:
      - from: traits.email
        to: email
    context_data_prefix: rudder_
    e_var_mapping:
      - from: category
        to: "1"
    product_identifier: name
    event_filtering:
      blacklist:
        - Application Opened
    use_native_sdk:
      web: true
    consent_management:
      android_kotlin:
        - provider: oneTrust
          resolution_strategy: and
          consents:
            - analytics
            - marketing
```

### Usage reminder

Requires `experimental: true` and `flags.destinationSupport: true` in the CLI config.

---

## Testing

- `go build ./...`
- `go test ./cli/internal/providers/destination/... ./cli/internal/app/...`
- `make lint`

---

## Risk / Impact

Low
Additive registry entry behind the existing destinationSupport experimental flag; no change to apply behavior for existing projects.

---

## Checklist

- [x] Ticket linked
- [x] Tests added/updated
- [x] No breaking changes (or documented)

Made with [Cursor](https://cursor.com)