### PR TITLE
fix(tests): stop snapshotting the volatile transformations error wrapper

### DIFF
--- a/cli/tests/command_transformations_test.go
+++ b/cli/tests/command_transformations_test.go
@@ -18,6 +18,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// badPyLibraryHandle is the handle of the intentionally broken Python library in the
+// failure fixture set.
+const badPyLibraryHandle = "badPyLibrary"
+
 func TestTransformationsTest(t *testing.T) {
 	executor, err := NewCmdExecutor("")
 	require.NoError(t, err)
@@ -52,7 +56,44 @@ func TestTransformationsTest(t *testing.T) {
 		require.Error(t, err, "test command should fail: %s", string(output))
 
 		verifyTestResults(t, "failure", resultsFile)
+		verifyBadLibraryMessage(t, resultsFile)
 	})
+}
+
+// verifyBadLibraryMessage asserts the stable part of the upstream error reported for
+// the deliberately broken Python library.
+//
+// The full message is snapshot-exempt (see testResultsIgnoreFields) because the
+// wrapper the backend puts around the interpreter error is not stable: the same
+// fixture has produced both
+//
+//	BadCodeError("'(' was never closed (<unknown>, line 1)")
+//	SyntaxError(("Line 1: SyntaxError: '(' was never closed at statement: ...",))
+//
+// on main within days of each other, each passing CI at the time. Pinning either
+// form makes this test flap on whatever the backend happens to return. The
+// interpreter's own diagnostic is the part we actually care about and is common to
+// both, so assert on that and let the wrapper vary.
+func verifyBadLibraryMessage(t *testing.T, resultsFile string) {
+	t.Helper()
+
+	results := readJSONFile(t, resultsFile)
+	libs, ok := results["libraries"].([]any)
+	require.True(t, ok, "test results contain no libraries array")
+
+	for _, entry := range libs {
+		lib, ok := entry.(map[string]any)
+		if !ok || lib["handleName"] != badPyLibraryHandle {
+			continue
+		}
+
+		assert.Equal(t, false, lib["pass"], "%s must be reported as failing", badPyLibraryHandle)
+		assert.Contains(t, lib["message"], "'(' was never closed",
+			"%s must report the unclosed-paren syntax error", badPyLibraryHandle)
+		return
+	}
+
+	t.Fatalf("library %q not found in test results", badPyLibraryHandle)
 }
 
 func verifyTestResults(t *testing.T, dir, resultsFile string) {
@@ -119,6 +160,9 @@ func testResultsIgnoreFields(results map[string]any) []string {
 				prefix+".id",
 				prefix+".versionId",
 				prefix+".externalId",
+				// The upstream error wrapper varies between backend responses;
+				// verifyBadLibraryMessage asserts the stable part instead.
+				prefix+".message",
 			)
 		}
 	}

--- a/cli/tests/testdata/expected/upstream/transformations-test/failure/expected_results.json
+++ b/cli/tests/testdata/expected/upstream/transformations-test/failure/expected_results.json
@@ -77,7 +77,7 @@
       "handleName": "badPyLibrary",
       "versionId": "placeholder",
       "pass": false,
-      "message": "SyntaxError((\"Line 1: SyntaxError: '(' was never closed at statement: 'def broken_function('\",))\n   in base transformation"
+      "message": "placeholder"
     },
     {
       "id": "placeholder",


### PR DESCRIPTION
## 🔗 Ticket

No Linear ticket — unplanned CI repair. `test with code coverage` is currently red on `main` and on every open PR in the repo, so this is worth landing on its own. Happy to file one for traceability if you'd rather.

---

## Summary

`TestTransformationsTest/failure` snapshot-compares the upstream error reported for the deliberately broken Python library (`badPyLibrary`). The backend does not return a stable wrapper around the interpreter diagnostic, so pinning the exact string makes the test flap.

Both of these have come back from the same fixture, days apart, each passing CI at the time:

```
BadCodeError("'(' was never closed (<unknown>, line 1)")
SyntaxError(("Line 1: SyntaxError: '(' was never closed at statement: 'def broken_function('",))
```

Timeline on `main`:

| When | Snapshot expects | Backend returned | Result |
|---|---|---|---|
| #472 (fixtures added) | `BadCodeError` | `BadCodeError` | pass |
| Jul 23, #709 (`8b4a90ab`) | changed to `SyntaxError` | `SyntaxError` | pass |
| Jul 24, #680 (`7393796`) | `SyntaxError` | `BadCodeError` | **fail** |

So this is not one-directional drift that a re-baseline fixes — whichever form is pinned, the test goes red when the other is served. Re-baselining to `BadCodeError` today would just move the coin flip.

Worth flagging separately for the transformations owners: the flip to `SyntaxError` came in via [#709](https://github.com/rudderlabs/rudder-iac/pull/709) ("destination stability fixes and presence-based secrets"), whose only change under `cli/tests` was that one snapshot line. If the wrapper class alternating between `BadCodeError` and `SyntaxError` is *not* expected backend behaviour, the real bug is upstream and this PR only stops the CLI test suite from being the thing that reports it.

---

## Changes

- Exempt `libraries[].message` from the snapshot comparison in `testResultsIgnoreFields`, alongside the existing dynamic fields (`id`, `versionId`, `externalId`).
- Add `verifyBadLibraryMessage`, asserting directly that `badPyLibrary` reports `pass: false` and that its message contains the interpreter's own `'(' was never closed` diagnostic — the part common to both wrappers and the part the fixture actually exercises.
- Set the snapshot's `message` to `"placeholder"`, matching the convention already used for the other ignored fields.

Assertion strength is preserved: previously a wrong-but-well-formed error message would be caught only by exact match; now it is caught by the substring plus `pass: false`, while the wrapper class is free to vary.

---

## Testing

- `make lint` — 0 issues.
- `go vet ./cli/tests/...`, `go build ./...`, `go test ./cli/tests/helpers/...` — all clean.
- The e2e suite itself needs `RUDDERSTACK_ACCESS_TOKEN` against the shared CI workspace, so **I could not run `TestTransformationsTest` locally** — this PR's own CI run is the real verification. Note that a single green run does not by itself prove the flake is gone (a re-baseline would also go green if the matching form happened to be served); the argument is that the varying field is no longer compared at all.

---

## Risk / Impact

Low. Test-only change, no production code touched. The trade-off is deliberate: we stop asserting the exact upstream error string, which is the field demonstrated to be unstable.

---

## Checklist

- [ ] Ticket linked (none — see above)
- [x] Tests added/updated
- [x] No breaking changes (or documented)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
