### PR TITLE
feat(cli): onboard iterable destination definition

### DIFF
--- a/cli/internal/app/dependencies.go
+++ b/cli/internal/app/dependencies.go
@@ -16,6 +16,7 @@ import (
 	dgProvider "github.com/rudderlabs/rudder-iac/cli/internal/providers/datagraph"
 	destProvider "github.com/rudderlabs/rudder-iac/cli/internal/providers/destination"
 	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions"
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions/iterable"
 	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions/s3"
 	esProvider "github.com/rudderlabs/rudder-iac/cli/internal/providers/event-stream"
 	"github.com/rudderlabs/rudder-iac/cli/internal/providers/retl"
@@ -247,6 +248,9 @@ func newDestinationRegistry(cfg config.Config) (*definitions.Registry, error) {
 	}
 	if err := registry.Register(s3.NewDefinition()); err != nil {
 		return nil, fmt.Errorf("registering s3 destination definition: %w", err)
+	}
+	if err := registry.Register(iterable.NewDefinition()); err != nil {
+		return nil, fmt.Errorf("registering iterable destination definition: %w", err)
 	}
 	return registry, nil
 }

--- a/cli/internal/app/dependencies_test.go
+++ b/cli/internal/app/dependencies_test.go
@@ -40,7 +40,7 @@ func TestNewDestinationRegistryRegistersS3WhenFlagEnabled(t *testing.T) {
 
 	registry, err := newDestinationRegistry(config.GetConfig())
 	require.NoError(t, err)
-	assert.Equal(t, []string{"s3"}, registry.SupportedTypes())
+	assert.Equal(t, []string{"iterable", "s3"}, registry.SupportedTypes())
 }
 
 func TestNewDestinationRegistryEmptyWhenFlagDisabled(t *testing.T) {

--- a/cli/internal/providers/destination/definitions/iterable/definition.go
+++ b/cli/internal/providers/destination/definitions/iterable/definition.go
@@ -1,0 +1,199 @@
+package iterable
+
+import (
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions"
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions/common"
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions/converter"
+)
+
+// Source types from integrations-config destinations/iterable/db-config.json
+// supportedSourceTypes, restricted to types the CLI event-stream provider owns.
+var sourceTypes = []string{
+	common.SourceTypeAndroid,
+	common.SourceTypeAndroidKotlin,
+	common.SourceTypeIOS,
+	common.SourceTypeIOSSwift,
+	common.SourceTypeWeb,
+	common.SourceTypeUnity,
+	common.SourceTypeReactNative,
+	common.SourceTypeFlutter,
+	common.SourceTypeCordova,
+	common.SourceTypeCloud,
+}
+
+var connectionModes = map[string][]string{
+	common.SourceTypeAndroid:       {"cloud"},
+	common.SourceTypeAndroidKotlin: {"cloud"},
+	common.SourceTypeIOS:           {"cloud"},
+	common.SourceTypeIOSSwift:      {"cloud"},
+	common.SourceTypeWeb:           {"cloud", "device"},
+	common.SourceTypeUnity:         {"cloud"},
+	common.SourceTypeReactNative:   {"cloud"},
+	common.SourceTypeFlutter:       {"cloud"},
+	common.SourceTypeCordova:       {"cloud"},
+	common.SourceTypeCloud:         {"cloud"},
+}
+
+type webBool struct {
+	Web *bool `mapstructure:"web"`
+}
+
+type webString struct {
+	Web string `mapstructure:"web"`
+}
+
+type webStringList struct {
+	Web []string `mapstructure:"web" validate:"omitempty,dive,max=100"`
+}
+
+type webInitIdentifier struct {
+	Web string `mapstructure:"web" validate:"omitempty,dynamic_or_oneof=email userId"`
+}
+
+type webHandleLinks struct {
+	Web string `mapstructure:"web" validate:"omitempty,dynamic_or_oneof=open-all-new-tab open-all-same-tab external-new-tab"`
+}
+
+type webCloseButtonPosition struct {
+	Web string `mapstructure:"web" validate:"omitempty,dynamic_or_oneof=top-right top-left"`
+}
+
+type webPackageName struct {
+	Web string `mapstructure:"web" validate:"omitempty,max=100"`
+}
+
+// iterableConfig is the local YAML config model. Field set mirrors terraform
+// destination_iterable.go mappings; validation constraints mirror overlapping
+// schema.json rules.
+type iterableConfig struct {
+	APIKey                     string                   `mapstructure:"api_key" validate:"required,min=1,max=100"`
+	MapToSingleEvent           *bool                    `mapstructure:"map_to_single_event"`
+	TrackAllPages              *bool                    `mapstructure:"track_all_pages"`
+	TrackCategorizedPages      *bool                    `mapstructure:"track_categorized_pages"`
+	TrackNamedPages            *bool                    `mapstructure:"track_named_pages"`
+	UseNativeSDK               webBool                  `mapstructure:"use_native_sdk"`
+	InitialisationIdentifier   webInitIdentifier        `mapstructure:"initialisation_identifier"`
+	GetInAppEventMapping       webStringList            `mapstructure:"get_in_app_event_mapping"`
+	PurchaseEventMapping       webStringList            `mapstructure:"purchase_event_mapping"`
+	SendTrackForInapp          webBool                  `mapstructure:"send_track_for_inapp"`
+	AnimationDuration          webString                `mapstructure:"animation_duration"`
+	DisplayInterval            webString                `mapstructure:"display_interval"`
+	OnOpenScreenReaderMessage  webString                `mapstructure:"on_open_screen_reader_message"`
+	OnOpenNodeToTakeFocus      webString                `mapstructure:"on_open_node_to_take_focus"`
+	PackageName                webPackageName           `mapstructure:"package_name"`
+	RightOffset                webString                `mapstructure:"right_offset"`
+	TopOffset                  webString                `mapstructure:"top_offset"`
+	BottomOffset               webString                `mapstructure:"bottom_offset"`
+	HandleLinks                webHandleLinks           `mapstructure:"handle_links"`
+	CloseButtonColor           webString                `mapstructure:"close_button_color"`
+	CloseButtonSize            webString                `mapstructure:"close_button_size"`
+	CloseButtonColorTopOffset  webString                `mapstructure:"close_button_color_top_offset"`
+	CloseButtonColorSideOffset webString                `mapstructure:"close_button_color_side_offset"`
+	IconPath                   webString                `mapstructure:"icon_path"`
+	IsRequiredToDismissMessage webBool                  `mapstructure:"is_required_to_dismiss_message"`
+	CloseButtonPosition        webCloseButtonPosition   `mapstructure:"close_button_position"`
+	ConsentManagement          common.ConsentManagement `mapstructure:"consent_management"`
+}
+
+// NewDefinition returns the Iterable destination definition.
+func NewDefinition() *definitions.DestinationDefinition {
+	properties := []converter.ConfigProperty{
+		converter.Simple("apiKey", "api_key", converter.SkipZeroValue),
+		converter.Simple("mapToSingleEvent", "map_to_single_event"),
+		converter.Simple("trackAllPages", "track_all_pages", converter.SkipZeroValue),
+		converter.Simple("trackCategorisedPages", "track_categorized_pages"),
+		converter.Simple("trackNamedPages", "track_named_pages"),
+		converter.Simple("useNativeSDK.web", "use_native_sdk.web"),
+		converter.Gated(
+			converter.Simple("initialisationIdentifier.web", "initialisation_identifier.web", converter.SkipZeroValue),
+			common.SourceTypeWeb,
+		),
+		converter.Gated(
+			converter.ArrayWithStrings("getInAppEventMapping.web", "eventName", "get_in_app_event_mapping.web"),
+			common.SourceTypeWeb,
+		),
+		converter.Gated(
+			converter.ArrayWithStrings("purchaseEventMapping.web", "eventName", "purchase_event_mapping.web"),
+			common.SourceTypeWeb,
+		),
+		converter.Gated(
+			converter.Simple("sendTrackForInapp.web", "send_track_for_inapp.web"),
+			common.SourceTypeWeb,
+		),
+		converter.Gated(
+			converter.Simple("animationDuration.web", "animation_duration.web", converter.SkipZeroValue),
+			common.SourceTypeWeb,
+		),
+		converter.Gated(
+			converter.Simple("displayInterval.web", "display_interval.web", converter.SkipZeroValue),
+			common.SourceTypeWeb,
+		),
+		converter.Gated(
+			converter.Simple("onOpenScreenReaderMessage.web", "on_open_screen_reader_message.web", converter.SkipZeroValue),
+			common.SourceTypeWeb,
+		),
+		converter.Gated(
+			converter.Simple("onOpenNodeToTakeFocus.web", "on_open_node_to_take_focus.web", converter.SkipZeroValue),
+			common.SourceTypeWeb,
+		),
+		// packageName is in destConfig.defaultConfig — not source-type-gated.
+		converter.Simple("packageName.web", "package_name.web", converter.SkipZeroValue),
+		converter.Gated(
+			converter.Simple("rightOffset.web", "right_offset.web", converter.SkipZeroValue),
+			common.SourceTypeWeb,
+		),
+		converter.Gated(
+			converter.Simple("topOffset.web", "top_offset.web", converter.SkipZeroValue),
+			common.SourceTypeWeb,
+		),
+		converter.Gated(
+			converter.Simple("bottomOffset.web", "bottom_offset.web", converter.SkipZeroValue),
+			common.SourceTypeWeb,
+		),
+		converter.Gated(
+			converter.Simple("handleLinks.web", "handle_links.web", converter.SkipZeroValue),
+			common.SourceTypeWeb,
+		),
+		converter.Gated(
+			converter.Simple("closeButtonColor.web", "close_button_color.web", converter.SkipZeroValue),
+			common.SourceTypeWeb,
+		),
+		converter.Gated(
+			converter.Simple("closeButtonSize.web", "close_button_size.web", converter.SkipZeroValue),
+			common.SourceTypeWeb,
+		),
+		converter.Gated(
+			converter.Simple("closeButtonColorTopOffset.web", "close_button_color_top_offset.web", converter.SkipZeroValue),
+			common.SourceTypeWeb,
+		),
+		converter.Gated(
+			converter.Simple("closeButtonColorSideOffset.web", "close_button_color_side_offset.web", converter.SkipZeroValue),
+			common.SourceTypeWeb,
+		),
+		converter.Gated(
+			converter.Simple("iconPath.web", "icon_path.web", converter.SkipZeroValue),
+			common.SourceTypeWeb,
+		),
+		converter.Gated(
+			converter.Simple("isRequiredToDismissMessage.web", "is_required_to_dismiss_message.web"),
+			common.SourceTypeWeb,
+		),
+		converter.Gated(
+			converter.Simple("closeButtonPosition.web", "close_button_position.web", converter.SkipZeroValue),
+			common.SourceTypeWeb,
+		),
+	}
+	properties = append(properties, common.Properties(sourceTypes)...)
+
+	return &definitions.DestinationDefinition{
+		Type:       "iterable",
+		APIType:    "ITERABLE",
+		Version:    1,
+		Properties: properties,
+		NewConfig: func() any {
+			return &iterableConfig{}
+		},
+		SourceTypes:     append([]string(nil), sourceTypes...),
+		ConnectionModes: connectionModes,
+	}
+}

--- a/cli/internal/providers/destination/definitions/iterable/definition_test.go
+++ b/cli/internal/providers/destination/definitions/iterable/definition_test.go
@@ -1,0 +1,373 @@
+package iterable_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions"
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions/iterable"
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions/testutil"
+)
+
+func TestNewDefinitionMetadata(t *testing.T) {
+	t.Parallel()
+
+	registry := definitions.NewRegistry()
+	require.NoError(t, registry.Register(iterable.NewDefinition()))
+
+	registered, err := registry.Get("iterable", 1)
+	require.NoError(t, err)
+
+	assert.Equal(t, "iterable", registered.Type)
+	assert.Equal(t, "ITERABLE", registered.APIType)
+	assert.Equal(t, int64(1), registered.Version)
+	assert.Equal(t, []string{}, registered.SecretKeys())
+
+	expectedSourceTypes := []string{
+		"android", "android_kotlin", "ios", "ios_swift", "web",
+		"unity", "react_native", "flutter", "cordova", "cloud",
+	}
+	assert.Equal(t, expectedSourceTypes, registered.SupportedSourceTypes())
+
+	for _, sourceType := range expectedSourceTypes {
+		modes, err := registered.ConnectionModes(sourceType)
+		require.NoError(t, err)
+		if sourceType == "web" {
+			assert.Equal(t, []string{"cloud", "device"}, modes)
+			continue
+		}
+		assert.Equal(t, []string{"cloud"}, modes)
+	}
+
+	assert.NotContains(t, registered.SupportedSourceTypes(), "amp")
+	assert.NotContains(t, registered.SupportedSourceTypes(), "shopify")
+	assert.NotContains(t, registered.SupportedSourceTypes(), "warehouse")
+
+	assert.Equal(t, map[string][]string{
+		"initialisation_identifier/web":      {"web"},
+		"get_in_app_event_mapping/web":       {"web"},
+		"purchase_event_mapping/web":         {"web"},
+		"send_track_for_inapp/web":           {"web"},
+		"animation_duration/web":             {"web"},
+		"display_interval/web":               {"web"},
+		"on_open_screen_reader_message/web":  {"web"},
+		"on_open_node_to_take_focus/web":     {"web"},
+		"right_offset/web":                   {"web"},
+		"top_offset/web":                     {"web"},
+		"bottom_offset/web":                  {"web"},
+		"handle_links/web":                   {"web"},
+		"close_button_color/web":             {"web"},
+		"close_button_size/web":              {"web"},
+		"close_button_color_top_offset/web":  {"web"},
+		"close_button_color_side_offset/web": {"web"},
+		"icon_path/web":                      {"web"},
+		"is_required_to_dismiss_message/web": {"web"},
+		"close_button_position/web":          {"web"},
+	}, registered.GatedKeyPaths())
+
+	byAPI, err := registry.GetByAPIType("ITERABLE", 1)
+	require.NoError(t, err)
+	assert.Equal(t, registered, byAPI)
+}
+
+func TestIterableConfigValidation(t *testing.T) {
+	t.Parallel()
+
+	registry := definitions.NewRegistry()
+	require.NoError(t, registry.Register(iterable.NewDefinition()))
+	registered, err := registry.Get("iterable", 1)
+	require.NoError(t, err)
+
+	t.Run("missing api_key", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{})
+		require.NotEmpty(t, errors)
+		assert.Equal(t, "/api_key", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "required")
+	})
+
+	t.Run("api_key too long", func(t *testing.T) {
+		t.Parallel()
+		long := make([]byte, 101)
+		for i := range long {
+			long[i] = 'a'
+		}
+		errors := registered.ValidateConfig(map[string]any{
+			"api_key": string(long),
+		})
+		require.NotEmpty(t, errors)
+		assert.Equal(t, "/api_key", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "100")
+	})
+
+	t.Run("invalid initialisation_identifier", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{
+			"api_key": "iterable-api-key",
+			"initialisation_identifier": map[string]any{
+				"web": "phone",
+			},
+		})
+		require.NotEmpty(t, errors)
+		assert.Equal(t, "/initialisation_identifier/web", errors[0].Path)
+	})
+
+	t.Run("invalid handle_links", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{
+			"api_key": "iterable-api-key",
+			"handle_links": map[string]any{
+				"web": "invalid-option",
+			},
+		})
+		require.NotEmpty(t, errors)
+		assert.Equal(t, "/handle_links/web", errors[0].Path)
+	})
+
+	t.Run("invalid close_button_position", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{
+			"api_key": "iterable-api-key",
+			"close_button_position": map[string]any{
+				"web": "bottom-right",
+			},
+		})
+		require.NotEmpty(t, errors)
+		assert.Equal(t, "/close_button_position/web", errors[0].Path)
+	})
+
+	t.Run("valid minimal config", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{
+			"api_key": "iterable-api-key",
+		})
+		assert.Empty(t, errors)
+	})
+
+	t.Run("valid example config", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{
+			"api_key":                 "iterable-api-key",
+			"map_to_single_event":     true,
+			"track_all_pages":         false,
+			"track_categorized_pages": true,
+			"track_named_pages":       true,
+			"use_native_sdk": map[string]any{
+				"web": true,
+			},
+			"initialisation_identifier": map[string]any{
+				"web": "email",
+			},
+			"get_in_app_event_mapping": map[string]any{
+				"web": []any{"Product Viewed", "Cart Updated"},
+			},
+			"purchase_event_mapping": map[string]any{
+				"web": []any{"Order Completed"},
+			},
+			"send_track_for_inapp": map[string]any{
+				"web": true,
+			},
+			"animation_duration": map[string]any{
+				"web": "200",
+			},
+			"display_interval": map[string]any{
+				"web": "2500",
+			},
+			"package_name": map[string]any{
+				"web": "com.example.app",
+			},
+			"handle_links": map[string]any{
+				"web": "open-all-new-tab",
+			},
+			"close_button_position": map[string]any{
+				"web": "top-right",
+			},
+			"consent_management": map[string]any{
+				"web": []any{
+					map[string]any{
+						"provider": "oneTrust",
+						"consents": []any{"analytics"},
+					},
+				},
+			},
+		})
+		assert.Empty(t, errors)
+	})
+
+	t.Run("unknown key rejected", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{
+			"api_key":     "iterable-api-key",
+			"not_a_field": true,
+		})
+		require.NotEmpty(t, errors)
+		assert.Equal(t, "/not_a_field", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "unknown config field")
+	})
+
+	t.Run("unsupported consent source rejected", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{
+			"api_key": "iterable-api-key",
+			"consent_management": map[string]any{
+				"warehouse": []any{},
+			},
+		})
+		require.Len(t, errors, 1)
+		assert.Equal(t, "/consent_management/warehouse", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "source type 'warehouse' is not supported")
+	})
+
+	t.Run("invalid consent provider rejected", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{
+			"api_key": "iterable-api-key",
+			"consent_management": map[string]any{
+				"ios_swift": []any{
+					map[string]any{"provider": "unknown"},
+				},
+			},
+		})
+		require.Len(t, errors, 1)
+		assert.Equal(t, "/consent_management/ios_swift/0/provider", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "'provider' must be one of")
+	})
+}
+
+func TestIterableConversionRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	def := iterable.NewDefinition()
+	testutil.AssertConversion(t, def.Properties, []testutil.ConversionCase{
+		{
+			Name: "minimal api key",
+			LocalJSON: `{
+				"api_key": "iterable-api-key"
+			}`,
+			APIJSON: `{
+				"apiKey": "iterable-api-key"
+			}`,
+		},
+		{
+			Name: "full TF fields",
+			LocalJSON: `{
+				"api_key": "iterable-api-key",
+				"map_to_single_event": true,
+				"track_all_pages": true,
+				"track_categorized_pages": true,
+				"track_named_pages": true,
+				"use_native_sdk": {"web": true},
+				"initialisation_identifier": {"web": "email"},
+				"get_in_app_event_mapping": {"web": ["Product Viewed", "Cart Updated"]},
+				"purchase_event_mapping": {"web": ["Order Completed"]},
+				"send_track_for_inapp": {"web": true},
+				"animation_duration": {"web": "200"},
+				"display_interval": {"web": "2500"},
+				"on_open_screen_reader_message": {"web": "New message"},
+				"on_open_node_to_take_focus": {"web": "#main"},
+				"package_name": {"web": "com.example.app"},
+				"right_offset": {"web": "15"},
+				"top_offset": {"web": "11"},
+				"bottom_offset": {"web": "24%"},
+				"handle_links": {"web": "open-all-new-tab"},
+				"close_button_color": {"web": "blue"},
+				"close_button_size": {"web": "16"},
+				"close_button_color_top_offset": {"web": "3%"},
+				"close_button_color_side_offset": {"web": "2%"},
+				"icon_path": {"web": "/icons/close.svg"},
+				"is_required_to_dismiss_message": {"web": true},
+				"close_button_position": {"web": "top-right"}
+			}`,
+			APIJSON: `{
+				"apiKey": "iterable-api-key",
+				"mapToSingleEvent": true,
+				"trackAllPages": true,
+				"trackCategorisedPages": true,
+				"trackNamedPages": true,
+				"useNativeSDK": {"web": true},
+				"initialisationIdentifier": {"web": "email"},
+				"getInAppEventMapping": {"web": [{"eventName": "Product Viewed"}, {"eventName": "Cart Updated"}]},
+				"purchaseEventMapping": {"web": [{"eventName": "Order Completed"}]},
+				"sendTrackForInapp": {"web": true},
+				"animationDuration": {"web": "200"},
+				"displayInterval": {"web": "2500"},
+				"onOpenScreenReaderMessage": {"web": "New message"},
+				"onOpenNodeToTakeFocus": {"web": "#main"},
+				"packageName": {"web": "com.example.app"},
+				"rightOffset": {"web": "15"},
+				"topOffset": {"web": "11"},
+				"bottomOffset": {"web": "24%"},
+				"handleLinks": {"web": "open-all-new-tab"},
+				"closeButtonColor": {"web": "blue"},
+				"closeButtonSize": {"web": "16"},
+				"closeButtonColorTopOffset": {"web": "3%"},
+				"closeButtonColorSideOffset": {"web": "2%"},
+				"iconPath": {"web": "/icons/close.svg"},
+				"isRequiredToDismissMessage": {"web": true},
+				"closeButtonPosition": {"web": "top-right"}
+			}`,
+		},
+		{
+			Name: "array reshape get in app mapping",
+			LocalJSON: `{
+				"api_key": "iterable-api-key",
+				"get_in_app_event_mapping": {"web": ["one", "two"]}
+			}`,
+			APIJSON: `{
+				"apiKey": "iterable-api-key",
+				"getInAppEventMapping": {"web": [{"eventName": "one"}, {"eventName": "two"}]}
+			}`,
+		},
+		{
+			Name: "consent for web",
+			LocalJSON: `{
+				"api_key": "iterable-api-key",
+				"consent_management": {
+					"web": [
+						{
+							"provider": "oneTrust",
+							"resolution_strategy": "and",
+							"consents": ["analytics", "marketing"]
+						}
+					]
+				}
+			}`,
+			APIJSON: `{
+				"apiKey": "iterable-api-key",
+				"consentManagement": {
+					"web": [
+						{
+							"provider": "oneTrust",
+							"resolutionStrategy": "and",
+							"consents": [
+								{"consent": "analytics"},
+								{"consent": "marketing"}
+							]
+						}
+					]
+				}
+			}`,
+		},
+		{
+			Name: "consent source boundary mappings",
+			LocalJSON: `{
+				"api_key": "iterable-api-key",
+				"consent_management": {
+					"android_kotlin": [{"provider": "oneTrust"}],
+					"ios_swift": [{"provider": "ketch"}],
+					"react_native": [{"provider": "iubenda"}]
+				}
+			}`,
+			APIJSON: `{
+				"apiKey": "iterable-api-key",
+				"consentManagement": {
+					"androidKotlin": [{"provider": "oneTrust"}],
+					"iosSwift": [{"provider": "ketch"}],
+					"reactnative": [{"provider": "iubenda"}]
+				}
+			}`,
+		},
+	})
+}


### PR DESCRIPTION
## 🔗 Ticket

Resolves [DEX-511](https://linear.app/rudderstack/issue/DEX-511/onboard-destination-iterable)

---

## Summary

Onboards the Iterable destination into the CLI destination definition registry so YAML specs can create/update Iterable destinations under the experimental destination-support flag.

---

## Changes

- Added `definitions/iterable` with property mappings ported from terraform `destination_iterable.go` and validations from integrations-config `schema.json`
- Registered Iterable in `newDestinationRegistry` (`APIType=ITERABLE`, `Type=iterable`, `Version=1`)
- Web-only device-mode config keys gated to `web` via `converter.Gated`
- Unit tests for metadata, validation, and local↔API conversion round-trips
- Updated registry `SupportedTypes` expectation to `["iterable", "s3"]`

### Onboarding report (DestinationDefinition)

**Files created/modified**
- `cli/internal/providers/destination/definitions/iterable/definition.go` (created)
- `cli/internal/providers/destination/definitions/iterable/definition_test.go` (created)
- `cli/internal/app/dependencies.go` (register)
- `cli/internal/app/dependencies_test.go` (SupportedTypes)

**Validated example YAML**

```yaml
version: rudder/v1
kind: destination
metadata:
  name: my-iterable-destination
spec:
  id: my-iterable-destination
  display_name: My Iterable Destination
  type: iterable
  enabled: true
  definition_version: 1
  config:
    api_key: iterable-api-key
    map_to_single_event: true
    track_all_pages: false
    track_categorized_pages: true
    track_named_pages: true
    use_native_sdk:
      web: true
    initialisation_identifier:
      web: email
    get_in_app_event_mapping:
      web:
        - Product Viewed
        - Cart Updated
    purchase_event_mapping:
      web:
        - Order Completed
    send_track_for_inapp:
      web: true
    animation_duration:
      web: "200"
    display_interval:
      web: "2500"
    package_name:
      web: com.example.app
    handle_links:
      web: open-all-new-tab
    close_button_position:
      web: top-right
    consent_management:
      web:
        - provider: oneTrust
          consents:
            - analytics
```

**Flagged discrepancies / omissions**
- Dropped upstream source types (S3 precedent / not CLI-owned): `amp`, `shopify`, `warehouse`
- Omitted fields present upstream but **not mapped in terraform** (out of supported surface):
  - `dataCenter` (required in schema.json — USDC/EUDC)
  - `preferUserId`
  - `mergeNestedObjects`
  - `registerDeviceOrBrowserApiKey` (also listed in db-config `secretKeys`; left out of CLI `SecretKeys` because there is no terraform mapping / config field)
- Terraform does not list `androidKotlin` / `iosSwift`; included from db-config capabilities
- Schema `anyOf` requiring flat `packageName` when `connectionMode.web=device` is **not enforced** in the CLI config model (no `connection_mode` validate field); terraform models `packageName` as nested `packageName.web`
- `useNativeSDK` is web-only in destConfig but left ungated per skill boilerplate rule (ported from terraform without `Gated`)

**Gated keys** (all → `web`)
- `initialisation_identifier.web`, `get_in_app_event_mapping.web`, `purchase_event_mapping.web`, `send_track_for_inapp.web`, `animation_duration.web`, `display_interval.web`, `on_open_screen_reader_message.web`, `on_open_node_to_take_focus.web`, `right_offset.web`, `top_offset.web`, `bottom_offset.web`, `handle_links.web`, `close_button_color.web`, `close_button_size.web`, `close_button_color_top_offset.web`, `close_button_color_side_offset.web`, `icon_path.web`, `is_required_to_dismiss_message.web`, `close_button_position.web`
- Not gated: `package_name.web` (present in `destConfig.defaultConfig`)

**Usage reminder**
Requires `experimental: true` + `flags.destinationSupport: true` in CLI config.

---

## Testing

- `go build ./...`
- `go test ./cli/internal/providers/destination/... ./cli/internal/app/...`
- `make lint`
- Example config asserted via `ValidateConfig` (`valid example config` subtest)

---

## Risk / Impact

Low
Additive registry entry behind experimental flag; no change to existing destination types.

---

## Checklist

- [x] Ticket linked
- [x] Tests added/updated
- [x] No breaking changes (or documented)

Made with [Cursor](https://cursor.com)