### PR TITLE
feat(cli): onboard posthog destination definition

### DIFF
--- a/cli/internal/app/dependencies.go
+++ b/cli/internal/app/dependencies.go
@@ -16,6 +16,7 @@ import (
 	dgProvider "github.com/rudderlabs/rudder-iac/cli/internal/providers/datagraph"
 	destProvider "github.com/rudderlabs/rudder-iac/cli/internal/providers/destination"
 	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions"
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions/posthog"
 	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions/s3"
 	esProvider "github.com/rudderlabs/rudder-iac/cli/internal/providers/event-stream"
 	"github.com/rudderlabs/rudder-iac/cli/internal/providers/retl"
@@ -247,6 +248,9 @@ func newDestinationRegistry(cfg config.Config) (*definitions.Registry, error) {
 	}
 	if err := registry.Register(s3.NewDefinition()); err != nil {
 		return nil, fmt.Errorf("registering s3 destination definition: %w", err)
+	}
+	if err := registry.Register(posthog.NewDefinition()); err != nil {
+		return nil, fmt.Errorf("registering posthog destination definition: %w", err)
 	}
 	return registry, nil
 }

--- a/cli/internal/app/dependencies_test.go
+++ b/cli/internal/app/dependencies_test.go
@@ -40,7 +40,7 @@ func TestNewDestinationRegistryRegistersS3WhenFlagEnabled(t *testing.T) {
 
 	registry, err := newDestinationRegistry(config.GetConfig())
 	require.NoError(t, err)
-	assert.Equal(t, []string{"s3"}, registry.SupportedTypes())
+	assert.Equal(t, []string{"posthog", "s3"}, registry.SupportedTypes())
 }
 
 func TestNewDestinationRegistryEmptyWhenFlagDisabled(t *testing.T) {

--- a/cli/internal/providers/destination/definitions/posthog/definition.go
+++ b/cli/internal/providers/destination/definitions/posthog/definition.go
@@ -1,0 +1,146 @@
+package posthog
+
+import (
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions"
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions/common"
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions/converter"
+)
+
+// Source types from integrations-config destinations/posthog/db-config.json
+// supportedSourceTypes, restricted to types the CLI event-stream provider owns.
+var sourceTypes = []string{
+	common.SourceTypeAndroid,
+	common.SourceTypeAndroidKotlin,
+	common.SourceTypeIOS,
+	common.SourceTypeIOSSwift,
+	common.SourceTypeWeb,
+	common.SourceTypeUnity,
+	common.SourceTypeReactNative,
+	common.SourceTypeFlutter,
+	common.SourceTypeCordova,
+	common.SourceTypeCloud,
+}
+
+var connectionModes = map[string][]string{
+	common.SourceTypeAndroid:       {"cloud"},
+	common.SourceTypeAndroidKotlin: {"cloud"},
+	common.SourceTypeIOS:           {"cloud"},
+	common.SourceTypeIOSSwift:      {"cloud"},
+	common.SourceTypeWeb:           {"cloud", "device"},
+	common.SourceTypeUnity:         {"cloud"},
+	common.SourceTypeReactNative:   {"cloud"},
+	common.SourceTypeFlutter:       {"cloud"},
+	common.SourceTypeCordova:       {"cloud"},
+	common.SourceTypeCloud:         {"cloud"},
+}
+
+type webBool struct {
+	Web *bool `mapstructure:"web"`
+}
+
+type webPersonProfiles struct {
+	Web string `mapstructure:"web" validate:"omitempty,dynamic_or_oneof=always identified_only"`
+}
+
+type xhrHeader struct {
+	Key   string `mapstructure:"key" validate:"omitempty,max=100"`
+	Value string `mapstructure:"value" validate:"omitempty,max=100"`
+}
+
+type propertyBlacklistItem struct {
+	Property string `mapstructure:"property"`
+}
+
+type eventFiltering struct {
+	Whitelist []string `mapstructure:"whitelist"`
+	Blacklist []string `mapstructure:"blacklist"`
+}
+
+type useNativeSDK struct {
+	Web *bool `mapstructure:"web"`
+}
+
+// posthogConfig is the local YAML config model. Field set mirrors terraform
+// destination_posthog mappings; validation constraints mirror schema.json.
+type posthogConfig struct {
+	APIKey string `mapstructure:"api_key" validate:"required,min=1,max=100"`
+	// schema.json also forbids `.ngrok.io` via negative lookahead; Go RE2 cannot
+	// express that, so only the length half of ^(.{0,100})$ is enforced here.
+	Endpoint                      string                   `mapstructure:"endpoint" validate:"omitempty,max=100"`
+	UseV2Group                    *bool                    `mapstructure:"use_v2_group"`
+	EventFiltering                *eventFiltering          `mapstructure:"event_filtering"`
+	UseNativeSDK                  *useNativeSDK            `mapstructure:"use_native_sdk"`
+	Autocapture                   *webBool                 `mapstructure:"autocapture"`
+	CapturePageView               *webBool                 `mapstructure:"capture_page_view"`
+	DisableSessionRecording       *webBool                 `mapstructure:"disable_session_recording"`
+	EnableLocalStoragePersistence *webBool                 `mapstructure:"enable_local_storage_persistence"`
+	PersonProfiles                *webPersonProfiles       `mapstructure:"person_profiles"`
+	XHRHeaders                    []xhrHeader              `mapstructure:"xhr_headers" validate:"omitempty,dive"`
+	PropertyBlacklist             []propertyBlacklistItem  `mapstructure:"property_blacklist" validate:"omitempty,dive"`
+	ConsentManagement             common.ConsentManagement `mapstructure:"consent_management"`
+}
+
+// NewDefinition returns the PostHog destination definition.
+func NewDefinition() *definitions.DestinationDefinition {
+	properties := []converter.ConfigProperty{
+		converter.Simple("yourInstance", "endpoint", converter.SkipZeroValue),
+		converter.Simple("teamApiKey", "api_key"),
+		converter.Simple("useV2Group", "use_v2_group"),
+		converter.Simple("useNativeSDK.web", "use_native_sdk.web"),
+		converter.Gated(
+			converter.Simple("disableSessionRecording.web", "disable_session_recording.web"),
+			common.SourceTypeWeb,
+		),
+		converter.Gated(
+			converter.Simple("capturePageView.web", "capture_page_view.web"),
+			common.SourceTypeWeb,
+		),
+		converter.Gated(
+			converter.Simple("autocapture.web", "autocapture.web"),
+			common.SourceTypeWeb,
+		),
+		converter.Gated(
+			converter.Simple("enableLocalStoragePersistence.web", "enable_local_storage_persistence.web"),
+			common.SourceTypeWeb,
+		),
+		converter.Gated(
+			converter.ArrayWithObjects("xhrHeaders.web", "xhr_headers", map[string]any{
+				"key":   "key",
+				"value": "value",
+			}),
+			common.SourceTypeWeb,
+		),
+		// terraform maps propertyBlacklist (lowercase L); upstream db-config/schema use propertyBlackList.
+		converter.Gated(
+			converter.ArrayWithObjects("propertyBlacklist.web", "property_blacklist", map[string]any{
+				"property": "property",
+			}),
+			common.SourceTypeWeb,
+		),
+		converter.Gated(
+			converter.Simple("personProfiles.web", "person_profiles.web"),
+			common.SourceTypeWeb,
+		),
+		converter.ArrayWithStrings("whitelistedEvents", "eventName", "event_filtering.whitelist"),
+		converter.ArrayWithStrings("blacklistedEvents", "eventName", "event_filtering.blacklist"),
+		converter.Discriminator("eventFilteringOption", converter.DiscriminatorValues{
+			"event_filtering.whitelist": "whitelistedEvents",
+			"event_filtering.blacklist": "blacklistedEvents",
+		}),
+	}
+	properties = append(properties, common.Properties(sourceTypes)...)
+
+	return &definitions.DestinationDefinition{
+		Type:       "posthog",
+		APIType:    "POSTHOG",
+		Version:    1,
+		Properties: properties,
+		// db-config secretKeys is empty; terraform marks api_key Sensitive.
+		SecretKeys: []string{"api_key"},
+		NewConfig: func() any {
+			return &posthogConfig{}
+		},
+		SourceTypes:     append([]string(nil), sourceTypes...),
+		ConnectionModes: connectionModes,
+	}
+}

--- a/cli/internal/providers/destination/definitions/posthog/definition.go
+++ b/cli/internal/providers/destination/definitions/posthog/definition.go
@@ -1,10 +1,21 @@
 package posthog
 
 import (
+	"github.com/rudderlabs/rudder-iac/cli/internal/provider/rules/funcs"
 	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions"
 	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions/common"
 	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions/converter"
 )
+
+func init() {
+	// schema.json yourInstance: (?!.*\.ngrok\.io)^(.{0,100})$ — allow length, reject ngrok hosts.
+	funcs.NewPatternWithReject(
+		"posthog_endpoint",
+		`^(.{0,100})$`,
+		`\.ngrok\.io`,
+		"must be at most 100 characters and must not contain .ngrok.io",
+	)
+}
 
 // Source types from integrations-config destinations/posthog/db-config.json
 // supportedSourceTypes, restricted to types the CLI event-stream provider owns.
@@ -63,10 +74,8 @@ type useNativeSDK struct {
 // posthogConfig is the local YAML config model. Field set mirrors terraform
 // destination_posthog mappings; validation constraints mirror schema.json.
 type posthogConfig struct {
-	APIKey string `mapstructure:"api_key" validate:"required,min=1,max=100"`
-	// schema.json also forbids `.ngrok.io` via negative lookahead; Go RE2 cannot
-	// express that, so only the length half of ^(.{0,100})$ is enforced here.
-	Endpoint                      string                   `mapstructure:"endpoint" validate:"omitempty,max=100"`
+	APIKey                        string                   `mapstructure:"api_key" validate:"required,min=1,max=100"`
+	Endpoint                      string                   `mapstructure:"endpoint" validate:"omitempty,pattern=posthog_endpoint"`
 	UseV2Group                    *bool                    `mapstructure:"use_v2_group"`
 	EventFiltering                *eventFiltering          `mapstructure:"event_filtering"`
 	UseNativeSDK                  *useNativeSDK            `mapstructure:"use_native_sdk"`

--- a/cli/internal/providers/destination/definitions/posthog/definition_test.go
+++ b/cli/internal/providers/destination/definitions/posthog/definition_test.go
@@ -107,6 +107,17 @@ func TestPosthogConfigValidation(t *testing.T) {
 		assert.Contains(t, errors[0].Message, "100")
 	})
 
+	t.Run("endpoint with ngrok rejected", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{
+			"api_key":  "phc_test_key",
+			"endpoint": "https://example.ngrok.io",
+		})
+		require.NotEmpty(t, errors)
+		assert.Equal(t, "/endpoint", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "ngrok")
+	})
+
 	t.Run("invalid person_profiles rejected", func(t *testing.T) {
 		t.Parallel()
 		errors := registered.ValidateConfig(map[string]any{

--- a/cli/internal/providers/destination/definitions/posthog/definition_test.go
+++ b/cli/internal/providers/destination/definitions/posthog/definition_test.go
@@ -1,0 +1,368 @@
+package posthog_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions"
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions/posthog"
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions/testutil"
+)
+
+func TestNewDefinitionMetadata(t *testing.T) {
+	t.Parallel()
+
+	registry := definitions.NewRegistry()
+	require.NoError(t, registry.Register(posthog.NewDefinition()))
+
+	registered, err := registry.Get("posthog", 1)
+	require.NoError(t, err)
+
+	assert.Equal(t, "posthog", registered.Type)
+	assert.Equal(t, "POSTHOG", registered.APIType)
+	assert.Equal(t, int64(1), registered.Version)
+	assert.Equal(t, []string{"api_key"}, registered.SecretKeys())
+
+	expectedSourceTypes := []string{
+		"android", "android_kotlin", "ios", "ios_swift", "web",
+		"unity", "react_native", "flutter", "cordova", "cloud",
+	}
+	assert.Equal(t, expectedSourceTypes, registered.SupportedSourceTypes())
+
+	expectedModes := map[string][]string{
+		"android":        {"cloud"},
+		"android_kotlin": {"cloud"},
+		"ios":            {"cloud"},
+		"ios_swift":      {"cloud"},
+		"web":            {"cloud", "device"},
+		"unity":          {"cloud"},
+		"react_native":   {"cloud"},
+		"flutter":        {"cloud"},
+		"cordova":        {"cloud"},
+		"cloud":          {"cloud"},
+	}
+	for sourceType, want := range expectedModes {
+		modes, err := registered.ConnectionModes(sourceType)
+		require.NoError(t, err)
+		assert.Equal(t, want, modes, "source type %s", sourceType)
+	}
+
+	assert.NotContains(t, registered.SupportedSourceTypes(), "amp")
+	assert.NotContains(t, registered.SupportedSourceTypes(), "shopify")
+	assert.NotContains(t, registered.SupportedSourceTypes(), "warehouse")
+
+	assert.Equal(t, map[string][]string{
+		"disable_session_recording/web":        {"web"},
+		"capture_page_view/web":                {"web"},
+		"autocapture/web":                      {"web"},
+		"enable_local_storage_persistence/web": {"web"},
+		"xhr_headers":                          {"web"},
+		"property_blacklist":                   {"web"},
+		"person_profiles/web":                  {"web"},
+	}, registered.GatedKeyPaths())
+
+	byAPI, err := registry.GetByAPIType("POSTHOG", 1)
+	require.NoError(t, err)
+	assert.Equal(t, registered, byAPI)
+}
+
+func TestPosthogConfigValidation(t *testing.T) {
+	t.Parallel()
+
+	registry := definitions.NewRegistry()
+	require.NoError(t, registry.Register(posthog.NewDefinition()))
+	registered, err := registry.Get("posthog", 1)
+	require.NoError(t, err)
+
+	t.Run("missing api_key", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{})
+		require.NotEmpty(t, errors)
+		assert.Equal(t, "/api_key", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "required")
+	})
+
+	t.Run("valid minimal config", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{
+			"api_key": "phc_test_key",
+		})
+		assert.Empty(t, errors)
+	})
+
+	t.Run("endpoint too long rejected", func(t *testing.T) {
+		t.Parallel()
+		longEndpoint := make([]byte, 101)
+		for i := range longEndpoint {
+			longEndpoint[i] = 'a'
+		}
+		errors := registered.ValidateConfig(map[string]any{
+			"api_key":  "phc_test_key",
+			"endpoint": string(longEndpoint),
+		})
+		require.NotEmpty(t, errors)
+		assert.Equal(t, "/endpoint", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "100")
+	})
+
+	t.Run("invalid person_profiles rejected", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{
+			"api_key": "phc_test_key",
+			"person_profiles": map[string]any{
+				"web": "sometimes",
+			},
+		})
+		require.NotEmpty(t, errors)
+		assert.Equal(t, "/person_profiles/web", errors[0].Path)
+	})
+
+	t.Run("xhr_headers value too long rejected", func(t *testing.T) {
+		t.Parallel()
+		longValue := make([]byte, 101)
+		for i := range longValue {
+			longValue[i] = 'a'
+		}
+		errors := registered.ValidateConfig(map[string]any{
+			"api_key": "phc_test_key",
+			"xhr_headers": []any{
+				map[string]any{"key": "X-Custom", "value": string(longValue)},
+			},
+		})
+		require.NotEmpty(t, errors)
+		assert.Equal(t, "/xhr_headers/0/value", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "100")
+	})
+
+	t.Run("valid full config", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{
+			"api_key":      "phc_test_key",
+			"endpoint":     "https://app.posthog.com",
+			"use_v2_group": true,
+			"event_filtering": map[string]any{
+				"whitelist": []any{"Product Viewed", "Order Completed"},
+			},
+			"use_native_sdk": map[string]any{
+				"web": true,
+			},
+			"autocapture": map[string]any{
+				"web": true,
+			},
+			"capture_page_view": map[string]any{
+				"web": false,
+			},
+			"disable_session_recording": map[string]any{
+				"web": true,
+			},
+			"enable_local_storage_persistence": map[string]any{
+				"web": true,
+			},
+			"person_profiles": map[string]any{
+				"web": "identified_only",
+			},
+			"xhr_headers": []any{
+				map[string]any{"key": "X-Custom", "value": "value"},
+			},
+			"property_blacklist": []any{
+				map[string]any{"property": "ssn"},
+			},
+			"consent_management": map[string]any{
+				"web": []any{
+					map[string]any{
+						"provider": "oneTrust",
+						"consents": []any{"analytics"},
+					},
+				},
+			},
+		})
+		assert.Empty(t, errors)
+	})
+
+	t.Run("example yaml config", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{
+			"api_key":      "phc_YOUR_PROJECT_API_KEY",
+			"endpoint":     "https://app.posthog.com",
+			"use_v2_group": true,
+			"event_filtering": map[string]any{
+				"whitelist": []any{"Product Viewed", "Order Completed"},
+			},
+			"use_native_sdk": map[string]any{
+				"web": true,
+			},
+			"autocapture": map[string]any{
+				"web": true,
+			},
+			"capture_page_view": map[string]any{
+				"web": true,
+			},
+			"disable_session_recording": map[string]any{
+				"web": false,
+			},
+			"enable_local_storage_persistence": map[string]any{
+				"web": true,
+			},
+			"person_profiles": map[string]any{
+				"web": "always",
+			},
+			"xhr_headers": []any{
+				map[string]any{"key": "X-Custom-Header", "value": "custom-value"},
+			},
+			"property_blacklist": []any{
+				map[string]any{"property": "ssn"},
+			},
+			"consent_management": map[string]any{
+				"web": []any{
+					map[string]any{
+						"provider": "oneTrust",
+						"consents": []any{"analytics"},
+					},
+				},
+			},
+		})
+		assert.Empty(t, errors)
+	})
+
+	t.Run("unknown key rejected", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{
+			"api_key":     "phc_test_key",
+			"not_a_field": true,
+		})
+		require.NotEmpty(t, errors)
+		assert.Equal(t, "/not_a_field", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "unknown config field")
+	})
+
+	t.Run("unsupported consent source rejected", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{
+			"api_key": "phc_test_key",
+			"consent_management": map[string]any{
+				"warehouse": []any{},
+			},
+		})
+		require.Len(t, errors, 1)
+		assert.Equal(t, "/consent_management/warehouse", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "source type 'warehouse' is not supported")
+	})
+
+	t.Run("invalid consent provider rejected", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{
+			"api_key": "phc_test_key",
+			"consent_management": map[string]any{
+				"android_kotlin": []any{
+					map[string]any{"provider": "unknown"},
+				},
+			},
+		})
+		require.Len(t, errors, 1)
+		assert.Equal(t, "/consent_management/android_kotlin/0/provider", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "'provider' must be one of")
+	})
+}
+
+func TestPosthogConversionRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	def := posthog.NewDefinition()
+	testutil.AssertConversion(t, def.Properties, []testutil.ConversionCase{
+		{
+			Name: "minimal api key",
+			LocalJSON: `{
+				"api_key": "phc_test_key"
+			}`,
+			APIJSON: `{
+				"teamApiKey": "phc_test_key"
+			}`,
+		},
+		{
+			Name: "full fields",
+			LocalJSON: `{
+				"api_key": "phc_test_key",
+				"endpoint": "https://app.posthog.com",
+				"use_v2_group": true,
+				"event_filtering": {
+					"whitelist": ["Product Viewed", "Order Completed"]
+				},
+				"use_native_sdk": {"web": true},
+				"autocapture": {"web": true},
+				"capture_page_view": {"web": false},
+				"disable_session_recording": {"web": true},
+				"enable_local_storage_persistence": {"web": true},
+				"person_profiles": {"web": "identified_only"},
+				"xhr_headers": [
+					{"key": "X-Custom", "value": "value"}
+				],
+				"property_blacklist": [
+					{"property": "ssn"}
+				]
+			}`,
+			APIJSON: `{
+				"teamApiKey": "phc_test_key",
+				"yourInstance": "https://app.posthog.com",
+				"useV2Group": true,
+				"eventFilteringOption": "whitelistedEvents",
+				"whitelistedEvents": [
+					{"eventName": "Product Viewed"},
+					{"eventName": "Order Completed"}
+				],
+				"useNativeSDK": {"web": true},
+				"autocapture": {"web": true},
+				"capturePageView": {"web": false},
+				"disableSessionRecording": {"web": true},
+				"enableLocalStoragePersistence": {"web": true},
+				"personProfiles": {"web": "identified_only"},
+				"xhrHeaders": {
+					"web": [
+						{"key": "X-Custom", "value": "value"}
+					]
+				},
+				"propertyBlacklist": {
+					"web": [
+						{"property": "ssn"}
+					]
+				}
+			}`,
+		},
+		{
+			Name: "event filtering blacklist",
+			LocalJSON: `{
+				"api_key": "phc_test_key",
+				"event_filtering": {
+					"blacklist": ["Application Opened"]
+				}
+			}`,
+			APIJSON: `{
+				"teamApiKey": "phc_test_key",
+				"eventFilteringOption": "blacklistedEvents",
+				"blacklistedEvents": [
+					{"eventName": "Application Opened"}
+				]
+			}`,
+		},
+		{
+			Name: "consent source boundary mappings",
+			LocalJSON: `{
+				"api_key": "phc_test_key",
+				"consent_management": {
+					"android_kotlin": [{"provider": "oneTrust"}],
+					"ios_swift": [{"provider": "ketch"}],
+					"react_native": [{"provider": "iubenda"}]
+				}
+			}`,
+			APIJSON: `{
+				"teamApiKey": "phc_test_key",
+				"consentManagement": {
+					"androidKotlin": [{"provider": "oneTrust"}],
+					"iosSwift": [{"provider": "ketch"}],
+					"reactnative": [{"provider": "iubenda"}]
+				}
+			}`,
+		},
+	})
+}


### PR DESCRIPTION
## 🔗 Ticket

Resolves [DEX-517](https://linear.app/rudderstack/issue/DEX-517/onboard-destination-posthog)

---

## Summary

Onboards the PostHog (`posthog`) destination into the CLI destination definition registry so it can be managed via YAML specs under the destination-support experimental flag.

---

## Changes

- Added `posthog` destination definition (`Type: posthog`, `APIType: POSTHOG`, `Version: 1`) with terraform-ported property mappings:
  - `api_key` (required, secret; API `teamApiKey`), `endpoint` (API `yourInstance`), `use_v2_group`
  - web device SDK options: `use_native_sdk`, gated `autocapture` / `capture_page_view` / `disable_session_recording` / `enable_local_storage_persistence` / `person_profiles`
  - gated `xhr_headers` / `property_blacklist` (array-of-objects under API `.web`)
  - `event_filtering.{whitelist,blacklist}` + `eventFilteringOption` discriminator
  - consent management via `common.Properties`
- Registered `posthog_endpoint` via `NewPatternWithReject` — allow `^(.{0,100})$`, reject `\.ngrok\.io` (schema negative-lookahead equivalent)
- Registered definition in `newDestinationRegistry` and updated `SupportedTypes` expectation (`posthog`, `s3`)
- Unit tests for metadata (incl. gated keypaths), config validation (incl. ngrok reject), and local↔API conversion round-trips

### Onboarding notes / discrepancies

- **Dropped source types** (CLI event-stream ownership, S3 precedent): `amp`, `shopify`, `warehouse`
- **Terraform vs db-config source types**: terraform omits `androidKotlin` / `iosSwift`; CLI includes them from db-config
- **Gated keys** (web-only; present in `destConfig.web`, not `defaultConfig`):
  - `autocapture/web`, `capture_page_view/web`, `disable_session_recording/web`, `enable_local_storage_persistence/web`, `person_profiles/web`
  - `xhr_headers`, `property_blacklist`
- **Not gated** (boilerplate): `use_native_sdk` mapped but not wrapped in `Gated`; `connectionMode.*` omitted (handled by definition `ConnectionModes`)
- **SecretKeys**: `api_key` included because terraform marks it `Sensitive`. db-config `secretKeys` is empty — flagged; CLI treats the key as a secret
- **Local key renames** (follow terraform, not raw snake_case of API keys): `teamApiKey` → `api_key`, `yourInstance` → `endpoint`
- **propertyBlacklist casing**: terraform maps `propertyBlacklist`; upstream db-config/schema use `propertyBlackList`. Mapping follows terraform
- **xhr_headers.value max**: schema `max=100`; terraform allows `max=500`. Validation follows schema (`max=100`)
- **endpoint required**: terraform schema marks `endpoint` Required; schema.json only requires `teamApiKey`. Validation follows schema (endpoint optional)
- **use_v2_group default**: schema default `false`; terraform default `true`. Optional `*bool`, no default baked into CLI

### Example YAML

```yaml
version: rudder/v1
kind: destination
metadata:
  name: my-posthog-destination
spec:
  id: my-posthog-destination
  display_name: My PostHog Destination
  type: posthog
  enabled: true
  definition_version: 1
  config:
    api_key: phc_YOUR_PROJECT_API_KEY
    endpoint: https://app.posthog.com
    use_v2_group: true
    event_filtering:
      whitelist:
        - Product Viewed
        - Order Completed
    use_native_sdk:
      web: true
    autocapture:
      web: true
    capture_page_view:
      web: true
    disable_session_recording:
      web: false
    enable_local_storage_persistence:
      web: true
    person_profiles:
      web: always
    xhr_headers:
      - key: X-Custom-Header
        value: custom-value
    property_blacklist:
      - property: ssn
    consent_management:
      web:
        - provider: oneTrust
          consents:
            - analytics
```

Requires `experimental: true` + `flags.destinationSupport: true` in CLI config.

---

## Testing

- `go build ./...`
- `go test ./cli/internal/providers/destination/... ./cli/internal/app/...`
- `make lint`

---

## Risk / Impact

Low
Notes: additive registry entry behind experimental destination-support flag; no change to existing destination behavior.

---

## Checklist

- [x] Ticket linked
- [x] Tests added/updated
- [x] No breaking changes (or documented)

Made with [Cursor](https://cursor.com)