### PR TITLE
feat(cli): onboard sentry destination definition

### DIFF
--- a/cli/internal/app/dependencies.go
+++ b/cli/internal/app/dependencies.go
@@ -17,6 +17,7 @@ import (
 	destProvider "github.com/rudderlabs/rudder-iac/cli/internal/providers/destination"
 	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions"
 	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions/s3"
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions/sentry"
 	esProvider "github.com/rudderlabs/rudder-iac/cli/internal/providers/event-stream"
 	"github.com/rudderlabs/rudder-iac/cli/internal/providers/retl"
 	"github.com/rudderlabs/rudder-iac/cli/internal/providers/transformations"
@@ -247,6 +248,9 @@ func newDestinationRegistry(cfg config.Config) (*definitions.Registry, error) {
 	}
 	if err := registry.Register(s3.NewDefinition()); err != nil {
 		return nil, fmt.Errorf("registering s3 destination definition: %w", err)
+	}
+	if err := registry.Register(sentry.NewDefinition()); err != nil {
+		return nil, fmt.Errorf("registering sentry destination definition: %w", err)
 	}
 	return registry, nil
 }

--- a/cli/internal/app/dependencies_test.go
+++ b/cli/internal/app/dependencies_test.go
@@ -40,7 +40,7 @@ func TestNewDestinationRegistryRegistersS3WhenFlagEnabled(t *testing.T) {
 
 	registry, err := newDestinationRegistry(config.GetConfig())
 	require.NoError(t, err)
-	assert.Equal(t, []string{"s3"}, registry.SupportedTypes())
+	assert.Equal(t, []string{"s3", "sentry"}, registry.SupportedTypes())
 }
 
 func TestNewDestinationRegistryEmptyWhenFlagDisabled(t *testing.T) {

--- a/cli/internal/providers/destination/definitions/sentry/definition.go
+++ b/cli/internal/providers/destination/definitions/sentry/definition.go
@@ -1,0 +1,94 @@
+package sentry
+
+import (
+	"github.com/rudderlabs/rudder-iac/cli/internal/provider/rules/funcs"
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions"
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions/common"
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions/converter"
+)
+
+func init() {
+	// schema.json allowUrls/denyUrls: (?!.*\.ngrok\.io).*$ — reject ngrok hosts.
+	funcs.NewPatternWithReject(
+		"sentry_url",
+		`^.*$`,
+		`\.ngrok\.io`,
+		"must not contain .ngrok.io",
+	)
+}
+
+// Source types from integrations-config destinations/sentry/db-config.json
+// supportedSourceTypes (web only).
+var sourceTypes = []string{
+	common.SourceTypeWeb,
+}
+
+var connectionModes = map[string][]string{
+	common.SourceTypeWeb: {"device"},
+}
+
+type eventFiltering struct {
+	Whitelist []string `mapstructure:"whitelist" validate:"omitempty,dive,max=100"`
+	Blacklist []string `mapstructure:"blacklist" validate:"omitempty,dive,max=100"`
+}
+
+type useNativeSDK struct {
+	Web *bool `mapstructure:"web"`
+}
+
+// sentryConfig is the local YAML config model. Field set mirrors terraform
+// destination_sentry.go mappings; validation constraints mirror schema.json.
+type sentryConfig struct {
+	DSN                   string                   `mapstructure:"dsn" validate:"required,min=1,max=300"`
+	Environment           string                   `mapstructure:"environment"`
+	CustomVersionProperty string                   `mapstructure:"custom_version_property"`
+	Release               string                   `mapstructure:"release"`
+	ServerName            string                   `mapstructure:"server_name"`
+	Logger                string                   `mapstructure:"logger"`
+	DebugMode             *bool                    `mapstructure:"debug_mode"`
+	IgnoreErrors          []string                 `mapstructure:"ignore_errors" validate:"omitempty,dive,max=100"`
+	IncludePaths          []string                 `mapstructure:"include_paths" validate:"omitempty,dive,max=100"`
+	AllowURLs             []string                 `mapstructure:"allow_urls" validate:"omitempty,dive,pattern=sentry_url"`
+	DenyURLs              []string                 `mapstructure:"deny_urls" validate:"omitempty,dive,pattern=sentry_url"`
+	EventFiltering        *eventFiltering          `mapstructure:"event_filtering"`
+	UseNativeSDK          *useNativeSDK            `mapstructure:"use_native_sdk"`
+	ConsentManagement     common.ConsentManagement `mapstructure:"consent_management"`
+}
+
+// NewDefinition returns the Sentry destination definition.
+func NewDefinition() *definitions.DestinationDefinition {
+	properties := []converter.ConfigProperty{
+		converter.Simple("dsn", "dsn"),
+		converter.Simple("environment", "environment", converter.SkipZeroValue),
+		converter.Simple("customVersionProperty", "custom_version_property", converter.SkipZeroValue),
+		converter.Simple("release", "release", converter.SkipZeroValue),
+		converter.Simple("serverName", "server_name", converter.SkipZeroValue),
+		converter.Simple("logger", "logger", converter.SkipZeroValue),
+		converter.Simple("debugMode", "debug_mode"),
+		converter.ArrayWithStrings("ignoreErrors", "ignoreErrors", "ignore_errors"),
+		converter.ArrayWithStrings("includePaths", "includePaths", "include_paths"),
+		converter.ArrayWithStrings("allowUrls", "allowUrls", "allow_urls"),
+		converter.ArrayWithStrings("denyUrls", "denyUrls", "deny_urls"),
+		converter.Simple("useNativeSDK.web", "use_native_sdk.web"),
+		converter.ArrayWithStrings("whitelistedEvents", "eventName", "event_filtering.whitelist"),
+		converter.ArrayWithStrings("blacklistedEvents", "eventName", "event_filtering.blacklist"),
+		// Terraform omits Discriminator; CLI sets eventFilteringOption from whitelist/blacklist presence (GA4/PostHog pattern).
+		converter.Discriminator("eventFilteringOption", converter.DiscriminatorValues{
+			"event_filtering.whitelist": "whitelistedEvents",
+			"event_filtering.blacklist": "blacklistedEvents",
+		}),
+	}
+	properties = append(properties, common.Properties(sourceTypes)...)
+
+	return &definitions.DestinationDefinition{
+		Type:       "sentry",
+		APIType:    "SENTRY",
+		Version:    1,
+		Properties: properties,
+		NewConfig: func() any {
+			return &sentryConfig{}
+		},
+		SourceTypes:     append([]string(nil), sourceTypes...),
+		ConnectionModes: connectionModes,
+	}
+}

--- a/cli/internal/providers/destination/definitions/sentry/definition_test.go
+++ b/cli/internal/providers/destination/definitions/sentry/definition_test.go
@@ -1,0 +1,340 @@
+package sentry_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions"
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions/sentry"
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions/testutil"
+)
+
+func TestNewDefinitionMetadata(t *testing.T) {
+	t.Parallel()
+
+	registry := definitions.NewRegistry()
+	require.NoError(t, registry.Register(sentry.NewDefinition()))
+
+	registered, err := registry.Get("sentry", 1)
+	require.NoError(t, err)
+
+	assert.Equal(t, "sentry", registered.Type)
+	assert.Equal(t, "SENTRY", registered.APIType)
+	assert.Equal(t, int64(1), registered.Version)
+	assert.Empty(t, registered.SecretKeys())
+
+	expectedSourceTypes := []string{"web"}
+	assert.Equal(t, expectedSourceTypes, registered.SupportedSourceTypes())
+
+	modes, err := registered.ConnectionModes("web")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"device"}, modes)
+
+	assert.NotContains(t, registered.SupportedSourceTypes(), "amp")
+	assert.NotContains(t, registered.SupportedSourceTypes(), "shopify")
+	assert.NotContains(t, registered.SupportedSourceTypes(), "warehouse")
+
+	assert.Empty(t, registered.GatedKeyPaths())
+
+	byAPI, err := registry.GetByAPIType("SENTRY", 1)
+	require.NoError(t, err)
+	assert.Equal(t, registered, byAPI)
+}
+
+func TestSentryConfigValidation(t *testing.T) {
+	t.Parallel()
+
+	registry := definitions.NewRegistry()
+	require.NoError(t, registry.Register(sentry.NewDefinition()))
+	registered, err := registry.Get("sentry", 1)
+	require.NoError(t, err)
+
+	t.Run("missing dsn", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{})
+		require.NotEmpty(t, errors)
+		assert.Equal(t, "/dsn", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "required")
+	})
+
+	t.Run("dsn too long rejected", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{
+			"dsn": strings.Repeat("a", 301),
+		})
+		require.NotEmpty(t, errors)
+		assert.Equal(t, "/dsn", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "300")
+	})
+
+	t.Run("valid minimal config", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{
+			"dsn": "https://public@o0.ingest.sentry.io/0",
+		})
+		assert.Empty(t, errors)
+	})
+
+	t.Run("ignore_errors item too long rejected", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{
+			"dsn":           "https://public@o0.ingest.sentry.io/0",
+			"ignore_errors": []any{strings.Repeat("e", 101)},
+		})
+		require.NotEmpty(t, errors)
+		assert.Equal(t, "/ignore_errors/0", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "100")
+	})
+
+	t.Run("allow_urls with ngrok rejected", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{
+			"dsn":        "https://public@o0.ingest.sentry.io/0",
+			"allow_urls": []any{"https://example.ngrok.io/app"},
+		})
+		require.NotEmpty(t, errors)
+		assert.Equal(t, "/allow_urls/0", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "ngrok")
+	})
+
+	t.Run("deny_urls with ngrok rejected", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{
+			"dsn":       "https://public@o0.ingest.sentry.io/0",
+			"deny_urls": []any{"https://evil.ngrok.io"},
+		})
+		require.NotEmpty(t, errors)
+		assert.Equal(t, "/deny_urls/0", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "ngrok")
+	})
+
+	t.Run("event_filtering whitelist item too long rejected", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{
+			"dsn": "https://public@o0.ingest.sentry.io/0",
+			"event_filtering": map[string]any{
+				"whitelist": []any{strings.Repeat("e", 101)},
+			},
+		})
+		require.NotEmpty(t, errors)
+		assert.Equal(t, "/event_filtering/whitelist/0", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "100")
+	})
+
+	t.Run("valid full config", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{
+			"dsn":                     "https://public@o0.ingest.sentry.io/0",
+			"environment":             "production",
+			"custom_version_property": "app.version",
+			"release":                 "1.2.3",
+			"server_name":             "api-1",
+			"logger":                  "rudderstack",
+			"debug_mode":              false,
+			"ignore_errors":           []any{"NetworkError", "ResizeObserver"},
+			"include_paths":           []any{"https://app.example.com"},
+			"allow_urls":              []any{"https://app.example.com"},
+			"deny_urls":               []any{"https://cdn.example.com"},
+			"event_filtering": map[string]any{
+				"whitelist": []any{"Error Captured", "Exception Thrown"},
+			},
+			"use_native_sdk": map[string]any{
+				"web": true,
+			},
+			"consent_management": map[string]any{
+				"web": []any{
+					map[string]any{
+						"provider": "oneTrust",
+						"consents": []any{"analytics"},
+					},
+				},
+			},
+		})
+		assert.Empty(t, errors)
+	})
+
+	t.Run("example yaml config", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{
+			"dsn":                     "https://public@o0.ingest.sentry.io/0",
+			"environment":             "production",
+			"custom_version_property": "app.version",
+			"release":                 "1.2.3",
+			"server_name":             "web-1",
+			"logger":                  "rudderstack",
+			"debug_mode":              false,
+			"ignore_errors":           []any{"NetworkError"},
+			"include_paths":           []any{"https://app.example.com"},
+			"allow_urls":              []any{"https://app.example.com"},
+			"deny_urls":               []any{"https://cdn.example.com"},
+			"event_filtering": map[string]any{
+				"whitelist": []any{"Error Captured"},
+			},
+			"use_native_sdk": map[string]any{
+				"web": true,
+			},
+			"consent_management": map[string]any{
+				"web": []any{
+					map[string]any{
+						"provider": "oneTrust",
+						"consents": []any{"analytics"},
+					},
+				},
+			},
+		})
+		assert.Empty(t, errors)
+	})
+
+	t.Run("unknown key rejected", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{
+			"dsn":         "https://public@o0.ingest.sentry.io/0",
+			"not_a_field": true,
+		})
+		require.NotEmpty(t, errors)
+		assert.Equal(t, "/not_a_field", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "unknown config field")
+	})
+
+	t.Run("unsupported consent source rejected", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{
+			"dsn": "https://public@o0.ingest.sentry.io/0",
+			"consent_management": map[string]any{
+				"warehouse": []any{},
+			},
+		})
+		require.Len(t, errors, 1)
+		assert.Equal(t, "/consent_management/warehouse", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "source type 'warehouse' is not supported")
+	})
+
+	t.Run("invalid consent provider rejected", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{
+			"dsn": "https://public@o0.ingest.sentry.io/0",
+			"consent_management": map[string]any{
+				"web": []any{
+					map[string]any{"provider": "unknown"},
+				},
+			},
+		})
+		require.Len(t, errors, 1)
+		assert.Equal(t, "/consent_management/web/0/provider", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "'provider' must be one of")
+	})
+}
+
+func TestSentryConversionRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	def := sentry.NewDefinition()
+	testutil.AssertConversion(t, def.Properties, []testutil.ConversionCase{
+		{
+			Name: "minimal dsn",
+			LocalJSON: `{
+				"dsn": "https://public@o0.ingest.sentry.io/0"
+			}`,
+			APIJSON: `{
+				"dsn": "https://public@o0.ingest.sentry.io/0"
+			}`,
+		},
+		{
+			Name: "full fields",
+			LocalJSON: `{
+				"dsn": "https://public@o0.ingest.sentry.io/0",
+				"environment": "production",
+				"custom_version_property": "app.version",
+				"release": "1.2.3",
+				"server_name": "api-1",
+				"logger": "rudderstack",
+				"debug_mode": true,
+				"ignore_errors": ["NetworkError", "ResizeObserver"],
+				"include_paths": ["https://app.example.com"],
+				"allow_urls": ["https://app.example.com"],
+				"deny_urls": ["https://cdn.example.com"],
+				"event_filtering": {
+					"whitelist": ["Error Captured", "Exception Thrown"]
+				},
+				"use_native_sdk": {"web": true}
+			}`,
+			APIJSON: `{
+				"dsn": "https://public@o0.ingest.sentry.io/0",
+				"environment": "production",
+				"customVersionProperty": "app.version",
+				"release": "1.2.3",
+				"serverName": "api-1",
+				"logger": "rudderstack",
+				"debugMode": true,
+				"ignoreErrors": [
+					{"ignoreErrors": "NetworkError"},
+					{"ignoreErrors": "ResizeObserver"}
+				],
+				"includePaths": [
+					{"includePaths": "https://app.example.com"}
+				],
+				"allowUrls": [
+					{"allowUrls": "https://app.example.com"}
+				],
+				"denyUrls": [
+					{"denyUrls": "https://cdn.example.com"}
+				],
+				"eventFilteringOption": "whitelistedEvents",
+				"whitelistedEvents": [
+					{"eventName": "Error Captured"},
+					{"eventName": "Exception Thrown"}
+				],
+				"useNativeSDK": {"web": true}
+			}`,
+		},
+		{
+			Name: "event filtering blacklist",
+			LocalJSON: `{
+				"dsn": "https://public@o0.ingest.sentry.io/0",
+				"event_filtering": {
+					"blacklist": ["Application Opened"]
+				}
+			}`,
+			APIJSON: `{
+				"dsn": "https://public@o0.ingest.sentry.io/0",
+				"eventFilteringOption": "blacklistedEvents",
+				"blacklistedEvents": [
+					{"eventName": "Application Opened"}
+				]
+			}`,
+		},
+		{
+			Name: "consent for web",
+			LocalJSON: `{
+				"dsn": "https://public@o0.ingest.sentry.io/0",
+				"consent_management": {
+					"web": [
+						{
+							"provider": "oneTrust",
+							"resolution_strategy": "and",
+							"consents": ["analytics", "marketing"]
+						}
+					]
+				}
+			}`,
+			APIJSON: `{
+				"dsn": "https://public@o0.ingest.sentry.io/0",
+				"consentManagement": {
+					"web": [
+						{
+							"provider": "oneTrust",
+							"resolutionStrategy": "and",
+							"consents": [
+								{"consent": "analytics"},
+								{"consent": "marketing"}
+							]
+						}
+					]
+				}
+			}`,
+		},
+	})
+}


### PR DESCRIPTION
## 🔗 Ticket

Resolves [DEX-524](https://linear.app/rudderstack/issue/DEX-524/onboard-destination-sentry)

---

## Summary

Onboards the Sentry destination into the CLI destination definition registry so YAML specs can create/update Sentry destinations under the experimental destination-support flag.

---

## Changes

- Added `definitions/sentry` with property mappings ported from terraform `destination_sentry.go` and validations from integrations-config `schema.json`
- Registered Sentry in `newDestinationRegistry` (`APIType=SENTRY`, `Type=sentry`, `Version=1`)
- Registered `sentry_url` via `NewPatternWithReject` — allow any string, reject `\.ngrok\.io` (schema negative-lookahead for `allowUrls` / `denyUrls`)
- Unit tests for metadata, validation (incl. ngrok reject + length), and local↔API conversion round-trips
- Updated registry `SupportedTypes` expectation to `["s3", "sentry"]`

### Onboarding report (DestinationDefinition)

**Files created/modified**
- `cli/internal/providers/destination/definitions/sentry/definition.go` (created)
- `cli/internal/providers/destination/definitions/sentry/definition_test.go` (created)
- `cli/internal/app/dependencies.go` (register)
- `cli/internal/app/dependencies_test.go` (SupportedTypes)

**Validated example YAML**

```yaml
version: rudder/v1
kind: destination
metadata:
  name: my-sentry-destination
spec:
  id: my-sentry-destination
  display_name: My Sentry Destination
  type: sentry
  enabled: true
  definition_version: 1
  config:
    dsn: https://public@o0.ingest.sentry.io/0
    environment: production
    custom_version_property: app.version
    release: "1.2.3"
    server_name: web-1
    logger: rudderstack
    debug_mode: false
    ignore_errors:
      - NetworkError
    include_paths:
      - https://app.example.com
    allow_urls:
      - https://app.example.com
    deny_urls:
      - https://cdn.example.com
    event_filtering:
      whitelist:
        - Error Captured
    use_native_sdk:
      web: true
    consent_management:
      web:
        - provider: oneTrust
          consents:
            - analytics
```

**Flagged discrepancies / omissions**
- Upstream source types: db-config lists only `web` (device mode) — no dropped source types
- **dsn max length**: schema.json allows `^(.{1,300})$`; terraform commented validators used max 100. Validation follows schema (`max=300`)
- **eventFilteringOption Discriminator**: terraform omits `Discriminator` / does not map `eventFilteringOption`; CLI adds Discriminator (GA4/PostHog pattern) so whitelist/blacklist set the API discriminator
- **Omitted / not modeled as config fields** (boilerplate / handled elsewhere): `connectionMode`, `oneTrustCookieCategories`, `ketchConsentPurposes` — consent via `common.Properties`; connection modes via definition `ConnectionModes`
- Optional string fields (`environment`, `custom_version_property`, `release`, `server_name`, `logger`) have no max in schema.json — left unconstrained (terraform commented validators suggested max 100)
- `SecretKeys`: empty (matches db-config `secretKeys: []`; no Sensitive fields in terraform)

**Gated keys**
- None. `useNativeSDK` is web-only in `destConfig.web` but left ungated per skill boilerplate rule (ported from terraform without `Gated`)

**Usage reminder**
Requires `experimental: true` + `flags.destinationSupport: true` in CLI config.

---

## Testing

- `go build ./...`
- `go test ./cli/internal/providers/destination/... ./cli/internal/app/...`
- `make lint`
- Example config asserted via `ValidateConfig` (`example yaml config` subtest)

---

## Risk / Impact

Low
Additive registry entry behind experimental flag; no change to existing destination types.

---

## Checklist

- [x] Ticket linked
- [x] Tests added/updated
- [x] No breaking changes (or documented)

Made with [Cursor](https://cursor.com)