### PR TITLE
feat(transformations): add connect/disconnect destination endpoints

### DIFF
--- a/api/client/transformations/transformations.go
+++ b/api/client/transformations/transformations.go
@@ -24,6 +24,8 @@ type TransformationStore interface {
 	ListTransformations(ctx context.Context) ([]*Transformation, error)
 	DeleteTransformation(ctx context.Context, id string) error
 	SetTransformationExternalID(ctx context.Context, id string, externalID string) error
+	ConnectToDestination(ctx context.Context, id string, req *ConnectToDestinationRequest) (*Transformation, error)
+	DisconnectFromDestination(ctx context.Context, id string, req *ConnectToDestinationRequest) (*Transformation, error)
 
 	// Library operations
 	CreateLibrary(ctx context.Context, req *CreateLibraryRequest, publish bool) (*TransformationLibrary, error)
@@ -156,6 +158,51 @@ func (r *rudderTransformationStore) SetTransformationExternalID(ctx context.Cont
 		return fmt.Errorf("setting transformation external ID: %w", err)
 	}
 	return nil
+}
+
+// ConnectToDestination connects a published transformation to a destination.
+// A destination can have only one connected transformation at a time, so
+// connecting replaces any transformation already connected to the destination.
+// The transformation must be published before it can be connected.
+func (r *rudderTransformationStore) ConnectToDestination(ctx context.Context, id string, req *ConnectToDestinationRequest) (*Transformation, error) {
+	data, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("marshalling connect to destination request: %w", err)
+	}
+
+	path := fmt.Sprintf("%s/%s/connectToDestination", transformationsPrefix, id)
+	resp, err := r.client.Do(ctx, "POST", path, bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("connecting transformation to destination: %w", err)
+	}
+
+	var transformation Transformation
+	if err := json.Unmarshal(resp, &transformation); err != nil {
+		return nil, fmt.Errorf("unmarshalling connect to destination response: %w", err)
+	}
+
+	return &transformation, nil
+}
+
+// DisconnectFromDestination disconnects a transformation from a destination.
+func (r *rudderTransformationStore) DisconnectFromDestination(ctx context.Context, id string, req *ConnectToDestinationRequest) (*Transformation, error) {
+	data, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("marshalling disconnect from destination request: %w", err)
+	}
+
+	path := fmt.Sprintf("%s/%s/disconnectFromDestination", transformationsPrefix, id)
+	resp, err := r.client.Do(ctx, "POST", path, bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("disconnecting transformation from destination: %w", err)
+	}
+
+	var transformation Transformation
+	if err := json.Unmarshal(resp, &transformation); err != nil {
+		return nil, fmt.Errorf("unmarshalling disconnect from destination response: %w", err)
+	}
+
+	return &transformation, nil
 }
 
 // Library operations

--- a/api/client/transformations/transformations_test.go
+++ b/api/client/transformations/transformations_test.go
@@ -1120,6 +1120,173 @@ func TestSetTransformationExternalID(t *testing.T) {
 	httpClient.AssertNumberOfCalls()
 }
 
+func TestConnectToDestination(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		ctx := context.Background()
+
+		calls := []testutils.Call{
+			{
+				Validate: func(req *http.Request) bool {
+					return testutils.ValidateRequest(t, req, "POST", "https://api.rudderstack.com/transformations/trans-123/connectToDestination", `{
+						"destinationId": "dest-456"
+					}`)
+				},
+				ResponseStatus: 200,
+				ResponseBody: `{
+					"id": "trans-123",
+					"versionId": "ver-456",
+					"name": "Cool transformation",
+					"description": "A test description",
+					"code": "export function transformEvent(event) { return event; }",
+					"language": "javascript",
+					"destinations": [
+						{
+							"id": "dest-456",
+							"name": "My destination",
+							"enabled": true
+						}
+					]
+				}`,
+			},
+		}
+
+		httpClient := testutils.NewMockHTTPClient(t, calls...)
+		c, err := client.New("some-access-token", client.WithHTTPClient(httpClient))
+		require.NoError(t, err)
+
+		store := transformations.NewRudderTransformationStore(c)
+		result, err := store.ConnectToDestination(ctx, "trans-123", &transformations.ConnectToDestinationRequest{
+			DestinationID: "dest-456",
+		})
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.Equal(t, "trans-123", result.ID)
+		require.Len(t, result.Destinations, 1)
+		assert.Equal(t, transformations.TransformationDestination{
+			ID:      "dest-456",
+			Name:    "My destination",
+			Enabled: true,
+		}, result.Destinations[0])
+
+		httpClient.AssertNumberOfCalls()
+	})
+
+	t.Run("not published", func(t *testing.T) {
+		ctx := context.Background()
+
+		calls := []testutils.Call{
+			{
+				ResponseStatus: 400,
+				ResponseBody:   `{"message": "Transformation is not published"}`,
+			},
+		}
+
+		httpClient := testutils.NewMockHTTPClient(t, calls...)
+		c, err := client.New("some-access-token", client.WithHTTPClient(httpClient))
+		require.NoError(t, err)
+
+		store := transformations.NewRudderTransformationStore(c)
+		result, err := store.ConnectToDestination(ctx, "trans-123", &transformations.ConnectToDestinationRequest{
+			DestinationID: "dest-456",
+		})
+		require.Error(t, err)
+		assert.Nil(t, result)
+		assert.ErrorContains(t, err, "connecting transformation to destination")
+
+		httpClient.AssertNumberOfCalls()
+	})
+
+	t.Run("unmarshal failure", func(t *testing.T) {
+		ctx := context.Background()
+
+		calls := []testutils.Call{
+			{
+				ResponseStatus: 200,
+				ResponseBody:   `not valid json`,
+			},
+		}
+
+		httpClient := testutils.NewMockHTTPClient(t, calls...)
+		c, err := client.New("some-access-token", client.WithHTTPClient(httpClient))
+		require.NoError(t, err)
+
+		store := transformations.NewRudderTransformationStore(c)
+		result, err := store.ConnectToDestination(ctx, "trans-123", &transformations.ConnectToDestinationRequest{
+			DestinationID: "dest-456",
+		})
+		require.Error(t, err)
+		assert.Nil(t, result)
+		assert.ErrorContains(t, err, "unmarshalling connect to destination response")
+
+		httpClient.AssertNumberOfCalls()
+	})
+}
+
+func TestDisconnectFromDestination(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		ctx := context.Background()
+
+		calls := []testutils.Call{
+			{
+				Validate: func(req *http.Request) bool {
+					return testutils.ValidateRequest(t, req, "POST", "https://api.rudderstack.com/transformations/trans-123/disconnectFromDestination", `{
+						"destinationId": "dest-456"
+					}`)
+				},
+				ResponseStatus: 200,
+				ResponseBody: `{
+					"id": "trans-123",
+					"versionId": "ver-456",
+					"name": "Cool transformation",
+					"description": "A test description",
+					"code": "export function transformEvent(event) { return event; }",
+					"language": "javascript"
+				}`,
+			},
+		}
+
+		httpClient := testutils.NewMockHTTPClient(t, calls...)
+		c, err := client.New("some-access-token", client.WithHTTPClient(httpClient))
+		require.NoError(t, err)
+
+		store := transformations.NewRudderTransformationStore(c)
+		result, err := store.DisconnectFromDestination(ctx, "trans-123", &transformations.ConnectToDestinationRequest{
+			DestinationID: "dest-456",
+		})
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.Equal(t, "trans-123", result.ID)
+		assert.Empty(t, result.Destinations)
+
+		httpClient.AssertNumberOfCalls()
+	})
+
+	t.Run("non-200 status code", func(t *testing.T) {
+		ctx := context.Background()
+
+		calls := []testutils.Call{
+			{
+				ResponseStatus: 404,
+				ResponseBody:   `{"message": "not found"}`,
+			},
+		}
+
+		httpClient := testutils.NewMockHTTPClient(t, calls...)
+		c, err := client.New("some-access-token", client.WithHTTPClient(httpClient))
+		require.NoError(t, err)
+
+		store := transformations.NewRudderTransformationStore(c)
+		result, err := store.DisconnectFromDestination(ctx, "trans-123", &transformations.ConnectToDestinationRequest{
+			DestinationID: "dest-456",
+		})
+		require.Error(t, err)
+		assert.Nil(t, result)
+		assert.ErrorContains(t, err, "disconnecting transformation from destination")
+
+		httpClient.AssertNumberOfCalls()
+	})
+}
+
 func TestSetLibraryExternalID(t *testing.T) {
 	ctx := context.Background()
 

--- a/api/client/transformations/types.go
+++ b/api/client/transformations/types.go
@@ -2,15 +2,24 @@ package transformations
 
 // Transformation represents a transformation resource from the API
 type Transformation struct {
-	ID          string   `json:"id"`
-	VersionID   string   `json:"versionId"`
-	Name        string   `json:"name"`
-	Description string   `json:"description"`
-	Code        string   `json:"code"`
-	Language    string   `json:"language"`
-	Imports     []string `json:"imports"`
-	WorkspaceID string   `json:"workspaceId"`
-	ExternalID  string   `json:"externalId,omitempty"`
+	ID           string                      `json:"id"`
+	VersionID    string                      `json:"versionId"`
+	Name         string                      `json:"name"`
+	Description  string                      `json:"description"`
+	Code         string                      `json:"code"`
+	Language     string                      `json:"language"`
+	Imports      []string                    `json:"imports"`
+	WorkspaceID  string                      `json:"workspaceId"`
+	ExternalID   string                      `json:"externalId,omitempty"`
+	Destinations []TransformationDestination `json:"destinations,omitempty"`
+}
+
+// TransformationDestination represents a destination that a transformation is
+// connected to, as returned by the destination connection endpoints.
+type TransformationDestination struct {
+	ID      string `json:"id"`
+	Name    string `json:"name"`
+	Enabled bool   `json:"enabled"`
 }
 
 // TransformationLibrary represents a transformation library resource from the API
@@ -41,6 +50,12 @@ type UpdateTransformationRequest struct {
 	Description string `json:"description"`
 	Code        string `json:"code"`
 	Language    string `json:"language"`
+}
+
+// ConnectToDestinationRequest is the request body for connecting or
+// disconnecting a transformation to/from a destination.
+type ConnectToDestinationRequest struct {
+	DestinationID string `json:"destinationId"`
 }
 
 // CreateLibraryRequest is the request body for creating a library


### PR DESCRIPTION
## 🔗 Ticket

<!-- Required for traceability -->

N/A

---

## Summary

Add client support for associating a transformation with a destination via the two dedicated API endpoints:

- POST /transformations/{id}/connectToDestination
- POST /transformations/{id}/disconnectFromDestination

Both accept a {"destinationId": "..."} body and return the updated transformation. The Transformation type gains a Destinations field so the connected destinations returned by these endpoints (and by GET /transformations/{id}) can be read back.

Adds unit tests covering success, the "not published" 400 error, and unmarshal failures.
---

## Changes

- adds connectToDestination for transformations
- adds disconnectFromDestination for transformations

---

## Testing

How was this tested?

- Unit tests

---

## Risk / Impact

Low
Notes (if any):

---

## Checklist

- [ ] Ticket linked
- [ ] Tests added/updated
- [x] No breaking changes (or documented)
