### PR TITLE
chore: add onboard-cli-destination skill aligned with merged S3 (#709)

### DIFF
--- a/.claude/skills/onboard-cli-destination/SKILL.md
+++ b/.claude/skills/onboard-cli-destination/SKILL.md
@@ -1,0 +1,228 @@
+---
+name: onboard-cli-destination
+description: Onboard a new destination type into the rudder-iac CLI destination registry. Use when asked to add/onboard/register a destination (e.g. webhook, ga4, digital_ocean_spaces) in the CLI. Takes the destination's localType (its directory name under rudder-integrations-config destinations) as input, derives the upstream APIType from that directory's db-config.json, ports property mappings from terraform-provider-rudderstack, derives validations from rudder-integrations-config schema.json, and produces definition.go, definition_test.go, registry wiring, and a valid example YAML.
+---
+
+# Onboard CLI Destination
+
+Add a new destination type to the rudder-iac CLI destination registry
+(`cli/internal/providers/destination/definitions/`).
+
+**Input**: the destination's `localType` — its directory name under
+`rudder-integrations-config/src/configurations/destinations/<name>` (e.g.
+`s3`, `webhook`, `digital_ocean_spaces`). The upstream `APIType` is derived
+automatically from that directory's `db-config.json` — do not ask the user
+for it.
+
+**Outputs** (exactly these, nothing more):
+
+1. `cli/internal/providers/destination/definitions/<type>/definition.go`
+2. `cli/internal/providers/destination/definitions/<type>/definition_test.go`
+3. Registration in `cli/internal/app/dependencies.go` (`newDestinationRegistry`)
+4. A valid example YAML spec, printed in the final response (not committed as a file)
+
+Out of scope: rule-doc updates, E2E test wiring, project fixtures.
+
+## Source-of-truth split (fixed roles — do not deviate)
+
+| Concern | Source | Location |
+| --- | --- | --- |
+| Property mappings (local ↔ API config keys, reshapes) | terraform-provider-rudderstack | `../terraform-provider-rudderstack/rudderstack/integrations/destinations/destination_<name>.go` |
+| Config validations (required, patterns, enums, conditionals) | integrations-config `schema.json` | `../rudder-integrations-config/src/configurations/destinations/<dir>/schema.json` |
+| Source types, connection modes, secrets | integrations-config `db-config.json` | `../rudder-integrations-config/src/configurations/destinations/<dir>/db-config.json` |
+| Structural template | S3 definition in this repo | `cli/internal/providers/destination/definitions/s3/definition.go` |
+
+`<dir>` in the table above is the input `localType`.
+
+Both sibling repos are checked out next to rudder-iac under
+`~/workspace/go/src/github.com/rudderlabs/`.
+
+Ignore `.specs/destination_definition_registry.md` — it describes a JSON-Schema
+approach the code did not follow. The S3 definition is the source of truth.
+
+## Workflow
+
+### Step 1: Resolve APIType from localType
+
+Read
+`rudder-integrations-config/src/configurations/destinations/<localType>/db-config.json`
+and take its `name` field — that is the upstream `APIType`.
+
+- `s3` → `db-config.json` `name: "S3"` → `APIType = S3`
+- `webhook` → `name: "WEBHOOK"` → `APIType = WEBHOOK`
+- `digital_ocean_spaces` → `name: "DIGITAL_OCEAN_SPACES"` → `APIType = DIGITAL_OCEAN_SPACES`
+
+If the directory or `db-config.json` doesn't exist, stop and tell the user —
+do not guess a directory name.
+
+Local CLI `Type` = `lowercase(APIType)`. This must equal the input
+`localType` — if it doesn't (directory name and registered `name` disagree,
+which happens for a handful of destinations), flag the mismatch in the final
+report and use `lowercase(APIType)` as the canonical `Type`, not the raw
+input.
+
+Directory: `definitions/<type>/`. Go package name: type with underscores
+stripped (`digital_ocean_spaces` dir → `package digitaloceanspaces`),
+following the S3 precedent (`definitions/s3/`, `package s3`).
+
+### Step 2: Locate the terraform source
+
+The integrations-config directory is already known (`localType`, the input)
+— no need to search for it.
+
+- Terraform file: grep `APIType: "<APITYPE>"` under
+  `terraform-provider-rudderstack/rudderstack/integrations/destinations/`.
+
+If the destination is missing from terraform, stop and tell the user — the
+skill requires terraform as mapping source (per team decision). Do not derive
+mappings from ui-config on your own.
+
+Read [reference/source-extraction.md](reference/source-extraction.md) for what
+to extract from each file.
+
+### Step 3: Refuse duplicates
+
+Check `newDestinationRegistry` in `cli/internal/app/dependencies.go`. If the
+`(APIType, Version)` pair is already registered, stop and report.
+
+### Step 4: Write definition.go
+
+Use the S3 definition as structural template. Read
+[reference/definition-anatomy.md](reference/definition-anatomy.md) for the
+annotated walkthrough, and
+[reference/converter-mapping.md](reference/converter-mapping.md) for porting
+terraform `ConfigProperty` calls to the CLI converter helpers.
+
+Mechanical rules:
+
+- API camelCase keys → snake_case local keys (`bucketName` → `bucket_name`).
+- Port `converter.Simple` mappings **bare** — never pass `SkipZeroValue` or
+  other value filters, even where terraform does. Enforce presence via
+  validation (`required` / `required_if`), not by skipping empty values (see
+  converter-mapping.md "Do not skip zero values").
+- `Version` = terraform's registered `Version` (currently 1 everywhere).
+- `schema.json` constraints → `validate` struct tags (see source-extraction.md
+  for the constraint translation table). Real regex patterns →
+  `pattern=<name>`: reuse an existing `NewPattern` registration, or register
+  a minimal new one. Strip upstream `env.` / `{{ … }}` alternations; never
+  bake those into the CLI regex (see source-extraction.md "Enforcing regex
+  patterns").
+- `db-config.json` `secretKeys` → `SecretKeys` field, translated to snake_case
+  local keys.
+- `db-config.json` `supportedSourceTypes` / `supportedConnectionModes` →
+  `SourceTypes` / `ConnectionModes`, translated to CLI-local source types via
+  [reference/source-type-mapping.md](reference/source-type-mapping.md).
+  Unmapped upstream types (e.g. `amp`, `shopify`, `warehouse` when not
+  CLI-owned): drop and flag in the final report — never guess.
+- Source-type-gated keys: if a terraform-mapped property's API key is absent
+  from `db-config.json` `destConfig.defaultConfig` but present under specific
+  `destConfig.<sourceType>` lists, wrap the ported property in
+  `converter.Gated(prop, localSourceTypes...)` with the local source types
+  that list it (see source-extraction.md "Detecting gated keys" for the scan
+  procedure and boilerplate keys to skip). The registry indexes these at
+  Register() and exposes them via `GatedKeyPaths()`.
+- If the destination supports consent management (nearly all do): append
+  `common.Properties(sourceTypes)...` to properties and add a
+  `ConsentManagement common.ConsentManagement` field tagged
+  `mapstructure:"consent_management"` to the config struct. The registry
+  rejects any other type for that field.
+
+### Step 5: Register in dependencies.go
+
+Add the import and one line inside `newDestinationRegistry`:
+
+```go
+if err := registry.Register(<pkg>.NewDefinition()); err != nil {
+    return nil, fmt.Errorf("registering <type> destination definition: %w", err)
+}
+```
+
+Registration itself validates the definition (source types mapped, connection
+modes complete for every source type, consent field type). A broken definition
+fails every test that builds the registry — good early signal.
+
+### Step 6: Write definition_test.go
+
+Mirror `definitions/s3/definition_test.go` exactly in structure:
+
+1. `TestNewDefinitionMetadata` — register in fresh registry, assert `Type`,
+   `APIType`, `Version`, `SecretKeys()`, `SupportedSourceTypes()`,
+   `ConnectionModes()` per source type, and `GetByAPIType` lookup. When the
+   definition has gated properties, also assert the full `GatedKeyPaths()`
+   map with `assert.Equal` (JSON-pointer keypaths, e.g.
+   `map[string][]string{"/mobile_api_key_android": {"android"}}`).
+2. `Test<Type>ConfigValidation` — subtests via `registered.ValidateConfig`:
+   each required field missing, each conditional/exclusion rule, each
+   `pattern=` field with an invalid literal rejected, valid minimal config,
+   valid full config, unknown key rejected, and (when consent is supported)
+   unsupported consent source + invalid provider.
+3. `Test<Type>ConversionRoundTrip` — `testutil.AssertConversion` with paired
+   `LocalJSON`/`APIJSON` cases: minimal, full, each reshape (arrays,
+   discriminators), consent for at least one boundary-mapped source type
+   (`android_kotlin` ↔ `androidKotlin`).
+
+Testify only. `t.Parallel()` on tests and subtests, matching S3.
+
+### Step 7: Generate and verify the example YAML
+
+Write a spec with realistic values that satisfies every `validate` tag:
+
+```yaml
+version: rudder/v1
+kind: destination
+metadata:
+  name: my-<type>-destination
+spec:
+  id: my-<type>-destination
+  display_name: My <Display Name> Destination
+  type: <type>
+  enabled: true
+  definition_version: <Version>
+  config:
+    # snake_case keys with realistic values
+```
+
+Verify it mechanically, not by eye: either include a `ValidateConfig` test
+case using the exact example config, or run a temp-project
+`rudder-cli project validate` with the experimental flag on. The example must
+pass before it ships in the response.
+
+### Step 8: Verify
+
+```bash
+go build ./...
+go test ./cli/internal/providers/destination/... ./cli/internal/app/...
+make lint
+```
+
+All must pass. `cli/internal/app` is included because `dependencies_test.go`
+and `ruledoc_test.go` exercise the registry with the new definition.
+
+### Step 9: Report
+
+Final response must include:
+
+- Files created/modified
+- The validated example YAML
+- Flagged discrepancies (terraform vs schema.json disagreements, dropped
+  source types, upstream fields intentionally omitted)
+- Gated keys: which properties were gated and to which source types; gates
+  narrowed or properties omitted because their source types were dropped
+- Reminder: usage requires `experimental: true` + `flags.destinationSupport: true`
+  in the CLI config
+
+## Guardrails
+
+- Never register two definitions with the same `(Type, Version)` or
+  `(APIType, Version)` — the registry errors, but check before writing code.
+- When terraform mappings and `schema.json` disagree (field present in one,
+  absent in the other; different optionality), follow terraform for the
+  mapping and schema.json for the validation, and flag the discrepancy in the
+  report. Do not silently invent a resolution.
+- Do not add fields that exist upstream but have no terraform mapping — they
+  are out of the supported surface. List them as omitted in the report.
+- Terraform's `Negated` helper has no CLI converter equivalent; see
+  converter-mapping.md before hand-rolling one.
+- Do not leave real `schema.json` / terraform regex constraints unenforced
+  when a named `pattern=` can express them. Do not create dynamic-supporting
+  regexes (`env.` / `{{ … }}` branches) for destination config fields.

--- a/.claude/skills/onboard-cli-destination/reference/converter-mapping.md
+++ b/.claude/skills/onboard-cli-destination/reference/converter-mapping.md
@@ -1,0 +1,89 @@
+# Converter Mapping Cookbook
+
+Porting terraform `configs.ConfigProperty` lists to the CLI
+`definitions/converter` package. The CLI package was modeled on the terraform
+one, so most calls port 1:1 — only the second argument's meaning changes from
+"terraform key" to "local YAML key" (both snake_case, usually identical).
+
+Package: `cli/internal/providers/destination/definitions/converter`
+
+## Helper translation table
+
+| Terraform (`rudderstack/configs`) | CLI (`definitions/converter`) | Notes |
+| --- | --- | --- |
+| `c.Simple(apiKey, tfKey, filters...)` | `converter.Simple(apiKey, localKey)` | Port **without** filters — see "Do not skip zero values" below. Terraform's `filters...` (`SkipZeroValue` etc.) are intentionally dropped for destination config |
+| `c.SkipZeroValue` | **do not port** | Would omit zero values / empty slices from the API config and cause phantom, non-converging diffs. See "Do not skip zero values" below |
+| `c.Conditional(apiKey, tfKey, cond)` | `converter.Conditional(apiKey, localKey, cond)` | Identical |
+| `c.Equals(key, value)` | `converter.Equals(key, value)` | Identical |
+| `c.Discriminator(apiKey, values)` | `converter.Discriminator(apiKey, values)` | Identical; `DiscriminatorValues` = `map[string]any` keyed by local key |
+| `c.ArrayWithStrings(rootAPIKey, nestedField, tfKey)` | `converter.ArrayWithStrings(rootAPIKey, nestedField, localKey)` | Identical: `["a"]` ↔ `[{nestedField: "a"}]` |
+| `c.ArrayWithObjects(rootAPIKey, tfKey, fields)` | `converter.ArrayWithObjects(rootAPIKey, localKey, fields)` | Identical; `fields` maps API field → local field name (string) or `converter.APINestedObject{LocalKey, NestedKey}` |
+| `c.Negated(apiKey, tfKey)` | **no equivalent** | Rare. If needed, add `Negated` to the converter package (mirror the terraform implementation) rather than inlining a custom `ConfigProperty` in the definition |
+| `GetCommonConfigMeta(sourceTypes)` | `common.Properties(sourceTypes)` | Consent management; CLI takes **local** source types |
+| — (no terraform equivalent) | `converter.Gated(prop, sourceTypes...)` | Wrapper, not a mapping: restricts the property's local key to the given **local** source types. Use when db-config `destConfig` lists the API key only under specific source types (see source-extraction.md). Wraps any constructor except `Discriminator` (no local key — registry rejects it) |
+
+## Do not skip zero values
+
+**Port every `converter.Simple` bare — no `SkipZeroValue` or other value
+filters**, even where terraform uses `c.SkipZeroValue`. Skipping empty values
+from the API config produces phantom diffs that never converge. Enforce presence
+through validation instead: `required` / `required_if` struct tags for fields
+that must not be empty, `omitempty` / `*bool` for genuinely optional ones. The
+merged S3 definition passes no filters to any `Simple`; match it.
+
+## Dot-path API keys
+
+gjson/sjson paths work the same in both: `"useNativeSDK.web"` writes/reads a
+nested API object. Terraform's local side uses TF list indexing
+(`use_native_sdk.0.web`); the CLI local side is plain YAML nesting, so use
+`"use_native_sdk.web"`.
+
+## Common patterns
+
+Simple field:
+
+```go
+converter.Simple("prefix", "prefix")
+```
+
+Whitelist/blacklist with discriminator (GA4-style):
+
+```go
+converter.ArrayWithStrings("whitelistedEvents", "eventName", "event_filtering_whitelist"),
+converter.ArrayWithStrings("blacklistedEvents", "eventName", "event_filtering_blacklist"),
+converter.Discriminator("eventFilteringOption", converter.DiscriminatorValues{
+    "event_filtering_whitelist": "whitelistedEvents",
+    "event_filtering_blacklist": "blacklistedEvents",
+}),
+```
+
+List of objects with field rename:
+
+```go
+converter.ArrayWithObjects("piiPropertiesToIgnore", "pii_property", map[string]any{
+    "piiProperty": "pii_property_name",
+})
+```
+
+Same-shape list (no rename needed, e.g. webhook headers `{from, to}`):
+
+```go
+converter.Simple("headers", "headers")
+```
+
+## Config struct fields for each property shape
+
+The converter maps values; the config struct validates them. Shapes must
+agree with what the YAML holds locally:
+
+| Local YAML shape | Struct field type |
+| --- | --- |
+| scalar string | `string` |
+| optional bool | `*bool` |
+| required bool (gates conditionals) | `*bool` + `validate:"required"` |
+| string list (`ArrayWithStrings` local side) | `[]string` |
+| object list | `[]struct{...}` with `mapstructure` tags per field, `validate:"omitempty,dive"` on the slice |
+| consent block | `common.ConsentManagement` tagged `mapstructure:"consent_management"` (mandatory type) |
+
+Unknown local keys are rejected by the validator automatically — the struct
+is the closed allowlist, so every mapped property needs a struct field.

--- a/.claude/skills/onboard-cli-destination/reference/definition-anatomy.md
+++ b/.claude/skills/onboard-cli-destination/reference/definition-anatomy.md
@@ -1,0 +1,159 @@
+# Definition Anatomy — Annotated S3 Walkthrough
+
+`cli/internal/providers/destination/definitions/s3/definition.go` is the
+canonical template. Every new definition follows its structure exactly.
+
+## File layout
+
+```go
+package s3  // = local type, underscores stripped for multi-word types
+
+import (
+    ".../destination/definitions"
+    ".../destination/definitions/common"
+    ".../destination/definitions/converter"
+)
+
+// 1. Source types: db-config supportedSourceTypes ∩ CLI event-stream ownership,
+//    as common.SourceType* constants.
+var sourceTypes = []string{
+    common.SourceTypeAndroid,
+    // ...
+    common.SourceTypeCloud,
+}
+
+// 2. Connection modes: one entry per sourceTypes element (registry enforces
+//    completeness). Values copied from db-config supportedConnectionModes.
+var connectionModes = map[string][]string{
+    common.SourceTypeAndroid: {"cloud"},
+    // ...
+}
+
+// 3. Config struct: the closed allowlist of local YAML config keys.
+//    mapstructure tag = snake_case local key; validate tag from schema.json.
+type s3Config struct {
+    BucketName    string `mapstructure:"bucket_name" validate:"required,min=1,max=100"`
+    Prefix        string `mapstructure:"prefix" validate:"omitempty,max=100"`
+    RoleBasedAuth *bool  `mapstructure:"role_based_auth" validate:"required"`
+    // Conditionals: required_if / excluded_if reference the Go FIELD name.
+    // Encode requiredness (required_if), not exclusion — presence is enforced
+    // by validation, never by skipping empty values in the converter.
+    IAMRoleARN  string `mapstructure:"iam_role_arn" validate:"required_if=RoleBasedAuth true,max=100"`
+    AccessKeyID string `mapstructure:"access_key_id" validate:"required_if=RoleBasedAuth false,max=100"`
+    AccessKey   string `mapstructure:"access_key" validate:"required_if=RoleBasedAuth false,max=100"`
+    EnableSSE   *bool  `mapstructure:"enable_sse"`
+    // Mandatory type when consent is supported.
+    ConsentManagement common.ConsentManagement `mapstructure:"consent_management"`
+}
+
+// 4. NewDefinition: properties ported from terraform + consent, then metadata.
+func NewDefinition() *definitions.DestinationDefinition {
+    properties := []converter.ConfigProperty{
+        converter.Simple("bucketName", "bucket_name"),
+        converter.Simple("prefix", "prefix"), // bare — no SkipZeroValue (see converter-mapping.md)
+        // ...
+    }
+    properties = append(properties, common.Properties(sourceTypes)...)
+
+    return &definitions.DestinationDefinition{
+        Type:       "s3",       // lowercase(APIType), deterministic; equals the input localType
+        APIType:    "S3",       // upstream API type, derived from db-config.json "name" (Step 1)
+        Version:    1,          // = terraform ConfigMeta.Version
+        Properties: properties,
+        SecretKeys: []string{"access_key_id", "access_key"}, // snake_case LOCAL keys
+        NewConfig:  func() any { return &s3Config{} },
+        SourceTypes:     append([]string(nil), sourceTypes...),
+        ConnectionModes: connectionModes,
+    }
+}
+```
+
+## Source-type-gated config keys
+
+When integrations-config `destConfig[<sourceType>]` exposes extra keys beyond
+`defaultConfig` (e.g. Amplitude `eventUploadPeriodMillis` for android/ios/web,
+Intercom `mobileApiKeyAndroid` for android), wrap the property in
+`converter.Gated` — the local key is written once, in the constructor:
+
+```go
+converter.Gated(
+    converter.Simple("eventUploadPeriodMillis", "event_upload_period_millis"),
+    common.SourceTypeWeb, common.SourceTypeAndroid, common.SourceTypeIOS,
+),
+```
+
+Do NOT gate the boilerplate consent/connection keys (`connection_mode`,
+`use_native_sdk`, `consent_management`) — those stay handled by the existing
+source-type-keyed block machinery. The registry builds a reverse index at
+Register(); `RegisteredDefinition.GatedKeyPaths()` returns
+`map[keypath][]sourceType` (JSON-pointer paths, e.g.
+`/event_upload_period_millis`) for validation to consume.
+
+## Rules the registry enforces at Register()
+
+Violations fail `newDestinationRegistry` and thus every `cli/internal/app` test:
+
+- `NewConfig` must return a pointer to struct.
+- Every `SourceTypes` entry must exist in the local→API source-type mapping.
+- `ConnectionModes` keys ⊆ `SourceTypes`, and every source type must have modes.
+- A `consent_management` config field must be `common.ConsentManagement`.
+- `(Type, Version)` and `(APIType, Version)` must be unique.
+- Gated properties: source types ⊆ `SourceTypes`, local key must exist on the
+  config struct, no duplicates, and the property must carry a local key
+  (`Gated(Discriminator(...))` is rejected).
+
+## Validation semantics to remember
+
+- The struct is a closed allowlist: unknown local config keys error with
+  `unknown config field`.
+- `mapstructure` decode is strict (`WeaklyTypedInput: false`): YAML `"true"`
+  string does not coerce to bool.
+- `excluded_if=Field value` / `required_if=Field value` use the Go field name
+  and the stringified value (`RoleBasedAuth true`).
+- Real regex constraints use `validate:"pattern=<name>"` (default validator).
+  Reuse an existing `NewPattern` or register a minimal one; strip upstream
+  env/template alternations — never encode them into the CLI regex. See
+  source-extraction.md "Enforcing regex patterns".
+- Error paths are JSON pointers over local keys (`/bucket_name`,
+  `/consent_management/web/0/provider`) — assert them in tests.
+
+## Test template
+
+`definitions/s3/definition_test.go` — three test functions:
+
+1. `TestNewDefinitionMetadata` — register + `registry.Get(type, version)`,
+   assert all metadata, `ConnectionModes` per source type, negative
+   `NotContains` for dropped upstream source types, `GetByAPIType`.
+2. `Test<Type>ConfigValidation` — parallel subtests through
+   `registered.ValidateConfig(map[string]any{...})`, asserting `Path` and
+   `Message` fragments.
+3. `Test<Type>ConversionRoundTrip` — `testutil.AssertConversion(t,
+   def.Properties, []testutil.ConversionCase{...})` with paired
+   `LocalJSON`/`APIJSON`; include a consent case with boundary-mapped source
+   types (`android_kotlin` ↔ `androidKotlin`, `react_native` ↔ `reactnative`).
+
+## Registration in dependencies.go
+
+```go
+func newDestinationRegistry(cfg config.Config) (*definitions.Registry, error) {
+    registry := definitions.NewRegistry()
+    if !cfg.ExperimentalFlags.DestinationSupport {
+        return registry, nil
+    }
+    if err := registry.Register(s3.NewDefinition()); err != nil {
+        return nil, fmt.Errorf("registering s3 destination definition: %w", err)
+    }
+    // Append the new definition here, same pattern.
+    return registry, nil
+}
+```
+
+Note: `cli/internal/app/dependencies_test.go` asserts the exact
+`registry.SupportedTypes()` slice — update that expectation when adding a
+type (it is sorted alphabetically).
+
+## Example YAML shape
+
+`project-minimal/destinations/d1_s3.yaml` shows the spec envelope. The
+generated example must use `definition_version` equal to the registered
+`Version` and a config that passes `ValidateConfig`.

--- a/.claude/skills/onboard-cli-destination/reference/source-extraction.md
+++ b/.claude/skills/onboard-cli-destination/reference/source-extraction.md
@@ -1,0 +1,145 @@
+# Source Extraction
+
+What to pull from each upstream source, per its fixed role.
+
+## 1. Terraform provider — property mappings
+
+File: `terraform-provider-rudderstack/rudderstack/integrations/destinations/destination_<name>.go`
+
+Extract from the `init()` function:
+
+| Extract | From | Use as |
+| --- | --- | --- |
+| `APIType` | `c.Destinations.Register(name, c.ConfigMeta{APIType: ...})` | `APIType` (must equal the value derived from db-config.json in Step 1) |
+| `Version` | `ConfigMeta.Version` | `Version` |
+| `[]c.ConfigProperty` list | `properties := ...` | Port 1:1 to CLI converter (see converter-mapping.md) |
+| `Sensitive: true` schema fields | `map[string]*schema.Schema` | Cross-check against db-config `secretKeys` |
+| Regex in `c.StringMatchesRegexp(...)` | schema validators | Cross-check against schema.json patterns |
+
+Skip anything produced by `GetCommonConfigMeta(...)` (consent management) —
+the CLI equivalent is `common.Properties(sourceTypes)`.
+
+Terraform keys are already snake_case; local CLI keys are the same
+snake_case keys. API keys are the camelCase first arguments.
+
+## 2. schema.json — validations
+
+File: `rudder-integrations-config/src/configurations/destinations/<dir>/schema.json`
+(root object is `configSchema`, JSON Schema draft-07).
+
+Translate constraints to `validate` struct tags on the config struct:
+
+| schema.json | validate tag |
+| --- | --- |
+| key in `required` | `required` |
+| optional string with max | `omitempty,max=N` (schema patterns like `^(.{0,100})$` → `max=100`) |
+| `enum: ["a","b"]` | `dynamic_or_oneof=a b` (custom tag in `definitions/dynamicvalues.go`: passes `env.VAR` / `{{ ... }}` dynamic values, otherwise enforces the enum). Use plain `oneof=a b` only when the field can never hold a dynamic value |
+| `pattern` (real regex, not just length) | `pattern=<name>` via the shared named-pattern registry (see "Enforcing regex patterns" below). Length-only patterns stay as `max=N` / `min=N` — do not register a regex for those |
+| `minLength`/`maxLength` | `min=N` / `max=N` |
+| `if/then` or `allOf` conditionals | `required_if=Field value`, `excluded_if=Field value` (see S3 `iam_role_arn`/`access_key` for the pattern) |
+
+Notes:
+
+- Strip the template/env prefix from upstream patterns before deciding what to
+  enforce. Upstream often wraps the real constraint as
+  `(^\{\{.*\|\|(.*)\}\}$)|(^env[.].+)|<real>` so terraform accepts UI/env
+  references. **CLI destination config must enforce only `<real>`** — never
+  re-encode the `env.` / `{{ ... }}` branches into the named pattern, and never
+  invent a `dynamic_or_pattern` (or similar) escape hatch for regex fields.
+  Example: schema
+  `(^\{\{.*\|\|(.*)\}\}$)|(^env[.].+)|^AW-(.{0,100})$` → register / reuse
+  `^AW-(.{0,100})$` and tag `validate:"required,pattern=<name>"`.
+- Booleans that gate conditionals (like S3 `role_based_auth`) should be
+  `*bool` with `validate:"required"` so "absent" and "false" are distinct.
+- Optional booleans → `*bool` without `required`.
+- `consentManagement` and `connectionMode` subtrees in schema.json are
+  handled by `common` — do not model them as ad-hoc fields.
+
+## Enforcing regex patterns
+
+Destination config validation already supports `validate:"pattern=<name>"`
+because `GetPatternValidator()` is registered as a default validator in
+`cli/internal/provider/rules/funcs/init.go`. Use named patterns — do not
+inline raw regex in struct tags, and do not leave real patterns "unenforced"
+in the report when a minimal named pattern can express them.
+
+### Decision ladder (use the first that fits)
+
+1. **Reuse an existing named pattern.** Search `NewPattern(` under
+   `cli/internal/provider/rules/funcs/` and
+   `cli/internal/providers/destination/` (and any sibling definition
+   packages). Prefer shared names already in use (`url`,
+   `destination_display_name`, etc.) when the constraint matches.
+2. **Register a new minimal named pattern** when no existing name fits.
+   - Shared / cross-destination constraints →
+     `cli/internal/provider/rules/funcs/init.go` (same place as `url`).
+   - Destination-specific constraints → `init()` (or a tiny `patterns.go`)
+     next to that destination's `definition.go`, calling `funcs.NewPattern`.
+   - Name: short, snake_case, destination-scoped when specific
+     (e.g. `googleads_conversion_id`).
+   - Regex: **only** the real value constraint after stripping upstream
+     env/template alternations. Keep it minimal — no `(env.…)|` /
+     `(\{\{…\}\})|` branches.
+   - Error message: short, user-facing (what the value must look like).
+3. Only if the constraint cannot be expressed as a regex (or is length-only
+   / enum-only) fall back to `min`/`max` / `dynamic_or_oneof` / report note.
+
+### Tag usage
+
+```go
+// required literal shape
+ConversionID string `mapstructure:"conversion_id" validate:"required,pattern=googleads_conversion_id"`
+
+// optional literal shape
+ServerURL string `mapstructure:"server_url" validate:"omitempty,pattern=url"`
+```
+
+### Tests
+
+For every `pattern=` field: add a `ValidateConfig` subtest that a clearly
+invalid literal is rejected (path + message fragment), and keep the valid
+example YAML using a literal that satisfies the pattern.
+
+## 3. db-config.json — capabilities
+
+File: `rudder-integrations-config/src/configurations/destinations/<dir>/db-config.json`
+
+| Extract | From | Use as |
+| --- | --- | --- |
+| Secrets | `config.secretKeys` (camelCase) | `SecretKeys` — translate to snake_case local keys. **Flat top-level keys only**: the CLI secret machinery (`wrapKnownSecrets`/`maskSecrets` in `handler.go`) replaces top-level string values. Nested paths like `headers.to` cannot be modeled — leave them out of `SecretKeys` and flag in the report |
+| Source types | `config.supportedSourceTypes` | `SourceTypes` — translate via source-type-mapping.md; drop unmapped, flag in report |
+| Connection modes | `config.supportedConnectionModes` (map per source type) | `ConnectionModes` keyed by **local** source type. Every entry in `SourceTypes` must have modes — the registry rejects gaps |
+| Field allowlist | `config.destConfig.defaultConfig` | Sanity check: every mapped property's API key should appear here OR in a per-source-type list (then it is gated, see below); in neither → flag |
+| Source-type-gated keys | `config.destConfig.<sourceType>` lists | API keys that appear only under specific source types (not in `defaultConfig`) are gated: wrap the ported property in `converter.Gated(prop, localSourceTypes...)` |
+
+## Detecting gated keys in destConfig
+
+`destConfig` merges `defaultConfig` + `destConfig[<connected sourceType>]`.
+For each terraform-mapped property's API key:
+
+1. In `defaultConfig` → default key, port normally.
+2. Not in `defaultConfig` but in one or more `destConfig.<sourceType>` lists →
+   gated. Collect the source types listing it, translate to local source types
+   via source-type-mapping.md, and wrap: `converter.Gated(prop, localTypes...)`.
+   If a listing source type is dropped (unmapped/not CLI-owned), exclude it
+   from the gate; if ALL its source types are dropped, omit the property and
+   flag in the report.
+3. In no list at all → flag as discrepancy.
+
+Skip the boilerplate keys when doing this scan — `connectionMode`,
+`useNativeSDK`, `consentManagement`, `oneTrustCookieCategories`,
+`ketchConsentPurposes`, `eventFilteringOption`, `whitelistedEvents`,
+`blacklistedEvents` are handled by the `common` package and the
+source-type-keyed block machinery, never by `Gated`.
+
+Example (Intercom): `mobileApiKeyAndroid` appears only in
+`destConfig.android` → `converter.Gated(converter.Simple("mobileApiKeyAndroid", "mobile_api_key_android"), common.SourceTypeAndroid)`.
+
+## Cross-checks (flag, never silently resolve)
+
+- Terraform property with no schema.json entry, or vice versa.
+- `Sensitive: true` in terraform but key absent from `secretKeys` (or reverse).
+- Terraform `supportedSourceTypes` differing from db-config's list — db-config
+  wins for capabilities, but note the difference.
+- Upstream fields present in db-config `defaultConfig` but never mapped in
+  terraform: omit from the CLI definition and list in the report.

--- a/.claude/skills/onboard-cli-destination/reference/source-type-mapping.md
+++ b/.claude/skills/onboard-cli-destination/reference/source-type-mapping.md
@@ -1,0 +1,47 @@
+# Source Type Mapping
+
+Upstream `db-config.json` `supportedSourceTypes` values are the **API** source
+types. The CLI definition uses **local** source types. The canonical mapping
+lives in code — always read it, since it may gain entries:
+
+`cli/internal/providers/destination/definitions/common/source_type_mapping.go`
+(`apiSourceTypeByLocal`).
+
+Current mapping (local → API):
+
+| Local constant | Local value | API / db-config value |
+| --- | --- | --- |
+| `common.SourceTypeAMP` | `amp` | `amp` |
+| `common.SourceTypeAndroid` | `android` | `android` |
+| `common.SourceTypeAndroidKotlin` | `android_kotlin` | `androidKotlin` |
+| `common.SourceTypeCloud` | `cloud` | `cloud` |
+| `common.SourceTypeCloudSource` | `cloud_source` | `cloudSource` |
+| `common.SourceTypeCordova` | `cordova` | `cordova` |
+| `common.SourceTypeFlutter` | `flutter` | `flutter` |
+| `common.SourceTypeIOS` | `ios` | `ios` |
+| `common.SourceTypeIOSSwift` | `ios_swift` | `iosSwift` |
+| `common.SourceTypeReactNative` | `react_native` | `reactnative` |
+| `common.SourceTypeShopify` | `shopify` | `shopify` |
+| `common.SourceTypeUnity` | `unity` | `unity` |
+| `common.SourceTypeWarehouse` | `warehouse` | `warehouse` |
+| `common.SourceTypeWeb` | `web` | `web` |
+
+## Rules
+
+- In `definition.go`, always reference the `common.SourceType*` constants,
+  never string literals.
+- Translate each upstream `supportedSourceTypes` entry to its local constant.
+  Upstream values with no row here (e.g. `tiktokAds`, `singer-*`): drop them
+  and flag in the final report — `registry.Register` fails on any local source
+  type missing from the mapping, so guessing breaks the build anyway.
+- The CLI intentionally supports a subset: follow the S3 precedent of
+  restricting to source types the CLI event-stream provider owns (S3 dropped
+  `amp`, `shopify`, `warehouse` even though upstream lists them). When unsure
+  whether to include a mapped-but-unusual type, include what S3 includes and
+  flag the rest.
+- `ConnectionModes` must be keyed by the same local types and cover every
+  entry in `SourceTypes` — registration errors otherwise. Copy the modes per
+  source type from db-config `supportedConnectionModes` (values are `cloud`,
+  `device`, `hybrid`).
+- Consent management uses the same mapping automatically via
+  `common.Properties(sourceTypes)` — no extra work per source type.


### PR DESCRIPTION
## 🔗 Ticket

resolves [DEX-564](https://linear.app/rudderstack/issue/DEX-564/tune-onboard-cli-destination-skill-to-match-merged-s3-definition-709)

---

## Summary

Adds the `onboard-cli-destination` skill (a Claude Code skill under `.claude/skills/`) for onboarding new destination types into the CLI destination registry. The skill was drafted before the S3 stability fixes in #709 (DEX-550) merged, so its guidance is corrected up front to match the merged S3 definition — following it as originally written would reproduce the phantom-diff bug that #709 fixed (empty local config values skipped from the API config never converge against remote state).

---

## Changes

- Add `SKILL.md` + reference docs (`converter-mapping.md`, `definition-anatomy.md`, `source-extraction.md`, `source-type-mapping.md`) describing the onboarding workflow, source-of-truth split, and test/registry structure
- Guidance: port `converter.Simple` mappings **bare** — never pass `SkipZeroValue` or other value filters, even where terraform does; enforce presence via validation instead. Added a directive rule in `SKILL.md` and a "Do not skip zero values" section in `converter-mapping.md`
- Struct-tag example matches merged S3: `required_if=RoleBasedAuth true/false` (was `excluded_if`)
- Note presence-based secret handling — import/export no longer scaffolds secrets; users supply them via `{{ .VAR }}` / `--var-file`
- All `converter.Simple` code examples updated to the bare (no-filter) form to match `cli/internal/providers/destination/definitions/s3/definition.go`

---

## Testing

- Docs-only change (no CLI code touched). Verified by cross-checking every code example and struct tag in the skill against the merged `s3/definition.go` and `converter/configproperty.go`, and confirming the `source-type-mapping.md` table matches `common/source_type_mapping.go` (`apiSourceTypeByLocal`)
- Grep-verified no remaining `SkipZeroValue` recommendation and no `excluded_if` in the S3 struct example

---

## Risk / Impact

Low
Notes: Tooling/docs only — introduces a Claude Code skill; no runtime code, no apply-cycle behavior change.

---

## Checklist

- [x] Ticket linked
- [x] Tests added/updated
- [x] No breaking changes (or documented)