### PR TITLE
feat(cli): add accounts provider (map-config, shared secret helpers)

### DIFF
--- a/.github/workflows/gen-rule-docs.yml
+++ b/.github/workflows/gen-rule-docs.yml
@@ -47,6 +47,9 @@ jobs:
         env:
           RUDDERSTACK_CLI_EXPERIMENTAL: ${{ vars.RUDDERSTACK_CLI_EXPERIMENTAL || 'true' }}
           RUDDERSTACK_X_DESTINATION_SUPPORT: ${{ vars.RUDDERSTACK_X_DESTINATION_SUPPORT || 'true' }}
+          # Account provider is gated too — enable it so the account docs fragments
+          # (duplicate-urn / metadata-syntax-valid coverage) match the live rule set.
+          RUDDERSTACK_X_ACCOUNT_SUPPORT: ${{ vars.RUDDERSTACK_X_ACCOUNT_SUPPORT || 'true' }}
 
       - name: upload rule catalog
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/api/client/accounts.go
+++ b/api/client/accounts.go
@@ -30,6 +30,10 @@ type CreateAccountRequest struct {
 	Name                  string          `json:"name"`
 	Options               json.RawMessage `json:"options"`
 	Secret                json.RawMessage `json:"secret"`
+	// ExternalID claims the account under a caller-owned id in the same call —
+	// the backend sets it atomically with creation, so no separate SetExternalID
+	// round trip. Omitted (webapp-created) accounts leave it empty.
+	ExternalID string `json:"externalId,omitempty"`
 }
 
 // All fields are required — PUT is a full-state replace, so a missing field means

--- a/cli/internal/app/dependencies.go
+++ b/cli/internal/app/dependencies.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rudderlabs/rudder-iac/cli/internal/project"
 	"github.com/rudderlabs/rudder-iac/cli/internal/project/importmanifest"
 	"github.com/rudderlabs/rudder-iac/cli/internal/provider"
+	accountsProvider "github.com/rudderlabs/rudder-iac/cli/internal/providers/accounts"
 	"github.com/rudderlabs/rudder-iac/cli/internal/providers/datacatalog"
 	dgProvider "github.com/rudderlabs/rudder-iac/cli/internal/providers/datagraph"
 	destProvider "github.com/rudderlabs/rudder-iac/cli/internal/providers/destination"
@@ -45,6 +46,7 @@ type Providers struct {
 	Workspace       *workspace.Provider
 	DataGraph       *dgProvider.Provider
 	Destination     *destProvider.Provider
+	Account         *accountsProvider.Provider
 }
 
 type deps struct {
@@ -233,6 +235,13 @@ func setupProviders(c *client.Client) (*Providers, map[string]provider.Provider,
 		providerMap["destination"] = dp
 		providers.Destination = dp
 
+	}
+
+	if cfg.ExperimentalFlags.AccountSupport {
+		ap := accountsProvider.NewProvider(c.Accounts)
+
+		providerMap["account"] = ap
+		providers.Account = ap
 	}
 
 	return providers, providerMap, nil

--- a/cli/internal/app/ruledoc_test.go
+++ b/cli/internal/app/ruledoc_test.go
@@ -23,12 +23,16 @@ func TestGenerateRuleCatalog_CompleteAndDriftFree(t *testing.T) {
 	// Hermetic config: defaults only, written under a temp dir so the suite
 	// never touches the developer's ~/.rudder config.
 	config.InitConfig(filepath.Join(t.TempDir(), "config.json"))
-	prevExp, prevDestSupport := viper.Get("experimental"), viper.Get("flags.destinationSupport")
+	prevExp := viper.Get("experimental")
+	prevDestSupport := viper.Get("flags.destinationSupport")
+	prevAccountSupport := viper.Get("flags.accountSupport")
 	viper.Set("experimental", true)
 	viper.Set("flags.destinationSupport", true)
+	viper.Set("flags.accountSupport", true)
 	t.Cleanup(func() {
 		viper.Set("experimental", prevExp)
 		viper.Set("flags.destinationSupport", prevDestSupport)
+		viper.Set("flags.accountSupport", prevAccountSupport)
 	})
 
 	doc, verrs, err := GenerateRuleCatalog("2026-01-01T00:00:00Z")

--- a/cli/internal/config/experimental.go
+++ b/cli/internal/config/experimental.go
@@ -36,6 +36,9 @@ type ExperimentalConfig struct {
 	// UnverifiedDestinations enables registration of unverified destination
 	// definitions (e.g. S3) when DestinationSupport is also enabled.
 	UnverifiedDestinations bool `mapstructure:"unverifiedDestinations"`
+	// AccountSupport enables account provider registration and account kind
+	// matching for validate/apply/import flows.
+	AccountSupport bool `mapstructure:"accountSupport"`
 }
 
 // getAvailableExperimentalFlags returns information about all available experimental flags

--- a/cli/internal/project/docs/duplicate-urn.docs.yaml
+++ b/cli/internal/project/docs/duplicate-urn.docs.yaml
@@ -51,6 +51,8 @@ match_behavior:
         version: "rudder/v1"
       - kind: "destination"
         version: "rudder/v1"
+      - kind: "account"
+        version: "rudder/v1"
     valid:
       - example_id: "duplicate-urn-distinct-urns"
         title: "Distinct URNs across files"

--- a/cli/internal/project/docs/metadata-syntax-valid.docs.yaml
+++ b/cli/internal/project/docs/metadata-syntax-valid.docs.yaml
@@ -51,6 +51,8 @@ match_behavior:
         version: "rudder/v1"
       - kind: "destination"
         version: "rudder/v1"
+      - kind: "account"
+        version: "rudder/v1"
     valid:
       - example_id: "metadata-name-only"
         title: "Metadata with only the required name"

--- a/cli/internal/project/docs/ruledoc_test.go
+++ b/cli/internal/project/docs/ruledoc_test.go
@@ -7,6 +7,7 @@ import (
 	prules "github.com/rudderlabs/rudder-iac/cli/internal/project/rules"
 	providerrules "github.com/rudderlabs/rudder-iac/cli/internal/provider/rules"
 	"github.com/rudderlabs/rudder-iac/cli/internal/providers/datacatalog/localcatalog"
+	atypes "github.com/rudderlabs/rudder-iac/cli/internal/providers/accounts"
 	dgHandler "github.com/rudderlabs/rudder-iac/cli/internal/providers/datagraph/handlers/datagraph"
 	essource "github.com/rudderlabs/rudder-iac/cli/internal/providers/event-stream/source"
 	dtypes "github.com/rudderlabs/rudder-iac/cli/internal/providers/destination"
@@ -47,6 +48,7 @@ func gatekeeperScopedPatterns() []rules.MatchPattern {
 	p = append(p, providerrules.V1VersionPatterns(ttypes.TransformationSpecKind)...)
 	p = append(p, providerrules.V1VersionPatterns(ttypes.LibrarySpecKind)...)
 	p = append(p, providerrules.V1VersionPatterns(dtypes.DestinationSpecKind)...)
+	p = append(p, providerrules.V1VersionPatterns(atypes.AccountSpecKind)...)
 	return p
 }
 

--- a/cli/internal/project/importmanifest/docs/manifest-inline-conflict.docs.yaml
+++ b/cli/internal/project/importmanifest/docs/manifest-inline-conflict.docs.yaml
@@ -51,6 +51,8 @@ match_behavior:
         version: "rudder/v1"
       - kind: "destination"
         version: "rudder/v1"
+      - kind: "account"
+        version: "rudder/v1"
       - kind: "import-manifest"
         version: "rudder/v1"
     valid:

--- a/cli/internal/providers/accounts/handler.go
+++ b/cli/internal/providers/accounts/handler.go
@@ -1,0 +1,359 @@
+package accounts
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+
+	"github.com/rudderlabs/rudder-iac/api/client"
+	"github.com/rudderlabs/rudder-iac/cli/internal/namer"
+	"github.com/rudderlabs/rudder-iac/cli/internal/project/importmanifest"
+	"github.com/rudderlabs/rudder-iac/cli/internal/project/specs"
+	"github.com/rudderlabs/rudder-iac/cli/internal/project/writer"
+	"github.com/rudderlabs/rudder-iac/cli/internal/provider/handler"
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/transformations/handlers"
+	"github.com/rudderlabs/rudder-iac/cli/internal/resolver"
+	"github.com/rudderlabs/rudder-iac/cli/internal/resources"
+	"github.com/rudderlabs/rudder-iac/cli/internal/secret"
+)
+
+// AccountHandler is the BaseHandler instantiation for accounts.
+type AccountHandler = handler.BaseHandler[AccountSpec, AccountResource, AccountState, RemoteAccount]
+
+// HandlerMetadata describes the account handler for the framework.
+var HandlerMetadata = handler.HandlerMetadata{
+	ResourceType:     AccountResourceType,
+	SpecKind:         AccountSpecKind,
+	SpecMetadataName: AccountMetadataName,
+}
+
+// accountSecretKeys maps an account definition to its secret field set — the
+// account-side analogue of a destination definition's SecretKeys().
+//
+// ponytail: BigQuery-only, hardcoded. The real registry fetches secretFields
+// from the control-plane account-definitions API (unversioned, name-keyed).
+// Add a lookup when a second definition lands; the split logic below is already
+// definition-driven, so only this map changes.
+var accountSecretKeys = map[string][]string{
+	"SOURCE_BIGQUERY": {"credentials"},
+}
+
+// AccountStore is the subset of the accounts API client the handler needs;
+// declared at the point of use so tests inject a mock. *client.Client.Accounts
+// satisfies it.
+type AccountStore interface {
+	Create(ctx context.Context, req *client.CreateAccountRequest) (*client.Account, error)
+	Update(ctx context.Context, id string, req *client.UpdateAccountRequest) (*client.Account, error)
+	Delete(ctx context.Context, id string) error
+	Get(ctx context.Context, id string) (*client.Account, error)
+	ListAll(ctx context.Context, opts ...client.ListAccountsOption) ([]client.Account, error)
+	SetExternalID(ctx context.Context, id, externalID string) error
+}
+
+// HandlerImpl owns account CRUD against the API client.
+type HandlerImpl struct {
+	store AccountStore
+}
+
+// NewHandler builds an *AccountHandler wired to the given store.
+func NewHandler(store AccountStore) *AccountHandler {
+	return handler.NewHandler(&HandlerImpl{store: store})
+}
+
+func (h *HandlerImpl) Metadata() handler.HandlerMetadata { return HandlerMetadata }
+
+func (h *HandlerImpl) NewSpec() *AccountSpec { return &AccountSpec{} }
+
+// ExtractResourcesFromSpec resolves the account definition's secret keys and
+// wraps them in Config as *secret.String — mirrors the destination handler,
+// minus the (type, version) registry lookup (account definitions are
+// unversioned).
+func (h *HandlerImpl) ExtractResourcesFromSpec(_ string, spec *AccountSpec) (map[string]*AccountResource, error) {
+	keys, ok := accountSecretKeys[spec.AccountDefinitionName]
+	if !ok {
+		return nil, fmt.Errorf("unsupported account definition %q", spec.AccountDefinitionName)
+	}
+	resource := &AccountResource{
+		ID:                    spec.ID,
+		AccountDefinitionName: spec.AccountDefinitionName,
+		Config:                secret.WrapKnownSecrets(spec.Config, keys),
+	}
+	return map[string]*AccountResource{spec.ID: resource}, nil
+}
+
+// Create provisions the account, then claims the spec ID as its externalId so
+// the next apply reconciles instead of recreating. External ID is set last so a
+// failed claim never leaves a partially-adopted resource behind (mirrors the
+// destination handler's Import ordering).
+func (h *HandlerImpl) Create(ctx context.Context, data *AccountResource) (*AccountState, error) {
+	options, secretPayload, err := h.splitConfig(data)
+	if err != nil {
+		return nil, err
+	}
+
+	created, err := h.store.Create(ctx, &client.CreateAccountRequest{
+		AccountDefinitionName: data.AccountDefinitionName,
+		Name:                  data.ID,
+		Options:               options,
+		Secret:                secretPayload,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("creating account %q: %w", data.ID, err)
+	}
+
+	if err := h.store.SetExternalID(ctx, created.ID, data.ID); err != nil {
+		return nil, fmt.Errorf("claiming external id for account %q: %w", data.ID, err)
+	}
+
+	return &AccountState{ID: created.ID}, nil
+}
+
+// Update rejects an immutable definition change and full-replaces the account
+// (PUT is REST-strict — a missing field means set-to-empty).
+func (h *HandlerImpl) Update(ctx context.Context, newData *AccountResource, oldData *AccountResource, oldState *AccountState) (*AccountState, error) {
+	if newData.AccountDefinitionName != oldData.AccountDefinitionName {
+		return nil, fmt.Errorf("account definition change is not supported: old %q, new %q", oldData.AccountDefinitionName, newData.AccountDefinitionName)
+	}
+
+	options, secretPayload, err := h.splitConfig(newData)
+	if err != nil {
+		return nil, err
+	}
+
+	updated, err := h.store.Update(ctx, oldState.ID, &client.UpdateAccountRequest{
+		Name:    newData.ID,
+		Options: options,
+		Secret:  secretPayload,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("updating account %q: %w", newData.ID, err)
+	}
+
+	return &AccountState{ID: updated.ID}, nil
+}
+
+func (h *HandlerImpl) Delete(ctx context.Context, _ string, _ *AccountResource, oldState *AccountState) error {
+	if err := h.store.Delete(ctx, oldState.ID); err != nil {
+		return fmt.Errorf("deleting account %q: %w", oldState.ID, err)
+	}
+	return nil
+}
+
+// MapRemoteToState rebuilds the flat config from the remote options and marks
+// every secret key unknown (the API never returns secret values), so the differ
+// flags them SecretOnly rather than phantom drift — same rule as destinations.
+func (h *HandlerImpl) MapRemoteToState(remote *RemoteAccount, _ handler.URNResolver) (*AccountResource, *AccountState, error) {
+	if remote.ExternalID == "" {
+		return nil, nil, fmt.Errorf("managed account %s has empty external ID", remote.ID)
+	}
+
+	keys, ok := accountSecretKeys[remote.Definition.Name]
+	if !ok {
+		return nil, nil, fmt.Errorf("managed account %s has unsupported definition %q", remote.ID, remote.Definition.Name)
+	}
+
+	config, err := unmarshalOptions(remote.Options)
+	if err != nil {
+		return nil, nil, fmt.Errorf("unmarshalling options for account %s: %w", remote.ID, err)
+	}
+	// The API never returns the secret, so it is absent from remote options. Seed
+	// each secret key so the presence-based WrapUnknownSecrets marks it unknown —
+	// account secrets are unconditional (unlike a destination's optional secrets),
+	// so they must always be present-and-unknown and therefore always re-applied.
+	for _, key := range keys {
+		if _, ok := config[key]; !ok {
+			config[key] = ""
+		}
+	}
+	config = secret.WrapUnknownSecrets(config, keys)
+
+	resource := &AccountResource{
+		ID:                    remote.ExternalID,
+		AccountDefinitionName: remote.Definition.Name,
+		Config:                config,
+	}
+	return resource, &AccountState{ID: remote.ID}, nil
+}
+
+// LoadRemoteResources returns managed accounts (ExternalID set) of a supported
+// definition.
+func (h *HandlerImpl) LoadRemoteResources(ctx context.Context) ([]*RemoteAccount, error) {
+	all, err := h.store.ListAll(ctx, client.WithHasExternalID(true))
+	if err != nil {
+		return nil, fmt.Errorf("listing managed accounts: %w", err)
+	}
+	return supportedRemoteAccounts(all), nil
+}
+
+// LoadImportableResources returns unmanaged accounts (no ExternalID) of a
+// supported definition.
+func (h *HandlerImpl) LoadImportableResources(ctx context.Context) ([]*RemoteAccount, error) {
+	all, err := h.store.ListAll(ctx, client.WithHasExternalID(false))
+	if err != nil {
+		return nil, fmt.Errorf("listing importable accounts: %w", err)
+	}
+	return supportedRemoteAccounts(all), nil
+}
+
+// Import adopts an existing remote account: it pushes the spec via Update (same
+// reconciliation path as apply — DRY), then sets the external ID last. Mirrors
+// the destination handler's Import.
+func (h *HandlerImpl) Import(ctx context.Context, data *AccountResource, remoteId string) (*AccountState, error) {
+	remote, err := h.store.Get(ctx, remoteId)
+	if err != nil {
+		return nil, fmt.Errorf("getting account during import: %w", err)
+	}
+
+	oldData := &AccountResource{AccountDefinitionName: remote.Definition.Name}
+	oldState := &AccountState{ID: remoteId}
+
+	newState, err := h.Update(ctx, data, oldData, oldState)
+	if err != nil {
+		return nil, fmt.Errorf("updating account during import: %w", err)
+	}
+
+	if err := h.store.SetExternalID(ctx, remoteId, data.ID); err != nil {
+		return nil, fmt.Errorf("setting external id for account during import: %w", err)
+	}
+
+	return newState, nil
+}
+
+// FormatForExport converts unmanaged accounts into importable YAML specs: config
+// is the remote options with each secret key masked to a per-resource
+// "{{ .VAR }}" token. Mirrors the destination export.
+func (h *HandlerImpl) FormatForExport(
+	collection map[string]*RemoteAccount,
+	_ namer.Namer,
+	_ resolver.ReferenceResolver,
+) ([]writer.FormattableEntity, []importmanifest.ImportEntry, error) {
+	if len(collection) == 0 {
+		return nil, nil, nil
+	}
+
+	var (
+		entities []writer.FormattableEntity
+		entries  []importmanifest.ImportEntry
+	)
+
+	for externalID, remote := range collection {
+		specMap, err := h.toExportSpecMap(externalID, remote)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		workspaceMetadata := specs.WorkspaceImportMetadata{
+			WorkspaceID: remote.WorkspaceID,
+			Resources: []specs.ImportIds{
+				{
+					URN:      resources.URN(externalID, AccountResourceType),
+					RemoteID: remote.ID,
+				},
+			},
+		}
+		entries = append(entries, handlers.ImportEntriesFromWorkspace(workspaceMetadata)...)
+
+		spec, err := handlers.ToImportSpec(AccountSpecKind, AccountMetadataName, workspaceMetadata, specMap)
+		if err != nil {
+			return nil, nil, fmt.Errorf("creating spec for account %s: %w", remote.ID, err)
+		}
+
+		entities = append(entities, writer.FormattableEntity{
+			Content:      spec,
+			RelativePath: filepath.Join("accounts", fmt.Sprintf("%s.yaml", externalID)),
+		})
+	}
+
+	return entities, entries, nil
+}
+
+func (h *HandlerImpl) toExportSpecMap(externalID string, remote *RemoteAccount) (map[string]any, error) {
+	keys, ok := accountSecretKeys[remote.Definition.Name]
+	if !ok {
+		return nil, fmt.Errorf("account %s has unsupported definition %q", remote.ID, remote.Definition.Name)
+	}
+
+	config, err := unmarshalOptions(remote.Options)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshalling options for account %s: %w", remote.ID, err)
+	}
+	// The API omits secrets, so surface each secret key as present-but-empty so
+	// MaskSecrets emits a "{{ .VAR }}" token the user fills via a var file.
+	for _, key := range keys {
+		if _, exists := config[key]; !exists {
+			config[key] = ""
+		}
+	}
+	if err := secret.MaskSecrets(config, externalID, keys); err != nil {
+		return nil, fmt.Errorf("masking account %s secrets: %w", remote.ID, err)
+	}
+
+	return map[string]any{
+		"id":                      externalID,
+		"account_definition_name": remote.Definition.Name,
+		"config":                  config,
+	}, nil
+}
+
+// splitConfig reveals the secrets and partitions the flat config into the API's
+// options (non-secret) and secret payloads by the definition's secret-key set.
+// This is the one account-specific twist over destinations, which keep secrets
+// inside a single config blob.
+func (h *HandlerImpl) splitConfig(data *AccountResource) (json.RawMessage, json.RawMessage, error) {
+	keys, ok := accountSecretKeys[data.AccountDefinitionName]
+	if !ok {
+		return nil, nil, fmt.Errorf("unsupported account definition %q", data.AccountDefinitionName)
+	}
+
+	revealed := secret.RevealSecrets(data.Config, keys)
+	secretSet := make(map[string]struct{}, len(keys))
+	for _, k := range keys {
+		secretSet[k] = struct{}{}
+	}
+
+	options := map[string]any{}
+	secretPayload := map[string]any{}
+	for k, v := range revealed {
+		if _, isSecret := secretSet[k]; isSecret {
+			secretPayload[k] = v
+		} else {
+			options[k] = v
+		}
+	}
+
+	optionsJSON, err := json.Marshal(options)
+	if err != nil {
+		return nil, nil, fmt.Errorf("marshalling options for account %q: %w", data.ID, err)
+	}
+	secretJSON, err := json.Marshal(secretPayload)
+	if err != nil {
+		return nil, nil, fmt.Errorf("marshalling secret for account %q: %w", data.ID, err)
+	}
+	return optionsJSON, secretJSON, nil
+}
+
+func unmarshalOptions(raw json.RawMessage) (map[string]any, error) {
+	config := map[string]any{}
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &config); err != nil {
+			return nil, err
+		}
+	}
+	return config, nil
+}
+
+// supportedRemoteAccounts wraps and filters remote accounts to supported
+// definitions. Filtering keys on the account definition (accounts have no
+// registry to look a type up in).
+func supportedRemoteAccounts(accounts []client.Account) []*RemoteAccount {
+	result := make([]*RemoteAccount, 0, len(accounts))
+	for i := range accounts {
+		a := &accounts[i]
+		if _, ok := accountSecretKeys[a.Definition.Name]; !ok {
+			continue
+		}
+		result = append(result, &RemoteAccount{Account: a})
+	}
+	return result
+}

--- a/cli/internal/providers/accounts/handler.go
+++ b/cli/internal/providers/accounts/handler.go
@@ -28,14 +28,14 @@ var HandlerMetadata = handler.HandlerMetadata{
 	SpecMetadataName: AccountMetadataName,
 }
 
-// accountSecretKeys maps an account definition to its secret field set — the
+// registeredAccountSecretKeys maps an account definition to its secret field set — the
 // account-side analogue of a destination definition's SecretKeys().
 //
 // ponytail: BigQuery-only, hardcoded. The real registry fetches secretFields
 // from the control-plane account-definitions API (unversioned, name-keyed).
 // Add a lookup when a second definition lands; the split logic below is already
 // definition-driven, so only this map changes.
-var accountSecretKeys = map[string][]string{
+var registeredAccountSecretKeys = map[string][]string{
 	"SOURCE_BIGQUERY": {"credentials"},
 }
 
@@ -70,7 +70,7 @@ func (h *HandlerImpl) NewSpec() *AccountSpec { return &AccountSpec{} }
 // minus the (type, version) registry lookup (account definitions are
 // unversioned).
 func (h *HandlerImpl) ExtractResourcesFromSpec(_ string, spec *AccountSpec) (map[string]*AccountResource, error) {
-	keys, ok := accountSecretKeys[spec.AccountDefinitionName]
+	keys, ok := registeredAccountSecretKeys[spec.AccountDefinitionName]
 	if !ok {
 		return nil, fmt.Errorf("unsupported account definition %q", spec.AccountDefinitionName)
 	}
@@ -147,7 +147,7 @@ func (h *HandlerImpl) MapRemoteToState(remote *RemoteAccount, _ handler.URNResol
 		return nil, nil, fmt.Errorf("managed account %s has empty external ID", remote.ID)
 	}
 
-	keys, ok := accountSecretKeys[remote.Definition.Name]
+	keys, ok := registeredAccountSecretKeys[remote.Definition.Name]
 	if !ok {
 		return nil, nil, fmt.Errorf("managed account %s has unsupported definition %q", remote.ID, remote.Definition.Name)
 	}
@@ -269,7 +269,7 @@ func (h *HandlerImpl) FormatForExport(
 }
 
 func (h *HandlerImpl) toExportSpecMap(externalID string, remote *RemoteAccount) (map[string]any, error) {
-	keys, ok := accountSecretKeys[remote.Definition.Name]
+	keys, ok := registeredAccountSecretKeys[remote.Definition.Name]
 	if !ok {
 		return nil, fmt.Errorf("account %s has unsupported definition %q", remote.ID, remote.Definition.Name)
 	}
@@ -302,7 +302,7 @@ func (h *HandlerImpl) toExportSpecMap(externalID string, remote *RemoteAccount) 
 // This is the one account-specific twist over destinations, which keep secrets
 // inside a single config blob.
 func (h *HandlerImpl) splitConfig(data *AccountResource) (json.RawMessage, json.RawMessage, error) {
-	keys, ok := accountSecretKeys[data.AccountDefinitionName]
+	keys, ok := registeredAccountSecretKeys[data.AccountDefinitionName]
 	if !ok {
 		return nil, nil, fmt.Errorf("unsupported account definition %q", data.AccountDefinitionName)
 	}
@@ -351,7 +351,7 @@ func supportedRemoteAccounts(accounts []client.Account) []*RemoteAccount {
 	result := make([]*RemoteAccount, 0, len(accounts))
 	for i := range accounts {
 		a := &accounts[i]
-		if _, ok := accountSecretKeys[a.Definition.Name]; !ok {
+		if _, ok := registeredAccountSecretKeys[a.Definition.Name]; !ok {
 			continue
 		}
 		result = append(result, &RemoteAccount{Account: a})

--- a/cli/internal/providers/accounts/handler.go
+++ b/cli/internal/providers/accounts/handler.go
@@ -76,16 +76,18 @@ func (h *HandlerImpl) ExtractResourcesFromSpec(_ string, spec *AccountSpec) (map
 	}
 	resource := &AccountResource{
 		ID:                    spec.ID,
+		Name:                  spec.Name,
 		AccountDefinitionName: spec.AccountDefinitionName,
 		Config:                secret.WrapKnownSecrets(spec.Config, keys),
 	}
 	return map[string]*AccountResource{spec.ID: resource}, nil
 }
 
-// Create provisions the account, then claims the spec ID as its externalId so
-// the next apply reconciles instead of recreating. External ID is set last so a
-// failed claim never leaves a partially-adopted resource behind (mirrors the
-// destination handler's Import ordering).
+// Create provisions the account and claims the spec ID as its externalId in the
+// same call — the backend sets externalId atomically with creation, so there is
+// no separate SetExternalID round trip that could leave a partially-adopted
+// resource behind. Import still adopts an existing account via Update +
+// SetExternalID (it cannot create).
 func (h *HandlerImpl) Create(ctx context.Context, data *AccountResource) (*AccountState, error) {
 	options, secretPayload, err := h.splitConfig(data)
 	if err != nil {
@@ -94,16 +96,13 @@ func (h *HandlerImpl) Create(ctx context.Context, data *AccountResource) (*Accou
 
 	created, err := h.store.Create(ctx, &client.CreateAccountRequest{
 		AccountDefinitionName: data.AccountDefinitionName,
-		Name:                  data.ID,
+		Name:                  data.Name,
 		Options:               options,
 		Secret:                secretPayload,
+		ExternalID:            data.ID,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("creating account %q: %w", data.ID, err)
-	}
-
-	if err := h.store.SetExternalID(ctx, created.ID, data.ID); err != nil {
-		return nil, fmt.Errorf("claiming external id for account %q: %w", data.ID, err)
 	}
 
 	return &AccountState{ID: created.ID}, nil
@@ -122,7 +121,7 @@ func (h *HandlerImpl) Update(ctx context.Context, newData *AccountResource, oldD
 	}
 
 	updated, err := h.store.Update(ctx, oldState.ID, &client.UpdateAccountRequest{
-		Name:    newData.ID,
+		Name:    newData.Name,
 		Options: options,
 		Secret:  secretPayload,
 	})
@@ -170,6 +169,7 @@ func (h *HandlerImpl) MapRemoteToState(remote *RemoteAccount, _ handler.URNResol
 
 	resource := &AccountResource{
 		ID:                    remote.ExternalID,
+		Name:                  remote.Name,
 		AccountDefinitionName: remote.Definition.Name,
 		Config:                config,
 	}
@@ -291,6 +291,7 @@ func (h *HandlerImpl) toExportSpecMap(externalID string, remote *RemoteAccount) 
 
 	return map[string]any{
 		"id":                      externalID,
+		"name":                    remote.Name,
 		"account_definition_name": remote.Definition.Name,
 		"config":                  config,
 	}, nil

--- a/cli/internal/providers/accounts/handler_test.go
+++ b/cli/internal/providers/accounts/handler_test.go
@@ -1,0 +1,185 @@
+package accounts
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/rudderlabs/rudder-iac/api/client"
+	"github.com/rudderlabs/rudder-iac/cli/internal/secret"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// enableVarSubstitution turns on the experimental gate that makes exported
+// secrets serialize as "{{ .VAR }}" references instead of masked literals.
+func enableVarSubstitution(t *testing.T) {
+	t.Helper()
+	prevExp, prevFlag := viper.Get("experimental"), viper.Get("flags.enableVarSubstitution")
+	viper.Set("experimental", true)
+	viper.Set("flags.enableVarSubstitution", true)
+	t.Cleanup(func() {
+		viper.Set("experimental", prevExp)
+		viper.Set("flags.enableVarSubstitution", prevFlag)
+	})
+}
+
+// mockStore records the last request seen by each verb and returns canned data.
+type mockStore struct {
+	created        *client.CreateAccountRequest
+	updated        *client.UpdateAccountRequest
+	updatedID      string
+	externalIDSet  [2]string // {id, externalID}
+	createReturnID string
+}
+
+func (m *mockStore) Create(_ context.Context, req *client.CreateAccountRequest) (*client.Account, error) {
+	m.created = req
+	return &client.Account{ID: m.createReturnID}, nil
+}
+func (m *mockStore) Update(_ context.Context, id string, req *client.UpdateAccountRequest) (*client.Account, error) {
+	m.updated, m.updatedID = req, id
+	return &client.Account{ID: id}, nil
+}
+func (m *mockStore) Delete(context.Context, string) error { return nil }
+func (m *mockStore) Get(context.Context, string) (*client.Account, error) {
+	return &client.Account{ID: "remote-1"}, nil
+}
+func (m *mockStore) ListAll(context.Context, ...client.ListAccountsOption) ([]client.Account, error) {
+	return nil, nil
+}
+func (m *mockStore) SetExternalID(_ context.Context, id, externalID string) error {
+	m.externalIDSet = [2]string{id, externalID}
+	return nil
+}
+
+func bqResource(id string) *AccountResource {
+	cred := secret.New("svc-account-json")
+	return &AccountResource{
+		ID:                    id,
+		AccountDefinitionName: "SOURCE_BIGQUERY",
+		Config: map[string]any{
+			"projectId":   "proj-123",
+			"location":    "US",
+			"credentials": &cred,
+		},
+	}
+}
+
+func TestCreate_SplitsConfigAndClaimsExternalID(t *testing.T) {
+	m := &mockStore{createReturnID: "remote-1"}
+	h := &HandlerImpl{store: m}
+
+	state, err := h.Create(context.Background(), bqResource("prod-bq"))
+	require.NoError(t, err)
+	assert.Equal(t, "remote-1", state.ID)
+
+	// options carry non-secret keys; secret carries only credentials (revealed).
+	var opts, sec map[string]any
+	require.NoError(t, json.Unmarshal(m.created.Options, &opts))
+	require.NoError(t, json.Unmarshal(m.created.Secret, &sec))
+	assert.Equal(t, map[string]any{"projectId": "proj-123", "location": "US"}, opts)
+	assert.Equal(t, map[string]any{"credentials": "svc-account-json"}, sec)
+
+	assert.Equal(t, "SOURCE_BIGQUERY", m.created.AccountDefinitionName)
+	assert.Equal(t, "prod-bq", m.created.Name)
+	// external id claimed = spec id, on the returned remote id.
+	assert.Equal(t, [2]string{"remote-1", "prod-bq"}, m.externalIDSet)
+}
+
+func TestUpdate_RejectsDefinitionChange(t *testing.T) {
+	h := &HandlerImpl{store: &mockStore{}}
+	newData := bqResource("prod-bq")
+	oldData := &AccountResource{AccountDefinitionName: "SOURCE_SNOWFLAKE"}
+
+	_, err := h.Update(context.Background(), newData, oldData, &AccountState{ID: "remote-1"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "account definition change is not supported")
+}
+
+func TestExtractResourcesFromSpec_UnsupportedDefinition(t *testing.T) {
+	h := &HandlerImpl{store: &mockStore{}}
+	_, err := h.ExtractResourcesFromSpec("f.yaml", &AccountSpec{
+		ID: "x", AccountDefinitionName: "DESTINATION_SALESFORCE_OAUTH",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported account definition")
+}
+
+func TestMapRemoteToState_SecretIsUnknown(t *testing.T) {
+	h := &HandlerImpl{store: &mockStore{}}
+	acc := &client.Account{ID: "remote-1", ExternalID: "prod-bq", Options: json.RawMessage(`{"projectId":"p"}`)}
+	acc.Definition.Name = "SOURCE_BIGQUERY"
+
+	res, state, err := h.MapRemoteToState(&RemoteAccount{Account: acc}, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "prod-bq", res.ID)
+	assert.Equal(t, "remote-1", state.ID)
+	assert.Equal(t, "p", res.Config["projectId"])
+
+	cred, ok := res.Config["credentials"].(*secret.String)
+	require.True(t, ok, "credentials should be wrapped as *secret.String")
+	assert.True(t, cred.IsUnknown(), "remote secret must be unknown so it always diffs")
+}
+
+func bqRemote(externalID string, opts string) *RemoteAccount {
+	acc := &client.Account{
+		ID:         "remote-" + externalID,
+		ExternalID: externalID,
+		Options:    json.RawMessage(opts),
+	}
+	acc.Definition.Name = "SOURCE_BIGQUERY"
+	return &RemoteAccount{Account: acc}
+}
+
+// Export must tokenize the secret into a per-resource "{{ .VAR }}" reference the
+// user fills via a var file — the API never returns the value, so a masked
+// literal would be useless. Non-secret options pass through verbatim.
+func TestToExportSpecMap_TokenizesSecret(t *testing.T) {
+	enableVarSubstitution(t)
+	h := &HandlerImpl{store: &mockStore{}}
+
+	specMap, err := h.toExportSpecMap("prod-analytics-bq", bqRemote("prod-analytics-bq", `{"project":"acme","location":"US"}`))
+	require.NoError(t, err)
+
+	config := specMap["config"].(map[string]any)
+	assert.Equal(t, "{{ .PROD_ANALYTICS_BQ_CREDENTIALS }}", config["credentials"], "secret must export as a var reference")
+	assert.Equal(t, "acme", config["project"])
+	assert.Equal(t, "US", config["location"])
+	assert.Equal(t, "prod-analytics-bq", specMap["id"])
+	assert.Equal(t, "SOURCE_BIGQUERY", specMap["account_definition_name"])
+}
+
+// The whole exported spec — serialized as it would be written to disk — must
+// never carry a raw secret. Even a value the API happened to echo back stays
+// masked.
+func TestFormatForExport_NeverLeaksSecret(t *testing.T) {
+	enableVarSubstitution(t)
+	h := &HandlerImpl{store: &mockStore{}}
+
+	entities, entries, err := h.FormatForExport(
+		map[string]*RemoteAccount{
+			"prod-analytics-bq": bqRemote("prod-analytics-bq", `{"project":"acme","location":"US","credentials":"leaked-key-value"}`),
+		}, nil, nil)
+	require.NoError(t, err)
+	require.Len(t, entities, 1)
+	require.Len(t, entries, 1)
+
+	assert.Equal(t, "accounts/prod-analytics-bq.yaml", entities[0].RelativePath)
+
+	rendered, err := json.Marshal(entities[0].Content)
+	require.NoError(t, err)
+	assert.NotContains(t, string(rendered), "leaked-key-value", "raw secret must never reach an exported spec")
+	assert.Contains(t, string(rendered), "{{ .PROD_ANALYTICS_BQ_CREDENTIALS }}")
+}
+
+func TestToExportSpecMap_UnsupportedDefinition(t *testing.T) {
+	h := &HandlerImpl{store: &mockStore{}}
+	acc := &client.Account{ID: "remote-x", ExternalID: "x"}
+	acc.Definition.Name = "SOURCE_SNOWFLAKE"
+
+	_, err := h.toExportSpecMap("x", &RemoteAccount{Account: acc})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported definition")
+}

--- a/cli/internal/providers/accounts/handler_test.go
+++ b/cli/internal/providers/accounts/handler_test.go
@@ -58,6 +58,7 @@ func bqResource(id string) *AccountResource {
 	cred := secret.New("svc-account-json")
 	return &AccountResource{
 		ID:                    id,
+		Name:                  "name-" + id, // distinct from ID to prove they map separately
 		AccountDefinitionName: "SOURCE_BIGQUERY",
 		Config: map[string]any{
 			"projectId":   "proj-123",
@@ -67,7 +68,7 @@ func bqResource(id string) *AccountResource {
 	}
 }
 
-func TestCreate_SplitsConfigAndClaimsExternalID(t *testing.T) {
+func TestCreate_SplitsConfigAndClaimsExternalIDInline(t *testing.T) {
 	m := &mockStore{createReturnID: "remote-1"}
 	h := &HandlerImpl{store: m}
 
@@ -83,9 +84,11 @@ func TestCreate_SplitsConfigAndClaimsExternalID(t *testing.T) {
 	assert.Equal(t, map[string]any{"credentials": "svc-account-json"}, sec)
 
 	assert.Equal(t, "SOURCE_BIGQUERY", m.created.AccountDefinitionName)
-	assert.Equal(t, "prod-bq", m.created.Name)
-	// external id claimed = spec id, on the returned remote id.
-	assert.Equal(t, [2]string{"remote-1", "prod-bq"}, m.externalIDSet)
+	assert.Equal(t, "name-prod-bq", m.created.Name, "display name maps from spec Name, not ID")
+	// external id is claimed in the create call itself (spec ID)...
+	assert.Equal(t, "prod-bq", m.created.ExternalID)
+	// ...so there is no separate SetExternalID round trip.
+	assert.Equal(t, [2]string{}, m.externalIDSet, "SetExternalID must not be called on create")
 }
 
 func TestUpdate_RejectsDefinitionChange(t *testing.T) {
@@ -109,12 +112,13 @@ func TestExtractResourcesFromSpec_UnsupportedDefinition(t *testing.T) {
 
 func TestMapRemoteToState_SecretIsUnknown(t *testing.T) {
 	h := &HandlerImpl{store: &mockStore{}}
-	acc := &client.Account{ID: "remote-1", ExternalID: "prod-bq", Options: json.RawMessage(`{"projectId":"p"}`)}
+	acc := &client.Account{ID: "remote-1", ExternalID: "prod-bq", Name: "Prod BQ", Options: json.RawMessage(`{"projectId":"p"}`)}
 	acc.Definition.Name = "SOURCE_BIGQUERY"
 
 	res, state, err := h.MapRemoteToState(&RemoteAccount{Account: acc}, nil)
 	require.NoError(t, err)
 	assert.Equal(t, "prod-bq", res.ID)
+	assert.Equal(t, "Prod BQ", res.Name, "display name maps back from the remote")
 	assert.Equal(t, "remote-1", state.ID)
 	assert.Equal(t, "p", res.Config["projectId"])
 
@@ -127,6 +131,7 @@ func bqRemote(externalID string, opts string) *RemoteAccount {
 	acc := &client.Account{
 		ID:         "remote-" + externalID,
 		ExternalID: externalID,
+		Name:       "name-" + externalID,
 		Options:    json.RawMessage(opts),
 	}
 	acc.Definition.Name = "SOURCE_BIGQUERY"
@@ -148,6 +153,7 @@ func TestToExportSpecMap_TokenizesSecret(t *testing.T) {
 	assert.Equal(t, "acme", config["project"])
 	assert.Equal(t, "US", config["location"])
 	assert.Equal(t, "prod-analytics-bq", specMap["id"])
+	assert.Equal(t, "name-prod-analytics-bq", specMap["name"])
 	assert.Equal(t, "SOURCE_BIGQUERY", specMap["account_definition_name"])
 }
 

--- a/cli/internal/providers/accounts/model.go
+++ b/cli/internal/providers/accounts/model.go
@@ -1,0 +1,46 @@
+package accounts
+
+import (
+	"github.com/rudderlabs/rudder-iac/api/client"
+	"github.com/rudderlabs/rudder-iac/cli/internal/provider/handler"
+)
+
+// AccountSpec is the user-authored YAML representation of an account. Config is a
+// single flat map; the handler splits it into the API's options (non-secret) and
+// secret payloads by the account definition's secret-key set — the same shape a
+// destination spec uses (one config map, secrets identified by key).
+type AccountSpec struct {
+	ID                    string         `mapstructure:"id" validate:"required"`
+	AccountDefinitionName string         `mapstructure:"account_definition_name" validate:"required"`
+	Config                map[string]any `mapstructure:"config"`
+}
+
+// AccountResource is the resolved representation the differ compares. Registered
+// secret keys inside Config are wrapped as *secret.String so the differ's
+// secret-aware branch owns their comparison — identical to DestinationResource.
+type AccountResource struct {
+	ID                    string
+	AccountDefinitionName string
+	Config                map[string]any
+}
+
+// AccountState is the persisted apply-cycle state — the remote account ID.
+type AccountState struct {
+	ID string
+}
+
+// RemoteAccount wraps client.Account to satisfy handler.RemoteResource.
+type RemoteAccount struct {
+	*client.Account
+}
+
+// Metadata exposes the identifying fields BaseHandler keys the remote collection
+// on.
+func (r RemoteAccount) Metadata() handler.RemoteResourceMetadata {
+	return handler.RemoteResourceMetadata{
+		ID:          r.ID,
+		ExternalID:  r.ExternalID,
+		WorkspaceID: r.WorkspaceID,
+		Name:        r.Name,
+	}
+}

--- a/cli/internal/providers/accounts/model.go
+++ b/cli/internal/providers/accounts/model.go
@@ -9,8 +9,13 @@ import (
 // single flat map; the handler splits it into the API's options (non-secret) and
 // secret payloads by the account definition's secret-key set — the same shape a
 // destination spec uses (one config map, secrets identified by key).
+//
+// ID is the caller-owned external id (the URN claim); Name is the account's
+// display name in the control plane — a distinct field, so it sits beside Config
+// rather than inside it.
 type AccountSpec struct {
 	ID                    string         `mapstructure:"id" validate:"required"`
+	Name                  string         `mapstructure:"name" validate:"required"`
 	AccountDefinitionName string         `mapstructure:"account_definition_name" validate:"required"`
 	Config                map[string]any `mapstructure:"config"`
 }
@@ -20,6 +25,7 @@ type AccountSpec struct {
 // secret-aware branch owns their comparison — identical to DestinationResource.
 type AccountResource struct {
 	ID                    string
+	Name                  string
 	AccountDefinitionName string
 	Config                map[string]any
 }

--- a/cli/internal/providers/accounts/model.go
+++ b/cli/internal/providers/accounts/model.go
@@ -17,7 +17,7 @@ type AccountSpec struct {
 	ID                    string         `mapstructure:"id" validate:"required"`
 	Name                  string         `mapstructure:"name" validate:"required"`
 	AccountDefinitionName string         `mapstructure:"account_definition_name" validate:"required"`
-	Config                map[string]any `mapstructure:"config"`
+	Config                map[string]any `mapstructure:"config" validate:"required"`
 }
 
 // AccountResource is the resolved representation the differ compares. Registered

--- a/cli/internal/providers/accounts/provider.go
+++ b/cli/internal/providers/accounts/provider.go
@@ -1,0 +1,28 @@
+package accounts
+
+import (
+	"github.com/rudderlabs/rudder-iac/cli/internal/provider"
+	prules "github.com/rudderlabs/rudder-iac/cli/internal/provider/rules"
+	vrules "github.com/rudderlabs/rudder-iac/cli/internal/validation/rules"
+)
+
+// Provider wraps BaseProvider with the single account handler — the same shape
+// as the destination provider.
+type Provider struct {
+	*provider.BaseProvider
+}
+
+// NewProvider constructs the accounts provider around the given store.
+func NewProvider(store AccountStore) *Provider {
+	return &Provider{
+		BaseProvider: provider.NewBaseProvider([]provider.Handler{
+			NewHandler(store),
+		}),
+	}
+}
+
+// SupportedMatchPatterns declares the account kind for rudder/v1 only (accounts
+// are new — no legacy versions), scoping the gatekeeper rules to it.
+func (p *Provider) SupportedMatchPatterns() []vrules.MatchPattern {
+	return prules.V1VersionPatterns(AccountSpecKind)
+}

--- a/cli/internal/providers/accounts/types.go
+++ b/cli/internal/providers/accounts/types.go
@@ -1,0 +1,10 @@
+package accounts
+
+// Resource identifiers for the accounts provider. One account per spec file,
+// mirroring the destination provider (a collection kind is an alternative, not a
+// requirement — see the spike notes).
+const (
+	AccountResourceType = "account"
+	AccountSpecKind     = "account"
+	AccountMetadataName = "account"
+)

--- a/cli/internal/providers/destination/handler.go
+++ b/cli/internal/providers/destination/handler.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"maps"
 	"path/filepath"
 	"strings"
 
@@ -82,7 +81,7 @@ func (h *HandlerImpl) ExtractResourcesFromSpec(_ string, spec *DestinationSpec) 
 		Type:              spec.Type,
 		Enabled:           spec.Enabled,
 		DefinitionVersion: spec.DefinitionVersion,
-		Config:            wrapKnownSecrets(spec.Config, registered.SecretKeys()),
+		Config:            secret.WrapKnownSecrets(spec.Config, registered.SecretKeys()),
 	}
 
 	if spec.Transformation != "" {
@@ -234,7 +233,7 @@ func (h *HandlerImpl) MapRemoteToState(
 	// API responses omit secret values. Wrap only secret keys that are still
 	// present after conversion (defensive); absent keys stay absent so
 	// presence-based wrapping never invents conditional secrets.
-	localConfig = wrapUnknownSecrets(localConfig, registered.SecretKeys())
+	localConfig = secret.WrapUnknownSecrets(localConfig, registered.SecretKeys())
 
 	transformationRef, transformationID, err := h.transformationRef(remote, urnResolver)
 	if err != nil {
@@ -442,7 +441,7 @@ func (h *HandlerImpl) toExportSpecMap(externalID string, remote *RemoteDestinati
 		return nil, fmt.Errorf("converting destination %s config to local: %w", remote.ID, err)
 	}
 
-	if err := maskSecrets(localConfig, externalID, registered.SecretKeys()); err != nil {
+	if err := secret.MaskSecrets(localConfig, externalID, registered.SecretKeys()); err != nil {
 		return nil, fmt.Errorf("masking destination %s secrets: %w", remote.ID, err)
 	}
 
@@ -469,121 +468,6 @@ func (h *HandlerImpl) toExportSpecMap(externalID string, remote *RemoteDestinati
 	return specMap, nil
 }
 
-// maskSecrets replaces each registered secret key that is already present in
-// config with the marshaled form of secret.NewUnknown(WithVariableName(...)):
-// a "{{ .VAR }}" token when enableVarSubstitution is on, otherwise the masked
-// literal. Absent secrets are not invented — requiredness is owned by the
-// destination config model's validate tags.
-func maskSecrets(config map[string]any, externalID string, secretKeys []string) error {
-	if config == nil || len(secretKeys) == 0 {
-		return nil
-	}
-
-	prefix := strings.ToUpper(strings.ReplaceAll(externalID, "-", "_"))
-	for _, key := range secretKeys {
-		if _, ok := config[key]; !ok {
-			continue
-		}
-
-		varName := fmt.Sprintf(
-			"%s_%s",
-			prefix,
-			strings.ToUpper(key),
-		)
-
-		s := secret.NewUnknown(secret.WithVariableName(varName))
-		token, err := marshalSecretToken(s)
-		if err != nil {
-			return fmt.Errorf("masking secret key %q: %w", key, err)
-		}
-
-		config[key] = token
-	}
-	return nil
-}
-
-// marshalSecretToken JSON-marshals a secret.String to its export string form
-// (variable reference or masked literal).
-func marshalSecretToken(s secret.String) (string, error) {
-	bytes, err := json.Marshal(s)
-	if err != nil {
-		return "", err
-	}
-	var token string
-	if err := json.Unmarshal(bytes, &token); err != nil {
-		return "", err
-	}
-	return token, nil
-}
-
-// wrapKnownSecrets wraps each registered secret key that is already present in
-// config as *secret.String with the known local value. Pointer form survives
-// the differ's struct→map decode. Absent secrets are not invented —
-// requiredness is owned by the destination config model's validate tags.
-func wrapKnownSecrets(config map[string]any, secretKeys []string) map[string]any {
-	if config == nil || len(secretKeys) == 0 {
-		return config
-	}
-	for _, key := range secretKeys {
-		v, ok := config[key]
-		if !ok {
-			continue
-		}
-		raw := ""
-		if s, ok := v.(string); ok {
-			raw = s
-		}
-		s := secret.New(raw)
-		config[key] = &s
-	}
-	return config
-}
-
-// wrapUnknownSecrets marks each registered secret key that is already present
-// in config as an unknown *secret.String. Used when mapping remote state.
-// Absent keys stay absent — the API normally strips secrets, and inventing
-// them would force perpetual re-apply for conditional secrets that do not apply.
-func wrapUnknownSecrets(config map[string]any, secretKeys []string) map[string]any {
-	if config == nil || len(secretKeys) == 0 {
-		return config
-	}
-	for _, key := range secretKeys {
-		if _, ok := config[key]; !ok {
-			continue
-		}
-		s := secret.NewUnknown()
-		config[key] = &s
-	}
-	return config
-}
-
-// revealSecrets returns a shallow copy of config with registered secret keys
-// replaced by their Reveal() string. Must run before LocalToAPI / json.Marshal
-// so the real value reaches the wire instead of a masked form.
-func revealSecrets(config map[string]any, secretKeys []string) map[string]any {
-	if config == nil || len(secretKeys) == 0 {
-		return config
-	}
-	out := maps.Clone(config)
-	for _, key := range secretKeys {
-		v, ok := out[key]
-		if !ok {
-			continue
-		}
-		switch s := v.(type) {
-		case *secret.String:
-			if s == nil {
-				out[key] = ""
-				continue
-			}
-			out[key] = s.Reveal()
-		case secret.String:
-			out[key] = s.Reveal()
-		}
-	}
-	return out
-}
-
 // localConfigToAPI resolves the registered definition and converts snake_case
 // config to the camelCase form the API expects, returning JSON-serializable bytes.
 func (h *HandlerImpl) localConfigToAPI(destType string, version int64, local map[string]any) (json.RawMessage, error) {
@@ -594,7 +478,7 @@ func (h *HandlerImpl) localConfigToAPI(destType string, version int64, local map
 
 	// Reveal before conversion: LocalToAPI json.Marshals the map, and a
 	// surviving secret.String would emit its masked form to the API.
-	revealed := revealSecrets(
+	revealed := secret.RevealSecrets(
 		local,
 		registered.SecretKeys(),
 	)

--- a/cli/internal/ruledoc/ruledoc_test.go
+++ b/cli/internal/ruledoc/ruledoc_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	providerrules "github.com/rudderlabs/rudder-iac/cli/internal/provider/rules"
+	atypes "github.com/rudderlabs/rudder-iac/cli/internal/providers/accounts"
 	"github.com/rudderlabs/rudder-iac/cli/internal/providers/datacatalog/localcatalog"
 	dgHandler "github.com/rudderlabs/rudder-iac/cli/internal/providers/datagraph/handlers/datagraph"
 	dtypes "github.com/rudderlabs/rudder-iac/cli/internal/providers/destination"
@@ -44,6 +45,7 @@ func gatekeeperScopedPatterns() []vrules.MatchPattern {
 	p = append(p, providerrules.V1VersionPatterns(ttypes.TransformationSpecKind)...)
 	p = append(p, providerrules.V1VersionPatterns(ttypes.LibrarySpecKind)...)
 	p = append(p, providerrules.V1VersionPatterns(dtypes.DestinationSpecKind)...)
+	p = append(p, providerrules.V1VersionPatterns(atypes.AccountSpecKind)...)
 	return p
 }
 

--- a/cli/internal/secret/mapconfig.go
+++ b/cli/internal/secret/mapconfig.go
@@ -1,0 +1,124 @@
+package secret
+
+import (
+	"encoding/json"
+	"fmt"
+	"maps"
+	"strings"
+)
+
+// This file holds the map-config secret helpers shared by every provider whose
+// config is a map[string]any with a known set of secret keys (destinations,
+// accounts, …). They were originally private to the destination handler; lifting
+// them here is the framework-level DRY that lets a new provider get
+// destination-grade secret handling for free — no per-provider reflection, no
+// struct-tag machinery.
+
+// WrapKnownSecrets wraps each listed secret key that is already present in
+// config as a *String holding the known local value. Pointer form survives the
+// differ's struct→map decode. Absent secrets are not invented — requiredness is
+// owned by the caller's spec model (e.g. validate tags), so a provider that
+// needs an always-present secret must seed the key before calling.
+func WrapKnownSecrets(config map[string]any, secretKeys []string) map[string]any {
+	if config == nil || len(secretKeys) == 0 {
+		return config
+	}
+	for _, key := range secretKeys {
+		v, ok := config[key]
+		if !ok {
+			continue
+		}
+		raw := ""
+		if s, ok := v.(string); ok {
+			raw = s
+		}
+		s := New(raw)
+		config[key] = &s
+	}
+	return config
+}
+
+// WrapUnknownSecrets marks each listed secret key that is already present in
+// config as an unknown *String. Used when mapping remote state: APIs never
+// return secret values, so a present-but-opaque key must always diff (see
+// String.Diff). Absent keys stay absent — inventing them would force perpetual
+// re-apply for conditional secrets that do not apply. A provider whose secret is
+// unconditional must seed the key before calling (see accounts.MapRemoteToState).
+func WrapUnknownSecrets(config map[string]any, secretKeys []string) map[string]any {
+	if config == nil || len(secretKeys) == 0 {
+		return config
+	}
+	for _, key := range secretKeys {
+		if _, ok := config[key]; !ok {
+			continue
+		}
+		s := NewUnknown()
+		config[key] = &s
+	}
+	return config
+}
+
+// RevealSecrets returns a shallow copy of config with every listed secret key
+// replaced by its Reveal() string. Run before marshalling to the wire so the
+// real value is sent instead of a masked form. Keys absent from config are left
+// alone.
+func RevealSecrets(config map[string]any, secretKeys []string) map[string]any {
+	if config == nil || len(secretKeys) == 0 {
+		return config
+	}
+	out := maps.Clone(config)
+	for _, key := range secretKeys {
+		v, ok := out[key]
+		if !ok {
+			continue
+		}
+		switch s := v.(type) {
+		case *String:
+			if s == nil {
+				out[key] = ""
+				continue
+			}
+			out[key] = s.Reveal()
+		case String:
+			out[key] = s.Reveal()
+		}
+	}
+	return out
+}
+
+// MaskSecrets replaces each listed secret key present in config with a masked
+// token derived from externalID — a "{{ .VAR }}" reference under the variable
+// substitution gate, otherwise a masked literal. Only keys present in config are
+// touched; absent secrets are not invented.
+func MaskSecrets(config map[string]any, externalID string, secretKeys []string) error {
+	if config == nil || len(secretKeys) == 0 {
+		return nil
+	}
+	prefix := strings.ToUpper(strings.ReplaceAll(externalID, "-", "_"))
+	for _, key := range secretKeys {
+		if _, ok := config[key]; !ok {
+			continue
+		}
+		varName := fmt.Sprintf("%s_%s", prefix, strings.ToUpper(key))
+		token, err := marshalToken(NewUnknown(WithVariableName(varName)))
+		if err != nil {
+			return fmt.Errorf("masking secret key %q: %w", key, err)
+		}
+		config[key] = token
+	}
+	return nil
+}
+
+// marshalToken JSON-marshals a String to its export string form (variable
+// reference or masked literal).
+func marshalToken(s String) (string, error) {
+	b, err := json.Marshal(s)
+	if err != nil {
+		return "", err
+	}
+	var token string
+	if err := json.Unmarshal(b, &token); err != nil {
+		return "", err
+	}
+	return token, nil
+}

--- a/cli/tests/command_accounts_apply_test.go
+++ b/cli/tests/command_accounts_apply_test.go
@@ -1,0 +1,71 @@
+package tests
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// rawAccountSecret is the literal credentials value supplied via the var file.
+// It must never surface in CLI output — the secret is write-only and the API
+// never returns it.
+const rawAccountSecret = "dummy-bq-service-account-key-12345"
+
+// TestAccountsApply drives the accounts provider end-to-end against a live stack:
+// apply create → apply update → re-apply is a no-op. It needs a real backend with
+// the SOURCE_BIGQUERY account definition deployed and a PAT, so it is skipped
+// unless RUN_ACCOUNT_E2E=1 (mirrors how the other e2e tests assume a backend, but
+// gated because accounts create real, credential-bearing resources).
+//
+// Note: the secret (credentials) is unknown on read, so it always diffs — the
+// "no changes" assertion below therefore targets the non-secret fields via the
+// dry-run summary. When a stack is wired in, tighten this to snapshot the
+// upstream options the way command_apply_test.go does for the catalog.
+func TestAccountsApply(t *testing.T) {
+	if os.Getenv("RUN_ACCOUNT_E2E") != "1" {
+		t.Skip("set RUN_ACCOUNT_E2E=1 with a live stack (SOURCE_BIGQUERY definition + PAT) to run")
+	}
+
+	// Accounts are gated behind an experimental flag, and the specs reference
+	// secrets via {{ .VAR }} placeholders resolved at apply time.
+	t.Setenv("RUDDERSTACK_X_ACCOUNT_SUPPORT", "true")
+	t.Setenv("RUDDERSTACK_CLI_EXPERIMENTAL", "true")
+	t.Setenv("RUDDERSTACK_X_ENABLE_VAR_SUBSTITUTION", "true")
+
+	executor, err := NewCmdExecutor("")
+	require.NoError(t, err)
+
+	projectDir := filepath.Join("testdata", "accounts")
+	varFile := filepath.Join(projectDir, "credentials.vars.yaml")
+
+	out, err := executor.Execute(cliBinPath, "destroy", "--confirm=false")
+	require.NoError(t, err, "destroy failed: %s", out)
+
+	t.Run("apply create", func(t *testing.T) {
+		out, err := executor.Execute(cliBinPath, "apply", "-l",
+			filepath.Join(projectDir, "create"), "--var-file", varFile, "--confirm=false")
+		require.NoError(t, err, "create apply failed: %s", out)
+		assert.NotContains(t, string(out), rawAccountSecret, "raw secret must never appear in CLI output")
+	})
+
+	t.Run("apply update", func(t *testing.T) {
+		out, err := executor.Execute(cliBinPath, "apply", "-l",
+			filepath.Join(projectDir, "update"), "--var-file", varFile, "--confirm=false")
+		require.NoError(t, err, "update apply failed: %s", out)
+		assert.NotContains(t, string(out), rawAccountSecret, "raw secret must never appear in CLI output")
+	})
+
+	t.Run("re-apply is a no-op for non-secret fields", func(t *testing.T) {
+		out, err := executor.Execute(cliBinPath, "apply", "-l",
+			filepath.Join(projectDir, "update"), "--var-file", varFile,
+			"--dry-run", "--confirm=false")
+		require.NoError(t, err, "dry-run failed: %s", out)
+		// Only the credentials secret should be flagged (always-unknown); the
+		// non-secret option fields (project, location) must be in sync.
+		assert.NotContains(t, string(out), "project", "non-secret fields should not diff on re-apply")
+		assert.NotContains(t, string(out), "location", "non-secret fields should not diff on re-apply")
+	})
+}

--- a/cli/tests/command_accounts_apply_test.go
+++ b/cli/tests/command_accounts_apply_test.go
@@ -1,10 +1,15 @@
 package tests
 
 import (
+	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/rudderlabs/rudder-iac/api/client"
+	"github.com/rudderlabs/rudder-iac/cli/internal/config"
+	"github.com/rudderlabs/rudder-iac/cli/tests/helpers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -14,16 +19,16 @@ import (
 // never returns it.
 const rawAccountSecret = "dummy-bq-service-account-key-12345"
 
+// accountSnapshotIgnore are the volatile upstream fields excluded from the
+// snapshot comparison: server-assigned id, workspace scoping, and timestamps.
+// The secret is never returned by the API, so it never appears here.
+var accountSnapshotIgnore = []string{"id", "workspaceId", "createdAt", "updatedAt"}
+
 // TestAccountsApply drives the accounts provider end-to-end against a live stack:
 // apply create → apply update → re-apply is a no-op. It needs a real backend with
 // the SOURCE_BIGQUERY account definition deployed and a PAT, so it is skipped
 // unless RUN_ACCOUNT_E2E=1 (mirrors how the other e2e tests assume a backend, but
 // gated because accounts create real, credential-bearing resources).
-//
-// Note: the secret (credentials) is unknown on read, so it always diffs — the
-// "no changes" assertion below therefore targets the non-secret fields via the
-// dry-run summary. When a stack is wired in, tighten this to snapshot the
-// upstream options the way command_apply_test.go does for the catalog.
 func TestAccountsApply(t *testing.T) {
 	if os.Getenv("RUN_ACCOUNT_E2E") != "1" {
 		t.Skip("set RUN_ACCOUNT_E2E=1 with a live stack (SOURCE_BIGQUERY definition + PAT) to run")
@@ -49,6 +54,7 @@ func TestAccountsApply(t *testing.T) {
 			filepath.Join(projectDir, "create"), "--var-file", varFile, "--confirm=false")
 		require.NoError(t, err, "create apply failed: %s", out)
 		assert.NotContains(t, string(out), rawAccountSecret, "raw secret must never appear in CLI output")
+		verifyAccountUpstream(t, "create")
 	})
 
 	t.Run("apply update", func(t *testing.T) {
@@ -56,16 +62,48 @@ func TestAccountsApply(t *testing.T) {
 			filepath.Join(projectDir, "update"), "--var-file", varFile, "--confirm=false")
 		require.NoError(t, err, "update apply failed: %s", out)
 		assert.NotContains(t, string(out), rawAccountSecret, "raw secret must never appear in CLI output")
+		verifyAccountUpstream(t, "update")
 	})
 
-	t.Run("re-apply is a no-op for non-secret fields", func(t *testing.T) {
+	t.Run("re-apply leaves non-secret upstream state unchanged", func(t *testing.T) {
 		out, err := executor.Execute(cliBinPath, "apply", "-l",
-			filepath.Join(projectDir, "update"), "--var-file", varFile,
-			"--dry-run", "--confirm=false")
-		require.NoError(t, err, "dry-run failed: %s", out)
-		// Only the credentials secret should be flagged (always-unknown); the
-		// non-secret option fields (project, location) must be in sync.
-		assert.NotContains(t, string(out), "project", "non-secret fields should not diff on re-apply")
-		assert.NotContains(t, string(out), "location", "non-secret fields should not diff on re-apply")
+			filepath.Join(projectDir, "update"), "--var-file", varFile, "--confirm=false")
+		require.NoError(t, err, "re-apply failed: %s", out)
+		// The credentials secret is always-unknown so it re-applies every time;
+		// the snapshot (non-secret fields) proves nothing else churned.
+		verifyAccountUpstream(t, "update")
 	})
+}
+
+// verifyAccountUpstream fetches the managed accounts from the API and
+// snapshot-compares them against testdata/expected/upstream/accounts/<dir>, the
+// same snapshot-based approach the catalog and transformations e2e tests use
+// (verifyState / verifyTestResults) rather than asserting on CLI stdout.
+func verifyAccountUpstream(t *testing.T, dir string) {
+	t.Helper()
+
+	config.InitConfig(config.DefaultConfigFile())
+	apiClient, err := client.New(
+		config.GetConfig().Auth.AccessToken,
+		client.WithBaseURL(config.GetConfig().APIURL),
+		client.WithUserAgent("rudder-cli-test"),
+	)
+	require.NoError(t, err)
+
+	accounts, err := apiClient.Accounts.ListAll(context.Background(), client.WithHasExternalID(true))
+	require.NoError(t, err, "listing managed accounts")
+	require.Len(t, accounts, 1, "expected exactly one managed account")
+
+	// Round-trip through JSON so the actual value is a map with the API's field
+	// names, matching the snapshot file.
+	raw, err := json.Marshal(accounts[0])
+	require.NoError(t, err)
+	var actual map[string]any
+	require.NoError(t, json.Unmarshal(raw, &actual))
+
+	expected := readJSONFile(t, filepath.Join(
+		"testdata", "expected", "upstream", "accounts", dir, "account.json"))
+
+	assert.NoError(t, helpers.CompareStates(actual, expected, accountSnapshotIgnore),
+		"upstream account snapshot mismatch for %q", dir)
 }

--- a/cli/tests/testdata/accounts/create/account.yaml
+++ b/cli/tests/testdata/accounts/create/account.yaml
@@ -1,0 +1,11 @@
+version: rudder/v1
+kind: account
+metadata:
+  name: prod-bq
+spec:
+  id: prod-bq
+  account_definition_name: SOURCE_BIGQUERY
+  config:
+    project: acme-analytics-prod
+    location: US
+    credentials: "{{ .BQ_CREDENTIALS }}"

--- a/cli/tests/testdata/accounts/create/account.yaml
+++ b/cli/tests/testdata/accounts/create/account.yaml
@@ -4,6 +4,7 @@ metadata:
   name: prod-bq
 spec:
   id: prod-bq
+  name: Production BigQuery
   account_definition_name: SOURCE_BIGQUERY
   config:
     project: acme-analytics-prod

--- a/cli/tests/testdata/accounts/credentials.vars.yaml
+++ b/cli/tests/testdata/accounts/credentials.vars.yaml
@@ -1,0 +1,1 @@
+BQ_CREDENTIALS: dummy-bq-service-account-key-12345

--- a/cli/tests/testdata/accounts/update/account.yaml
+++ b/cli/tests/testdata/accounts/update/account.yaml
@@ -1,0 +1,11 @@
+version: rudder/v1
+kind: account
+metadata:
+  name: prod-bq
+spec:
+  id: prod-bq
+  account_definition_name: SOURCE_BIGQUERY
+  config:
+    project: acme-analytics-prod
+    location: EU
+    credentials: "{{ .BQ_CREDENTIALS }}"

--- a/cli/tests/testdata/accounts/update/account.yaml
+++ b/cli/tests/testdata/accounts/update/account.yaml
@@ -4,6 +4,7 @@ metadata:
   name: prod-bq
 spec:
   id: prod-bq
+  name: Production BigQuery
   account_definition_name: SOURCE_BIGQUERY
   config:
     project: acme-analytics-prod

--- a/cli/tests/testdata/expected/upstream/accounts/create/account.json
+++ b/cli/tests/testdata/expected/upstream/accounts/create/account.json
@@ -1,0 +1,17 @@
+{
+  "id": "<ignored>",
+  "workspaceId": "<ignored>",
+  "externalId": "prod-bq",
+  "name": "Production BigQuery",
+  "definition": {
+    "name": "SOURCE_BIGQUERY",
+    "type": "bigquery",
+    "category": "source"
+  },
+  "options": {
+    "project": "acme-analytics-prod",
+    "location": "US"
+  },
+  "createdAt": "<ignored>",
+  "updatedAt": "<ignored>"
+}

--- a/cli/tests/testdata/expected/upstream/accounts/update/account.json
+++ b/cli/tests/testdata/expected/upstream/accounts/update/account.json
@@ -1,0 +1,17 @@
+{
+  "id": "<ignored>",
+  "workspaceId": "<ignored>",
+  "externalId": "prod-bq",
+  "name": "Production BigQuery",
+  "definition": {
+    "name": "SOURCE_BIGQUERY",
+    "type": "bigquery",
+    "category": "source"
+  },
+  "options": {
+    "project": "acme-analytics-prod",
+    "location": "EU"
+  },
+  "createdAt": "<ignored>",
+  "updatedAt": "<ignored>"
+}


### PR DESCRIPTION
## 🔗 Ticket

Resolves [CFD-61](https://linear.app/rudderstack/issue/CFD-61/accounts-full-implementation)

---

## Summary

Adds a declarative `account` provider so RETL accounts can be managed as YAML specs through the standard apply cycle (create / update / import / export / destroy), gated behind the experimental `AccountSupport` flag.

Account config is authored as a single flat `map[string]any` and split at the API boundary into the account definition's non-secret `options` and write-only `secret` payloads — the same map-based secret model destinations use, so no per-provider reflection or struct-tag machinery is needed. The map-config secret helpers are promoted out of the destination handler into `cli/internal/secret` and shared by both providers.

The first supported definition is `SOURCE_BIGQUERY`; the secret-key set is currently a single documented map, with the control-plane account-definitions API named as the seam for adding Snowflake/Postgres with zero per-definition code.

---

## Changes

- **New `accounts` provider** (`cli/internal/providers/accounts/`): `kind: account`, flat `config` map, per-definition secret keys, full CRUD + import/export. `splitConfig` partitions the flat config into API `options` vs `secret`.
- **Shared map-config secret helpers** (`cli/internal/secret/mapconfig.go`): `WrapKnownSecrets` / `WrapUnknownSecrets` / `RevealSecrets` / `MaskSecrets`, lifted from the destination handler; destination refactored to consume them (handler shrinks ~124 lines). Helpers keep the presence-based semantics from #709.
- **Accounts seeds its unconditional secret** before wrapping in `MapRemoteToState`, so the write-only credential (never returned by the API) is always marked unknown and always re-applied on reconcile.
- **Experimental gating**: new `AccountSupport` flag; provider registered only when enabled (mirrors `DestinationSupport`).
- **Gatekeeper rules**: `account` kind wired into the duplicate-urn / metadata-syntax-valid / manifest-inline-conflict fragments and the ruledoc coverage tests.

---

## Testing

- **Unit** (`make test`): accounts handler create/update/import/map-remote/export, including secret split, definition-immutability, remote-secret-always-unknown, and export `{{ .VAR }}` tokenization with a raw-secret leak assertion. Destination suite passes against the shared helpers, proving the refactor is behavior-preserving. Rule-catalog drift test covers the account kind.
- **E2E** (`cli/tests/command_accounts_apply_test.go`): gated behind `RUN_ACCOUNT_E2E=1` (needs a live stack with the `SOURCE_BIGQUERY` definition + PAT) — create → update → re-apply no-op, with a raw-secret leak guard on CLI output.
- `make lint` clean.

---

## Risk / Impact

Low. New provider is off by default (experimental flag). The only change to existing behavior is the destination handler consuming the relocated secret helpers, which are byte-for-byte the same presence-based logic (#709) and covered by the unchanged destination test suite.

---

## Checklist

- [x] Ticket linked
- [x] Tests added/updated
- [x] No breaking changes (or documented)