### PR TITLE
feat(cli): onboard redis destination definition

### DIFF
--- a/cli/internal/app/dependencies.go
+++ b/cli/internal/app/dependencies.go
@@ -16,6 +16,7 @@ import (
 	dgProvider "github.com/rudderlabs/rudder-iac/cli/internal/providers/datagraph"
 	destProvider "github.com/rudderlabs/rudder-iac/cli/internal/providers/destination"
 	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions"
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions/redis"
 	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions/s3"
 	esProvider "github.com/rudderlabs/rudder-iac/cli/internal/providers/event-stream"
 	"github.com/rudderlabs/rudder-iac/cli/internal/providers/retl"
@@ -247,6 +248,9 @@ func newDestinationRegistry(cfg config.Config) (*definitions.Registry, error) {
 	}
 	if err := registry.Register(s3.NewDefinition()); err != nil {
 		return nil, fmt.Errorf("registering s3 destination definition: %w", err)
+	}
+	if err := registry.Register(redis.NewDefinition()); err != nil {
+		return nil, fmt.Errorf("registering redis destination definition: %w", err)
 	}
 	return registry, nil
 }

--- a/cli/internal/app/dependencies_test.go
+++ b/cli/internal/app/dependencies_test.go
@@ -40,7 +40,7 @@ func TestNewDestinationRegistryRegistersS3WhenFlagEnabled(t *testing.T) {
 
 	registry, err := newDestinationRegistry(config.GetConfig())
 	require.NoError(t, err)
-	assert.Equal(t, []string{"s3"}, registry.SupportedTypes())
+	assert.Equal(t, []string{"redis", "s3"}, registry.SupportedTypes())
 }
 
 func TestNewDestinationRegistryEmptyWhenFlagDisabled(t *testing.T) {

--- a/cli/internal/providers/destination/definitions/redis/definition.go
+++ b/cli/internal/providers/destination/definitions/redis/definition.go
@@ -1,0 +1,89 @@
+package redis
+
+import (
+	"github.com/rudderlabs/rudder-iac/cli/internal/provider/rules/funcs"
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions"
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions/common"
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions/converter"
+)
+
+func init() {
+	// Upstream schema rejects ngrok tunnels via a negative lookahead, which RE2
+	// cannot express — use NewPatternWithReject instead.
+	funcs.NewPatternWithReject(
+		"redis_address",
+		`^.{0,100}$`,
+		`\.ngrok\.io`,
+		"must be at most 100 characters and must not contain .ngrok.io",
+	)
+}
+
+// Source types from integrations-config destinations/redis/db-config.json
+// supportedSourceTypes, restricted to types the CLI event-stream provider owns.
+var sourceTypes = []string{
+	common.SourceTypeAndroid,
+	common.SourceTypeAndroidKotlin,
+	common.SourceTypeIOS,
+	common.SourceTypeIOSSwift,
+	common.SourceTypeWeb,
+	common.SourceTypeUnity,
+	common.SourceTypeReactNative,
+	common.SourceTypeFlutter,
+	common.SourceTypeCordova,
+	common.SourceTypeCloud,
+}
+
+var connectionModes = map[string][]string{
+	common.SourceTypeAndroid:       {"cloud"},
+	common.SourceTypeAndroidKotlin: {"cloud"},
+	common.SourceTypeIOS:           {"cloud"},
+	common.SourceTypeIOSSwift:      {"cloud"},
+	common.SourceTypeWeb:           {"cloud"},
+	common.SourceTypeUnity:         {"cloud"},
+	common.SourceTypeReactNative:   {"cloud"},
+	common.SourceTypeFlutter:       {"cloud"},
+	common.SourceTypeCordova:       {"cloud"},
+	common.SourceTypeCloud:         {"cloud"},
+}
+
+// redisConfig is the local YAML config model. Field set mirrors terraform
+// destination_redis mappings; validation constraints mirror schema.json.
+type redisConfig struct {
+	Address           string                   `mapstructure:"address" validate:"required,pattern=redis_address"`
+	Password          string                   `mapstructure:"password" validate:"omitempty"`
+	ClusterMode       *bool                    `mapstructure:"cluster_mode"`
+	Secure            *bool                    `mapstructure:"secure"`
+	Prefix            string                   `mapstructure:"prefix" validate:"omitempty,max=100"`
+	Database          string                   `mapstructure:"database" validate:"omitempty,max=100"`
+	CACertificate     string                   `mapstructure:"ca_certificate" validate:"omitempty"`
+	SkipVerify        *bool                    `mapstructure:"skip_verify"`
+	ConsentManagement common.ConsentManagement `mapstructure:"consent_management"`
+}
+
+// NewDefinition returns the Redis destination definition.
+func NewDefinition() *definitions.DestinationDefinition {
+	properties := []converter.ConfigProperty{
+		converter.Simple("address", "address"),
+		converter.Simple("password", "password", converter.SkipZeroValue),
+		converter.Simple("clusterMode", "cluster_mode"),
+		converter.Simple("secure", "secure"),
+		converter.Simple("prefix", "prefix", converter.SkipZeroValue),
+		converter.Simple("database", "database", converter.SkipZeroValue),
+		converter.Simple("caCertificate", "ca_certificate", converter.SkipZeroValue),
+		converter.Simple("skipVerify", "skip_verify"),
+	}
+	properties = append(properties, common.Properties(sourceTypes)...)
+
+	return &definitions.DestinationDefinition{
+		Type:       "redis",
+		APIType:    "REDIS",
+		Version:    1,
+		Properties: properties,
+		SecretKeys: []string{"password", "ca_certificate"},
+		NewConfig: func() any {
+			return &redisConfig{}
+		},
+		SourceTypes:     append([]string(nil), sourceTypes...),
+		ConnectionModes: connectionModes,
+	}
+}

--- a/cli/internal/providers/destination/definitions/redis/definition_test.go
+++ b/cli/internal/providers/destination/definitions/redis/definition_test.go
@@ -1,0 +1,285 @@
+package redis_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions"
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions/redis"
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions/testutil"
+)
+
+func TestNewDefinitionMetadata(t *testing.T) {
+	t.Parallel()
+
+	registry := definitions.NewRegistry()
+	require.NoError(t, registry.Register(redis.NewDefinition()))
+
+	registered, err := registry.Get("redis", 1)
+	require.NoError(t, err)
+
+	assert.Equal(t, "redis", registered.Type)
+	assert.Equal(t, "REDIS", registered.APIType)
+	assert.Equal(t, int64(1), registered.Version)
+	assert.Equal(t, []string{"password", "ca_certificate"}, registered.SecretKeys())
+
+	expectedSourceTypes := []string{
+		"android", "android_kotlin", "ios", "ios_swift", "web",
+		"unity", "react_native", "flutter", "cordova", "cloud",
+	}
+	assert.Equal(t, expectedSourceTypes, registered.SupportedSourceTypes())
+
+	for _, sourceType := range expectedSourceTypes {
+		modes, err := registered.ConnectionModes(sourceType)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"cloud"}, modes)
+	}
+
+	assert.NotContains(t, registered.SupportedSourceTypes(), "amp")
+	assert.NotContains(t, registered.SupportedSourceTypes(), "shopify")
+	assert.NotContains(t, registered.SupportedSourceTypes(), "warehouse")
+
+	byAPI, err := registry.GetByAPIType("REDIS", 1)
+	require.NoError(t, err)
+	assert.Equal(t, registered, byAPI)
+}
+
+func TestRedisConfigValidation(t *testing.T) {
+	t.Parallel()
+
+	registry := definitions.NewRegistry()
+	require.NoError(t, registry.Register(redis.NewDefinition()))
+	registered, err := registry.Get("redis", 1)
+	require.NoError(t, err)
+
+	t.Run("missing address", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{})
+		require.NotEmpty(t, errors)
+		assert.Equal(t, "/address", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "required")
+	})
+
+	t.Run("address too long rejected", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{
+			"address": strings.Repeat("a", 101),
+		})
+		require.NotEmpty(t, errors)
+		assert.Equal(t, "/address", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "must be at most 100 characters")
+	})
+
+	t.Run("address with ngrok rejected", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{
+			"address": "redis.ngrok.io:6379",
+		})
+		require.NotEmpty(t, errors)
+		assert.Equal(t, "/address", errors[0].Path)
+		assert.Contains(t, errors[0].Message, ".ngrok.io")
+	})
+
+	t.Run("prefix too long rejected", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{
+			"address": "redis.example.com:6379",
+			"prefix":  strings.Repeat("p", 101),
+		})
+		require.NotEmpty(t, errors)
+		assert.Equal(t, "/prefix", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "less than or equal to 100")
+	})
+
+	t.Run("valid minimal config", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{
+			"address": "redis.example.com:6379",
+		})
+		assert.Empty(t, errors)
+	})
+
+	t.Run("valid example config", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{
+			"address":        "redis.example.com:6379",
+			"password":       "s3cret",
+			"cluster_mode":   true,
+			"secure":         true,
+			"prefix":         "rudder",
+			"database":       "0",
+			"ca_certificate": "-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----",
+			"skip_verify":    false,
+			"consent_management": map[string]any{
+				"web": []any{
+					map[string]any{
+						"provider": "oneTrust",
+						"consents": []any{"analytics"},
+					},
+				},
+			},
+		})
+		assert.Empty(t, errors)
+	})
+
+	t.Run("valid full config", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{
+			"address":        "redis.example.com:6379",
+			"password":       "s3cret",
+			"cluster_mode":   false,
+			"secure":         true,
+			"prefix":         "rudder",
+			"database":       "1",
+			"ca_certificate": "cert-data",
+			"skip_verify":    true,
+		})
+		assert.Empty(t, errors)
+	})
+
+	t.Run("unknown key rejected", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{
+			"address":     "redis.example.com:6379",
+			"not_a_field": true,
+		})
+		require.NotEmpty(t, errors)
+		assert.Equal(t, "/not_a_field", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "unknown config field")
+	})
+
+	t.Run("unsupported consent source rejected", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{
+			"address": "redis.example.com:6379",
+			"consent_management": map[string]any{
+				"warehouse": []any{},
+			},
+		})
+		require.Len(t, errors, 1)
+		assert.Equal(t, "/consent_management/warehouse", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "source type 'warehouse' is not supported")
+	})
+
+	t.Run("invalid consent provider rejected", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{
+			"address": "redis.example.com:6379",
+			"consent_management": map[string]any{
+				"ios_swift": []any{
+					map[string]any{"provider": "unknown"},
+				},
+			},
+		})
+		require.Len(t, errors, 1)
+		assert.Equal(t, "/consent_management/ios_swift/0/provider", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "'provider' must be one of")
+	})
+}
+
+func TestRedisConversionRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	def := redis.NewDefinition()
+	testutil.AssertConversion(t, def.Properties, []testutil.ConversionCase{
+		{
+			Name: "minimal address only",
+			LocalJSON: `{
+				"address": "redis.example.com:6379"
+			}`,
+			APIJSON: `{
+				"address": "redis.example.com:6379"
+			}`,
+		},
+		{
+			Name: "full TF fields",
+			LocalJSON: `{
+				"address": "redis.example.com:6379",
+				"password": "s3cret",
+				"cluster_mode": false,
+				"secure": true,
+				"prefix": "rudder",
+				"database": "1",
+				"ca_certificate": "cert-data",
+				"skip_verify": true
+			}`,
+			APIJSON: `{
+				"address": "redis.example.com:6379",
+				"password": "s3cret",
+				"clusterMode": false,
+				"secure": true,
+				"prefix": "rudder",
+				"database": "1",
+				"caCertificate": "cert-data",
+				"skipVerify": true
+			}`,
+		},
+		{
+			Name: "booleans false written without SkipZeroValue",
+			LocalJSON: `{
+				"address": "redis.example.com:6379",
+				"cluster_mode": false,
+				"secure": false,
+				"skip_verify": false
+			}`,
+			APIJSON: `{
+				"address": "redis.example.com:6379",
+				"clusterMode": false,
+				"secure": false,
+				"skipVerify": false
+			}`,
+		},
+		{
+			Name: "consent for web",
+			LocalJSON: `{
+				"address": "redis.example.com:6379",
+				"consent_management": {
+					"web": [
+						{
+							"provider": "oneTrust",
+							"resolution_strategy": "and",
+							"consents": ["analytics", "marketing"]
+						}
+					]
+				}
+			}`,
+			APIJSON: `{
+				"address": "redis.example.com:6379",
+				"consentManagement": {
+					"web": [
+						{
+							"provider": "oneTrust",
+							"resolutionStrategy": "and",
+							"consents": [
+								{"consent": "analytics"},
+								{"consent": "marketing"}
+							]
+						}
+					]
+				}
+			}`,
+		},
+		{
+			Name: "consent source boundary mappings",
+			LocalJSON: `{
+				"address": "redis.example.com:6379",
+				"consent_management": {
+					"android_kotlin": [{"provider": "oneTrust"}],
+					"ios_swift": [{"provider": "ketch"}],
+					"react_native": [{"provider": "iubenda"}]
+				}
+			}`,
+			APIJSON: `{
+				"address": "redis.example.com:6379",
+				"consentManagement": {
+					"androidKotlin": [{"provider": "oneTrust"}],
+					"iosSwift": [{"provider": "ketch"}],
+					"reactnative": [{"provider": "iubenda"}]
+				}
+			}`,
+		},
+	})
+}


### PR DESCRIPTION
## 🔗 Ticket

Resolves [DEX-519](https://linear.app/rudderstack/issue/DEX-519/onboard-destination-redis)

---

## Summary

Onboards the Redis destination into the CLI destination definition registry so Redis can be managed via YAML specs when destination support is enabled.

---

## Changes

- Added `definitions/redis` with config struct, terraform-ported property mappings, schema-derived validations, and consent management
- Registered Redis in `newDestinationRegistry` (alongside S3)
- Added metadata, validation, and conversion round-trip unit tests
- Enforced address constraints via `NewPatternWithReject` (max 100 chars + reject `.ngrok.io`)

### Onboarding notes (DestinationDefinition)

- **Type / APIType / Version**: `redis` / `REDIS` / `1`
- **Secret keys**: `password`, `ca_certificate` (from db-config `secretKeys`)
- **Source types included** (S3 precedent): android, android_kotlin, ios, ios_swift, web, unity, react_native, flutter, cordova, cloud — all `cloud` connection mode
- **Dropped upstream source types**: `amp`, `shopify`, `warehouse`
- **Omitted (no terraform mapping)**: `useJSONModule` (present in db-config `defaultConfig` + schema.json)
- **Discrepancies flagged**:
  - Terraform `supportedSourceTypes` omits `androidKotlin` / `iosSwift`; db-config includes them — CLI follows db-config (plus S3 ownership filter)
  - Terraform marks only `password` Sensitive; db-config also lists `caCertificate` as secret — CLI includes both
  - schema.json address uses negative lookahead for ngrok (not RE2-compatible); CLI uses `NewPatternWithReject("redis_address", …)`
  - schema.json `clusterMode`/`secure` conditionals only expose optional fields (`required: []`) — no `excluded_if`/`required_if` gates
- **Gated keys**: none (all mapped config keys are in `defaultConfig`)

---

## Testing

- `go test ./cli/internal/providers/destination/... ./cli/internal/app/...`
- `go build ./...`
- `make lint`

---

## Risk / Impact

Low
Additive registry entry behind `experimental: true` + `flags.destinationSupport: true`. No change to existing destination types.

---

## Checklist

- [x] Ticket linked
- [x] Tests added/updated
- [x] No breaking changes (or documented)


Made with [Cursor](https://cursor.com)