### PR TITLE
test: assert stable transformations diagnostic instead of pinning error wrapper

### DIFF
--- a/cli/tests/command_transformations_test.go
+++ b/cli/tests/command_transformations_test.go
@@ -18,6 +18,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// badPyLibraryHandle is the handle of the intentionally broken Python library in the
+// failure fixture set.
+const badPyLibraryHandle = "badPyLibrary"
+
 func TestTransformationsTest(t *testing.T) {
 	executor, err := NewCmdExecutor("")
 	require.NoError(t, err)
@@ -52,7 +56,44 @@ func TestTransformationsTest(t *testing.T) {
 		require.Error(t, err, "test command should fail: %s", string(output))
 
 		verifyTestResults(t, "failure", resultsFile)
+		verifyBadLibraryMessage(t, resultsFile)
 	})
+}
+
+// verifyBadLibraryMessage asserts the stable part of the upstream error reported for
+// the deliberately broken Python library.
+//
+// The full message is snapshot-exempt (see testResultsIgnoreFields) because the
+// wrapper the backend puts around the interpreter error is not stable: the same
+// fixture has produced both
+//
+//	BadCodeError("'(' was never closed (<unknown>, line 1)")
+//	SyntaxError(("Line 1: SyntaxError: '(' was never closed at statement: ...",))
+//
+// on main within days of each other, each passing CI at the time. Pinning either
+// form makes this test flap on whatever the backend happens to return. The
+// interpreter's own diagnostic is the part we actually care about and is common to
+// both, so assert on that and let the wrapper vary.
+func verifyBadLibraryMessage(t *testing.T, resultsFile string) {
+	t.Helper()
+
+	results := readJSONFile(t, resultsFile)
+	libs, ok := results["libraries"].([]any)
+	require.True(t, ok, "test results contain no libraries array")
+
+	for _, entry := range libs {
+		lib, ok := entry.(map[string]any)
+		if !ok || lib["handleName"] != badPyLibraryHandle {
+			continue
+		}
+
+		assert.Equal(t, false, lib["pass"], "%s must be reported as failing", badPyLibraryHandle)
+		assert.Contains(t, lib["message"], "'(' was never closed",
+			"%s must report the unclosed-paren syntax error", badPyLibraryHandle)
+		return
+	}
+
+	t.Fatalf("library %q not found in test results", badPyLibraryHandle)
 }
 
 func verifyTestResults(t *testing.T, dir, resultsFile string) {
@@ -119,9 +160,8 @@ func testResultsIgnoreFields(results map[string]any) []string {
 				prefix+".id",
 				prefix+".versionId",
 				prefix+".externalId",
-				// message is a verbatim upstream error string (e.g. the Python
-				// interpreter's SyntaxError text); its wording changes upstream and
-				// is not the CLI's contract — pass/status already assert failure.
+				// The upstream error wrapper varies between backend responses;
+				// verifyBadLibraryMessage asserts the stable part instead.
 				prefix+".message",
 			)
 		}

--- a/cli/tests/testdata/expected/upstream/transformations-test/failure/expected_results.json
+++ b/cli/tests/testdata/expected/upstream/transformations-test/failure/expected_results.json
@@ -77,7 +77,7 @@
       "handleName": "badPyLibrary",
       "versionId": "placeholder",
       "pass": false,
-      "message": "SyntaxError((\"Line 1: SyntaxError: '(' was never closed at statement: 'def broken_function('\",))\n   in base transformation"
+      "message": "placeholder"
     },
     {
       "id": "placeholder",


### PR DESCRIPTION
## Ticket

N/A — CI hardening follow-up to #712.

## Summary

#712 stopped `TestTransformationsTest/failure` from flapping by exempting the volatile upstream error `message` from the snapshot comparison — but that alone throws away the assertion. This follow-up restores assertion strength while keeping the field snapshot-exempt.

The backend does not return a stable wrapper around the interpreter diagnostic. The same fixture (`badPyLibrary`) has produced both forms on `main` within days, each green at the time:

```
BadCodeError("'(' was never closed (<unknown>, line 1)")
SyntaxError(("Line 1: SyntaxError: '(' was never closed at statement: 'def broken_function('",))
```

Pinning either form re-introduces the flake. The interpreter's own diagnostic — `'(' was never closed` — is common to both and is the part the fixture actually exercises.

## Changes

- Add `verifyBadLibraryMessage`: asserts `badPyLibrary` reports `pass: false` and that its `message` **contains** `'(' was never closed` — the stable substring — letting the wrapper class vary.
- Set the snapshot's `message` to `"placeholder"`, matching the convention for the other ignored fields (`id`, `versionId`, `externalId`).
- Keep the `libraries[i].message` snapshot exemption, now cross-referencing the new helper.

Assertion strength is preserved: a wrong-but-well-formed message is still caught by the substring + `pass: false`, while the volatile wrapper is free to vary.

## Testing

- `make lint` — 0 issues.
- `go vet ./cli/tests/` — clean.
- Full e2e needs `RUDDERSTACK_ACCESS_TOKEN` against the shared CI workspace, so `TestTransformationsTest` is verified by this PR's CI run.

## Risk / Impact

Low — test-only change, no production code touched.

## Checklist

- [x] Root cause understood (unstable upstream error wrapper)
- [x] Assertion strength preserved
- [x] `make lint` / `go vet` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)