### PR TITLE
feat(cli): onboard tiktok_ads destination definition

### DIFF
--- a/cli/internal/app/dependencies.go
+++ b/cli/internal/app/dependencies.go
@@ -17,6 +17,7 @@ import (
 	destProvider "github.com/rudderlabs/rudder-iac/cli/internal/providers/destination"
 	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions"
 	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions/s3"
+	tiktokads "github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions/tiktok_ads"
 	esProvider "github.com/rudderlabs/rudder-iac/cli/internal/providers/event-stream"
 	"github.com/rudderlabs/rudder-iac/cli/internal/providers/retl"
 	"github.com/rudderlabs/rudder-iac/cli/internal/providers/transformations"
@@ -247,6 +248,9 @@ func newDestinationRegistry(cfg config.Config) (*definitions.Registry, error) {
 	}
 	if err := registry.Register(s3.NewDefinition()); err != nil {
 		return nil, fmt.Errorf("registering s3 destination definition: %w", err)
+	}
+	if err := registry.Register(tiktokads.NewDefinition()); err != nil {
+		return nil, fmt.Errorf("registering tiktok_ads destination definition: %w", err)
 	}
 	return registry, nil
 }

--- a/cli/internal/app/dependencies_test.go
+++ b/cli/internal/app/dependencies_test.go
@@ -40,7 +40,7 @@ func TestNewDestinationRegistryRegistersS3WhenFlagEnabled(t *testing.T) {
 
 	registry, err := newDestinationRegistry(config.GetConfig())
 	require.NoError(t, err)
-	assert.Equal(t, []string{"s3"}, registry.SupportedTypes())
+	assert.Equal(t, []string{"s3", "tiktok_ads"}, registry.SupportedTypes())
 }
 
 func TestNewDestinationRegistryEmptyWhenFlagDisabled(t *testing.T) {

--- a/cli/internal/providers/destination/definitions/tiktok_ads/definition.go
+++ b/cli/internal/providers/destination/definitions/tiktok_ads/definition.go
@@ -1,0 +1,119 @@
+package tiktokads
+
+import (
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions"
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions/common"
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions/converter"
+)
+
+// Source types from integrations-config destinations/tiktok_ads/db-config.json
+// supportedSourceTypes, restricted to types the CLI event-stream provider owns.
+var sourceTypes = []string{
+	common.SourceTypeAndroid,
+	common.SourceTypeAndroidKotlin,
+	common.SourceTypeIOS,
+	common.SourceTypeIOSSwift,
+	common.SourceTypeWeb,
+	common.SourceTypeUnity,
+	common.SourceTypeReactNative,
+	common.SourceTypeFlutter,
+	common.SourceTypeCordova,
+	common.SourceTypeCloud,
+}
+
+var connectionModes = map[string][]string{
+	common.SourceTypeAndroid:       {"cloud"},
+	common.SourceTypeAndroidKotlin: {"cloud"},
+	common.SourceTypeIOS:           {"cloud"},
+	common.SourceTypeIOSSwift:      {"cloud"},
+	common.SourceTypeWeb:           {"cloud", "device"},
+	common.SourceTypeUnity:         {"cloud"},
+	common.SourceTypeReactNative:   {"cloud"},
+	common.SourceTypeFlutter:       {"cloud"},
+	common.SourceTypeCordova:       {"cloud"},
+	common.SourceTypeCloud:         {"cloud"},
+}
+
+type eventToStandard struct {
+	From string `mapstructure:"from" validate:"omitempty,max=100"`
+	To   string `mapstructure:"to" validate:"omitempty,dynamic_or_oneof=AddPaymentInfo AddToCart AddToWishlist ClickButton CompletePayment CompleteRegistration Contact Download InitiateCheckout PlaceAnOrder Search SubmitForm Subscribe ViewContent CustomizeProduct FindLocation Schedule Purchase Lead ApplicationApproval SubmitApplication StartTrial"`
+}
+
+type useNativeSDK struct {
+	Web *bool `mapstructure:"web"`
+}
+
+type connectionMode struct {
+	Web           *string `mapstructure:"web" validate:"omitempty,dynamic_or_oneof=cloud device"`
+	Cloud         *string `mapstructure:"cloud" validate:"omitempty,dynamic_or_oneof=cloud"`
+	IOS           *string `mapstructure:"ios" validate:"omitempty,dynamic_or_oneof=cloud"`
+	IOSSwift      *string `mapstructure:"ios_swift" validate:"omitempty,dynamic_or_oneof=cloud"`
+	Android       *string `mapstructure:"android" validate:"omitempty,dynamic_or_oneof=cloud"`
+	AndroidKotlin *string `mapstructure:"android_kotlin" validate:"omitempty,dynamic_or_oneof=cloud"`
+	Unity         *string `mapstructure:"unity" validate:"omitempty,dynamic_or_oneof=cloud"`
+	ReactNative   *string `mapstructure:"react_native" validate:"omitempty,dynamic_or_oneof=cloud"`
+	Flutter       *string `mapstructure:"flutter" validate:"omitempty,dynamic_or_oneof=cloud"`
+	Cordova       *string `mapstructure:"cordova" validate:"omitempty,dynamic_or_oneof=cloud"`
+}
+
+// tiktokAdsConfig is the local YAML config model. Field set mirrors terraform
+// destination_tiktok_ads mappings; validation constraints mirror schema.json.
+type tiktokAdsConfig struct {
+	PixelCode               string                   `mapstructure:"pixel_code" validate:"required,min=1,max=100"`
+	AccessToken             string                   `mapstructure:"access_token"`
+	Version                 string                   `mapstructure:"version" validate:"omitempty,dynamic_or_oneof=v2 v1"`
+	HashUserProperties      *bool                    `mapstructure:"hash_user_properties"`
+	SendCustomEvents        *bool                    `mapstructure:"send_custom_events"`
+	EventsToStandard        []eventToStandard        `mapstructure:"events_to_standard" validate:"omitempty,dive"`
+	EventFilteringWhitelist []string                 `mapstructure:"event_filtering_whitelist"`
+	EventFilteringBlacklist []string                 `mapstructure:"event_filtering_blacklist"`
+	UseNativeSDK            useNativeSDK             `mapstructure:"use_native_sdk"`
+	ConnectionMode          connectionMode           `mapstructure:"connection_mode"`
+	ConsentManagement       common.ConsentManagement `mapstructure:"consent_management"`
+}
+
+// NewDefinition returns the TikTok Ads destination definition.
+func NewDefinition() *definitions.DestinationDefinition {
+	properties := []converter.ConfigProperty{
+		converter.Simple("pixelCode", "pixel_code"),
+		converter.Simple("accessToken", "access_token", converter.SkipZeroValue),
+		converter.Simple("version", "version"),
+		converter.Simple("hashUserProperties", "hash_user_properties"),
+		converter.Simple("sendCustomEvents", "send_custom_events", converter.SkipZeroValue),
+		converter.ArrayWithObjects("eventsToStandard", "events_to_standard", map[string]any{
+			"from": "from",
+			"to":   "to",
+		}),
+		converter.ArrayWithStrings("whitelistedEvents", "eventName", "event_filtering_whitelist"),
+		converter.ArrayWithStrings("blacklistedEvents", "eventName", "event_filtering_blacklist"),
+		converter.Discriminator("eventFilteringOption", converter.DiscriminatorValues{
+			"event_filtering_whitelist": "whitelistedEvents",
+			"event_filtering_blacklist": "blacklistedEvents",
+		}),
+		converter.Simple("useNativeSDK.web", "use_native_sdk.web"),
+		converter.Simple("connectionMode.web", "connection_mode.web", converter.SkipZeroValue),
+		converter.Simple("connectionMode.cloud", "connection_mode.cloud", converter.SkipZeroValue),
+		converter.Simple("connectionMode.ios", "connection_mode.ios", converter.SkipZeroValue),
+		converter.Simple("connectionMode.iosSwift", "connection_mode.ios_swift", converter.SkipZeroValue),
+		converter.Simple("connectionMode.android", "connection_mode.android", converter.SkipZeroValue),
+		converter.Simple("connectionMode.androidKotlin", "connection_mode.android_kotlin", converter.SkipZeroValue),
+		converter.Simple("connectionMode.unity", "connection_mode.unity", converter.SkipZeroValue),
+		converter.Simple("connectionMode.reactnative", "connection_mode.react_native", converter.SkipZeroValue),
+		converter.Simple("connectionMode.flutter", "connection_mode.flutter", converter.SkipZeroValue),
+		converter.Simple("connectionMode.cordova", "connection_mode.cordova", converter.SkipZeroValue),
+	}
+	properties = append(properties, common.Properties(sourceTypes)...)
+
+	return &definitions.DestinationDefinition{
+		Type:       "tiktok_ads",
+		APIType:    "TIKTOK_ADS",
+		Version:    1,
+		Properties: properties,
+		SecretKeys: []string{"access_token"},
+		NewConfig: func() any {
+			return &tiktokAdsConfig{}
+		},
+		SourceTypes:     append([]string(nil), sourceTypes...),
+		ConnectionModes: connectionModes,
+	}
+}

--- a/cli/internal/providers/destination/definitions/tiktok_ads/definition_test.go
+++ b/cli/internal/providers/destination/definitions/tiktok_ads/definition_test.go
@@ -1,0 +1,304 @@
+package tiktokads_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions"
+	tiktokads "github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions/tiktok_ads"
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions/testutil"
+)
+
+func TestNewDefinitionMetadata(t *testing.T) {
+	t.Parallel()
+
+	registry := definitions.NewRegistry()
+	require.NoError(t, registry.Register(tiktokads.NewDefinition()))
+
+	registered, err := registry.Get("tiktok_ads", 1)
+	require.NoError(t, err)
+
+	assert.Equal(t, "tiktok_ads", registered.Type)
+	assert.Equal(t, "TIKTOK_ADS", registered.APIType)
+	assert.Equal(t, int64(1), registered.Version)
+	assert.Equal(t, []string{"access_token"}, registered.SecretKeys())
+
+	expectedSourceTypes := []string{
+		"android", "android_kotlin", "ios", "ios_swift", "web",
+		"unity", "react_native", "flutter", "cordova", "cloud",
+	}
+	assert.Equal(t, expectedSourceTypes, registered.SupportedSourceTypes())
+
+	for _, sourceType := range expectedSourceTypes {
+		modes, err := registered.ConnectionModes(sourceType)
+		require.NoError(t, err)
+		if sourceType == "web" {
+			assert.Equal(t, []string{"cloud", "device"}, modes)
+			continue
+		}
+		assert.Equal(t, []string{"cloud"}, modes)
+	}
+
+	assert.NotContains(t, registered.SupportedSourceTypes(), "amp")
+	assert.NotContains(t, registered.SupportedSourceTypes(), "shopify")
+	assert.NotContains(t, registered.SupportedSourceTypes(), "warehouse")
+
+	byAPI, err := registry.GetByAPIType("TIKTOK_ADS", 1)
+	require.NoError(t, err)
+	assert.Equal(t, registered, byAPI)
+}
+
+func TestTiktokAdsConfigValidation(t *testing.T) {
+	t.Parallel()
+
+	registry := definitions.NewRegistry()
+	require.NoError(t, registry.Register(tiktokads.NewDefinition()))
+	registered, err := registry.Get("tiktok_ads", 1)
+	require.NoError(t, err)
+
+	t.Run("missing pixel_code", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{
+			"access_token": "token",
+		})
+		require.NotEmpty(t, errors)
+		assert.Equal(t, "/pixel_code", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "required")
+	})
+
+	t.Run("empty pixel_code rejected", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{
+			"pixel_code": "",
+		})
+		require.NotEmpty(t, errors)
+		assert.Equal(t, "/pixel_code", errors[0].Path)
+	})
+
+	t.Run("invalid version rejected", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{
+			"pixel_code": "C12345",
+			"version":    "v3",
+		})
+		require.NotEmpty(t, errors)
+		assert.Equal(t, "/version", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "must be one of")
+	})
+
+	t.Run("invalid events_to_standard.to rejected", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{
+			"pixel_code": "C12345",
+			"events_to_standard": []any{
+				map[string]any{"from": "Product Viewed", "to": "NotAStandardEvent"},
+			},
+		})
+		require.NotEmpty(t, errors)
+		assert.Equal(t, "/events_to_standard/0/to", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "must be one of")
+	})
+
+	t.Run("invalid connection_mode.web rejected", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{
+			"pixel_code": "C12345",
+			"connection_mode": map[string]any{
+				"web": "hybrid",
+			},
+		})
+		require.NotEmpty(t, errors)
+		assert.Equal(t, "/connection_mode/web", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "must be one of")
+	})
+
+	t.Run("valid minimal config", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{
+			"pixel_code": "C12345",
+		})
+		assert.Empty(t, errors)
+	})
+
+	t.Run("valid example config", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{
+			"pixel_code":           "C12345ABCDEF",
+			"access_token":         "tiktok-long-lived-token",
+			"version":              "v2",
+			"hash_user_properties": true,
+			"send_custom_events":   true,
+			"events_to_standard": []any{
+				map[string]any{"from": "Order Completed", "to": "CompletePayment"},
+				map[string]any{"from": "Product Added", "to": "AddToCart"},
+			},
+			"event_filtering_whitelist": []any{"Order Completed", "Product Added"},
+			"use_native_sdk": map[string]any{
+				"web": true,
+			},
+			"connection_mode": map[string]any{
+				"web":   "device",
+				"cloud": "cloud",
+			},
+			"consent_management": map[string]any{
+				"web": []any{
+					map[string]any{
+						"provider": "oneTrust",
+						"consents": []any{"analytics"},
+					},
+				},
+			},
+		})
+		assert.Empty(t, errors)
+	})
+
+	t.Run("valid full config", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{
+			"pixel_code":           "C12345",
+			"access_token":         "secret-token",
+			"version":              "v1",
+			"hash_user_properties": false,
+			"send_custom_events":   false,
+			"events_to_standard": []any{
+				map[string]any{"from": "Signed Up", "to": "CompleteRegistration"},
+			},
+			"event_filtering_blacklist": []any{"Page Viewed"},
+			"connection_mode": map[string]any{
+				"android":        "cloud",
+				"android_kotlin": "cloud",
+				"ios":            "cloud",
+				"ios_swift":      "cloud",
+				"react_native":   "cloud",
+				"flutter":        "cloud",
+				"cordova":        "cloud",
+				"unity":          "cloud",
+			},
+		})
+		assert.Empty(t, errors)
+	})
+
+	t.Run("unknown key rejected", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{
+			"pixel_code":  "C12345",
+			"not_a_field": true,
+		})
+		require.NotEmpty(t, errors)
+		assert.Equal(t, "/not_a_field", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "unknown config field")
+	})
+
+	t.Run("unsupported consent source rejected", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{
+			"pixel_code": "C12345",
+			"consent_management": map[string]any{
+				"warehouse": []any{},
+			},
+		})
+		require.Len(t, errors, 1)
+		assert.Equal(t, "/consent_management/warehouse", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "source type 'warehouse' is not supported")
+	})
+
+	t.Run("invalid consent provider rejected", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{
+			"pixel_code": "C12345",
+			"consent_management": map[string]any{
+				"android_kotlin": []any{
+					map[string]any{"provider": "unknown"},
+				},
+			},
+		})
+		require.Len(t, errors, 1)
+		assert.Equal(t, "/consent_management/android_kotlin/0/provider", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "'provider' must be one of")
+	})
+}
+
+func TestTiktokAdsConversionRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	def := tiktokads.NewDefinition()
+	testutil.AssertConversion(t, def.Properties, []testutil.ConversionCase{
+		{
+			Name: "minimal pixel only",
+			LocalJSON: `{
+				"pixel_code": "C12345"
+			}`,
+			APIJSON: `{
+				"pixelCode": "C12345"
+			}`,
+		},
+		{
+			Name: "full fields with whitelist reshape",
+			LocalJSON: `{
+				"pixel_code": "C12345",
+				"access_token": "secret-token",
+				"version": "v2",
+				"hash_user_properties": true,
+				"send_custom_events": true,
+				"events_to_standard": [
+					{"from": "Order Completed", "to": "CompletePayment"}
+				],
+				"event_filtering_whitelist": ["Order Completed", "Product Added"],
+				"use_native_sdk": {"web": true},
+				"connection_mode": {"web": "device", "cloud": "cloud"}
+			}`,
+			APIJSON: `{
+				"pixelCode": "C12345",
+				"accessToken": "secret-token",
+				"version": "v2",
+				"hashUserProperties": true,
+				"sendCustomEvents": true,
+				"eventsToStandard": [
+					{"from": "Order Completed", "to": "CompletePayment"}
+				],
+				"whitelistedEvents": [
+					{"eventName": "Order Completed"},
+					{"eventName": "Product Added"}
+				],
+				"eventFilteringOption": "whitelistedEvents",
+				"useNativeSDK": {"web": true},
+				"connectionMode": {"web": "device", "cloud": "cloud"}
+			}`,
+		},
+		{
+			Name: "blacklist reshape",
+			LocalJSON: `{
+				"pixel_code": "C12345",
+				"event_filtering_blacklist": ["Page Viewed"]
+			}`,
+			APIJSON: `{
+				"pixelCode": "C12345",
+				"blacklistedEvents": [
+					{"eventName": "Page Viewed"}
+				],
+				"eventFilteringOption": "blacklistedEvents"
+			}`,
+		},
+		{
+			Name: "consent source boundary mappings",
+			LocalJSON: `{
+				"pixel_code": "C12345",
+				"consent_management": {
+					"android_kotlin": [{"provider": "oneTrust"}],
+					"ios_swift": [{"provider": "ketch"}],
+					"react_native": [{"provider": "iubenda"}]
+				}
+			}`,
+			APIJSON: `{
+				"pixelCode": "C12345",
+				"consentManagement": {
+					"androidKotlin": [{"provider": "oneTrust"}],
+					"iosSwift": [{"provider": "ketch"}],
+					"reactnative": [{"provider": "iubenda"}]
+				}
+			}`,
+		},
+	})
+}


### PR DESCRIPTION
## 🔗 Ticket

Resolves [DEX-530](https://linear.app/rudderstack/issue/DEX-530/onboard-destination-tiktok-ads)

---

## Summary

Onboards the `tiktok_ads` destination into the CLI destination definition registry so YAML specs can validate and convert config for TikTok Ads (`TIKTOK_ADS` API type).

---

## Changes

- Added `cli/internal/providers/destination/definitions/tiktok_ads/definition.go` (Type=`tiktok_ads`, APIType=`TIKTOK_ADS`, Version=`1`)
- Added metadata / validation / conversion round-trip tests
- Registered definition in `newDestinationRegistry` and updated supported-types expectation

### Mapping / validation sources

| Concern | Source |
| --- | --- |
| Property mappings | `terraform-provider-rudderstack` `destination_tiktok_ads.go` |
| Validations | integrations-config `tiktok_ads/schema.json` |
| Capabilities / secrets | integrations-config `tiktok_ads/db-config.json` (`secretKeys`: `accessToken` → `access_token`) |

### Supported config surface

- Required: `pixel_code` (1–100 chars)
- Optional: `access_token` (secret), `version` (`v1`/`v2`), `hash_user_properties`, `send_custom_events`
- Reshapes: `events_to_standard` (object list), `event_filtering_whitelist` / `event_filtering_blacklist` → API whitelist/blacklist + `eventFilteringOption` discriminator
- Nested: `use_native_sdk.web`, `connection_mode.*`, `consent_management`

### Source types

Included (S3 precedent / CLI event-stream ownership): `android`, `android_kotlin`, `ios`, `ios_swift`, `web`, `unity`, `react_native`, `flutter`, `cordova`, `cloud`

Dropped (flagged): `amp`, `shopify`, `warehouse`

Connection modes: `web` → `cloud|device`; all others → `cloud`

### Gated keys

None via `converter.Gated`. `useNativeSDK` / `connectionMode` / event-filtering / consent are handled as nested source-type-keyed blocks (not gated properties), per onboard skill.

### Discrepancies / intentional omissions

- Dropped terraform `connectionMode.{amp,warehouse,shopify}` mappings because those source types are not CLI-owned
- Upstream `schema.json` allows empty `eventsToStandard[].to`; CLI `dynamic_or_oneof` already accepts empty strings
- `access_token` optional in schema (terraform notes “required for cloud mode”) — CLI follows schema optionality
- No new named regex patterns needed (`pixel_code` length-only → `min`/`max`)

### Example YAML (validated via `ValidateConfig`)

```yaml
version: rudder/v1
kind: destination
metadata:
  name: my-tiktok-ads-destination
spec:
  id: my-tiktok-ads-destination
  display_name: My TikTok Ads Destination
  type: tiktok_ads
  enabled: true
  definition_version: 1
  config:
    pixel_code: C12345ABCDEF
    access_token: tiktok-long-lived-token
    version: v2
    hash_user_properties: true
    send_custom_events: true
    events_to_standard:
      - from: Order Completed
        to: CompletePayment
      - from: Product Added
        to: AddToCart
    event_filtering_whitelist:
      - Order Completed
      - Product Added
    use_native_sdk:
      web: true
    connection_mode:
      web: device
      cloud: cloud
    consent_management:
      web:
        - provider: oneTrust
          consents:
            - analytics
```

### Usage reminder

Requires `experimental: true` + `flags.destinationSupport: true` in the CLI config.

---

## Testing

- `go test ./cli/internal/providers/destination/... ./cli/internal/app/...`
- `go build ./...`
- `make lint`

---

## Risk / Impact

Low
Additive registry entry behind the existing destination-support experimental flag.

---

## Checklist

- [x] Ticket linked
- [x] Tests added/updated
- [x] No breaking changes (or documented)


Made with [Cursor](https://cursor.com)