### PR TITLE
fix(tests): ignore volatile upstream error message in transformations e2e

### DIFF
--- a/cli/tests/command_transformations_test.go
+++ b/cli/tests/command_transformations_test.go
@@ -119,6 +119,10 @@ func testResultsIgnoreFields(results map[string]any) []string {
 				prefix+".id",
 				prefix+".versionId",
 				prefix+".externalId",
+				// message is a verbatim upstream error string (e.g. the Python
+				// interpreter's SyntaxError text); its wording changes upstream and
+				// is not the CLI's contract — pass/status already assert failure.
+				prefix+".message",
 			)
 		}
 	}


### PR DESCRIPTION
## Ticket

N/A — CI infra fix.

## Summary

`TestTransformationsTest/failure` is failing on **every** branch (seen on #708 and #710, both unrelated to transformations). The test snapshots the *verbatim* error string returned by RudderStack's live transformation-test service for a deliberately-broken Python library. Upstream changed its syntax-error format, so the stored snapshot is now stale:

```
mismatch at path 'libraries[0].message':
  got  BadCodeError("'(' was never closed (<unknown>, line 1)")
  want SyntaxError(("Line 1: SyntaxError: '(' was never closed ...",))
```

Since this asserts an upstream-controlled string byte-for-byte, it breaks CI on unrelated PRs whenever the service rewords its errors.

## Changes

- Add `libraries[i].message` to the ignore list in `testResultsIgnoreFields`, alongside the other volatile fields already ignored (`.id`, `.versionId`, `.externalId`). `pass`/`status` still assert the real contract — that the CLI detects and reports the bad library.

## Testing

- `go vet ./cli/tests/` passes. Full e2e requires a live API token; the change only widens the ignore set, so the previously-passing `success` subtest is unaffected and `failure` no longer pins the volatile string.

## Risk / Impact

Low — test-only change; narrows what a snapshot asserts to fields the CLI actually owns.

## Checklist

- [x] Root cause identified (upstream error-format change)
- [x] Test-only, minimal-scope fix
- [x] `go vet` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)