### PR TITLE
feat: onboard HTTP (WEBHOOK) destination into CLI destination registry

### DIFF
--- a/cli/internal/app/dependencies.go
+++ b/cli/internal/app/dependencies.go
@@ -17,6 +17,7 @@ import (
 	dgProvider "github.com/rudderlabs/rudder-iac/cli/internal/providers/datagraph"
 	destProvider "github.com/rudderlabs/rudder-iac/cli/internal/providers/destination"
 	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions"
+	httpDef "github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions/http"
 	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions/s3"
 	esProvider "github.com/rudderlabs/rudder-iac/cli/internal/providers/event-stream"
 	"github.com/rudderlabs/rudder-iac/cli/internal/providers/retl"
@@ -260,6 +261,9 @@ func newDestinationRegistry(cfg config.Config) (*definitions.Registry, error) {
 	// Verified/native destination definitions register here when available.
 
 	if cfg.ExperimentalFlags.UnverifiedDestinations {
+		if err := registry.Register(httpDef.NewDefinition()); err != nil {
+			return nil, fmt.Errorf("registering http destination definition: %w", err)
+		}
 		if err := registry.Register(s3.NewDefinition()); err != nil {
 			return nil, fmt.Errorf("registering s3 destination definition: %w", err)
 		}

--- a/cli/internal/app/dependencies_test.go
+++ b/cli/internal/app/dependencies_test.go
@@ -54,10 +54,10 @@ func TestNewDestinationRegistryFlagMatrix(t *testing.T) {
 			wantTypes:              []string{},
 		},
 		{
-			name:                   "both flags enabled registers s3",
+			name:                   "both flags enabled registers http and s3",
 			destinationSupport:     true,
 			unverifiedDestinations: true,
-			wantTypes:              []string{"s3"},
+			wantTypes:              []string{"http", "s3"},
 		},
 	}
 

--- a/cli/internal/providers/destination/definitions/http/definition.go
+++ b/cli/internal/providers/destination/definitions/http/definition.go
@@ -1,0 +1,158 @@
+package http
+
+import (
+	"github.com/rudderlabs/rudder-iac/cli/internal/provider/rules/funcs"
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions"
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions/common"
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions/converter"
+)
+
+const (
+	// apiURLPatternTag validates the base endpoint URL. Only domain-name URLs
+	// over http/https are accepted; ngrok and localhost hosts are rejected to
+	// reduce misconfiguration risk (ported from terraform-provider-rudderstack,
+	// which splits the source schema's single lookahead pattern into a positive
+	// match plus reject patterns because Go's RE2 has no negative lookahead).
+	apiURLPatternTag     = "http_api_url"
+	apiURLPattern        = `^(https?://)([a-zA-Z0-9-]{1,63}\.)+[a-zA-Z]{2,}(:(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5]\d{4}|[1-9]\d{1,3}))?(/.*)?$`
+	apiURLRejectPattern  = `^https?://(?:[^/]*\.ngrok\.io|localhost[^/:]*|[^/]*\.localhost[^/:]*)(?:[:/].*)?$`
+	apiURLPatternMessage = "must be a valid http(s) URL with a domain name (ngrok and localhost hosts are not allowed)"
+
+	// maxBatchSizePatternTag validates the batch size cap (1-100).
+	maxBatchSizePatternTag     = "http_max_batch_size"
+	maxBatchSizePattern        = `^([1-9][0-9]?|100)$`
+	maxBatchSizePatternMessage = "must be a number between 1 and 100"
+)
+
+func init() {
+	funcs.NewPatternWithReject(apiURLPatternTag, apiURLPattern, apiURLRejectPattern, apiURLPatternMessage)
+	funcs.NewPattern(maxBatchSizePatternTag, maxBatchSizePattern, maxBatchSizePatternMessage)
+}
+
+// Source types from integrations-config destinations/http/db-config.json
+// supportedSourceTypes, restricted to types the CLI event-stream provider owns
+// (amp, shopify, warehouse dropped, matching the S3 precedent).
+var sourceTypes = []string{
+	common.SourceTypeAndroid,
+	common.SourceTypeAndroidKotlin,
+	common.SourceTypeIOS,
+	common.SourceTypeIOSSwift,
+	common.SourceTypeWeb,
+	common.SourceTypeUnity,
+	common.SourceTypeReactNative,
+	common.SourceTypeFlutter,
+	common.SourceTypeCordova,
+	common.SourceTypeCloud,
+}
+
+var connectionModes = map[string][]string{
+	common.SourceTypeAndroid:       {"cloud"},
+	common.SourceTypeAndroidKotlin: {"cloud"},
+	common.SourceTypeIOS:           {"cloud"},
+	common.SourceTypeIOSSwift:      {"cloud"},
+	common.SourceTypeWeb:           {"cloud"},
+	common.SourceTypeUnity:         {"cloud"},
+	common.SourceTypeReactNative:   {"cloud"},
+	common.SourceTypeFlutter:       {"cloud"},
+	common.SourceTypeCordova:       {"cloud"},
+	common.SourceTypeCloud:         {"cloud"},
+}
+
+// keyValueMapping is the local shape for query params, headers, and properties
+// mapping: a list of {to, from} pairs.
+type keyValueMapping struct {
+	To   string `mapstructure:"to" validate:"omitempty,max=100"`
+	From string `mapstructure:"from" validate:"omitempty,max=100"`
+}
+
+// pathParam is the local shape for a single path parameter entry.
+type pathParam struct {
+	Path string `mapstructure:"path" validate:"omitempty,max=100"`
+}
+
+// eventFiltering holds the allowlist/denylist of event names. Exactly one side
+// is populated; the eventFilteringOption discriminator is derived at conversion.
+type eventFiltering struct {
+	Whitelist []string `mapstructure:"whitelist" validate:"omitempty,dive,max=100"`
+	Blacklist []string `mapstructure:"blacklist" validate:"omitempty,dive,max=100"`
+}
+
+// httpConfig is the local YAML config model. Field set mirrors integrations-config
+// destinations/http defaultConfig (schema.json / db-config.json), excluding
+// connection_mode and the consent boilerplate handled by common. Validation
+// constraints mirror the overlapping schema.json / terraform rules.
+type httpConfig struct {
+	APIURL      string `mapstructure:"api_url" validate:"required,pattern=http_api_url"`
+	Auth        string `mapstructure:"auth" validate:"required,dynamic_or_oneof=noAuth basicAuth bearerTokenAuth apiKeyAuth"`
+	Username    string `mapstructure:"username" validate:"omitempty,max=100"`
+	Password    string `mapstructure:"password" validate:"omitempty,max=100"`
+	BearerToken string `mapstructure:"bearer_token" validate:"omitempty,max=255"`
+	APIKeyName  string `mapstructure:"api_key_name" validate:"omitempty,max=100"`
+	APIKeyValue string `mapstructure:"api_key_value" validate:"omitempty,max=100"`
+	XMLRootKey  string `mapstructure:"xml_root_key" validate:"omitempty,max=100"`
+	Method      string `mapstructure:"method" validate:"required,dynamic_or_oneof=POST PUT PATCH GET DELETE"`
+	Format      string `mapstructure:"format" validate:"required,dynamic_or_oneof=JSON XML FORM"`
+
+	PropertiesMapping []keyValueMapping `mapstructure:"properties_mapping" validate:"omitempty,dive"`
+	QueryParams       []keyValueMapping `mapstructure:"query_params" validate:"omitempty,dive"`
+	Headers           []keyValueMapping `mapstructure:"headers" validate:"omitempty,dive"`
+	PathParams        []pathParam       `mapstructure:"path_params" validate:"omitempty,dive"`
+
+	IsBatchingEnabled *bool  `mapstructure:"is_batching_enabled"`
+	MaxBatchSize      string `mapstructure:"max_batch_size" validate:"omitempty,pattern=http_max_batch_size"`
+
+	EventFiltering   *eventFiltering `mapstructure:"event_filtering" validate:"omitempty"`
+	IsDefaultMapping *bool           `mapstructure:"is_default_mapping"`
+
+	ConsentManagement common.ConsentManagement `mapstructure:"consent_management"`
+}
+
+// NewDefinition returns the HTTP Webhook destination definition.
+func NewDefinition() *definitions.DestinationDefinition {
+	keyValueFields := map[string]any{
+		"to":   "to",
+		"from": "from",
+	}
+
+	properties := []converter.ConfigProperty{
+		converter.Simple("apiUrl", "api_url"),
+		converter.Simple("auth", "auth"),
+		converter.Simple("username", "username"),
+		converter.Simple("password", "password"),
+		converter.Simple("bearerToken", "bearer_token"),
+		converter.Simple("apiKeyName", "api_key_name"),
+		converter.Simple("apiKeyValue", "api_key_value"),
+		converter.Simple("xmlRootKey", "xml_root_key"),
+		converter.Simple("method", "method"),
+		converter.Simple("format", "format"),
+		converter.ArrayWithObjects("propertiesMapping", "properties_mapping", keyValueFields),
+		converter.ArrayWithObjects("queryParams", "query_params", keyValueFields),
+		converter.ArrayWithObjects("headers", "headers", keyValueFields),
+		converter.ArrayWithObjects("pathParams", "path_params", map[string]any{
+			"path": "path",
+		}),
+		converter.Simple("isBatchingEnabled", "is_batching_enabled"),
+		converter.Simple("maxBatchSize", "max_batch_size"),
+		converter.ArrayWithStrings("whitelistedEvents", "eventName", "event_filtering.whitelist"),
+		converter.ArrayWithStrings("blacklistedEvents", "eventName", "event_filtering.blacklist"),
+		converter.Discriminator("eventFilteringOption", converter.DiscriminatorValues{
+			"event_filtering.whitelist": "whitelistedEvents",
+			"event_filtering.blacklist": "blacklistedEvents",
+		}),
+		converter.Simple("isDefaultMapping", "is_default_mapping"),
+	}
+	properties = append(properties, common.Properties(sourceTypes)...)
+
+	return &definitions.DestinationDefinition{
+		Type:       "http",
+		APIType:    "HTTP",
+		Version:    1,
+		Properties: properties,
+		SecretKeys: []string{"password", "bearer_token", "api_key_value"},
+		NewConfig: func() any {
+			return &httpConfig{}
+		},
+		SourceTypes:     append([]string(nil), sourceTypes...),
+		ConnectionModes: connectionModes,
+	}
+}

--- a/cli/internal/providers/destination/definitions/http/definition_test.go
+++ b/cli/internal/providers/destination/definitions/http/definition_test.go
@@ -1,0 +1,423 @@
+package http_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions"
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions/http"
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions/testutil"
+)
+
+func TestNewDefinitionMetadata(t *testing.T) {
+	t.Parallel()
+
+	registry := definitions.NewRegistry()
+	require.NoError(t, registry.Register(http.NewDefinition()))
+
+	registered, err := registry.Get("http", 1)
+	require.NoError(t, err)
+
+	assert.Equal(t, "http", registered.Type)
+	assert.Equal(t, "HTTP", registered.APIType)
+	assert.Equal(t, int64(1), registered.Version)
+	assert.Equal(t, []string{"password", "bearer_token", "api_key_value"}, registered.SecretKeys())
+
+	expectedSourceTypes := []string{
+		"android", "android_kotlin", "ios", "ios_swift", "web",
+		"unity", "react_native", "flutter", "cordova", "cloud",
+	}
+	assert.Equal(t, expectedSourceTypes, registered.SupportedSourceTypes())
+
+	for _, sourceType := range expectedSourceTypes {
+		modes, err := registered.ConnectionModes(sourceType)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"cloud"}, modes)
+	}
+
+	assert.NotContains(t, registered.SupportedSourceTypes(), "amp")
+	assert.NotContains(t, registered.SupportedSourceTypes(), "shopify")
+	assert.NotContains(t, registered.SupportedSourceTypes(), "warehouse")
+
+	byAPI, err := registry.GetByAPIType("HTTP", 1)
+	require.NoError(t, err)
+	assert.Equal(t, registered, byAPI)
+}
+
+func TestHTTPConfigValidation(t *testing.T) {
+	t.Parallel()
+
+	registry := definitions.NewRegistry()
+	require.NoError(t, registry.Register(http.NewDefinition()))
+	registered, err := registry.Get("http", 1)
+	require.NoError(t, err)
+
+	validMinimal := func() map[string]any {
+		return map[string]any{
+			"api_url": "https://example.com/webhook",
+			"auth":    "noAuth",
+			"method":  "POST",
+			"format":  "JSON",
+		}
+	}
+
+	t.Run("valid minimal", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(validMinimal())
+		assert.Empty(t, errors)
+	})
+
+	t.Run("missing api_url", func(t *testing.T) {
+		t.Parallel()
+		cfg := validMinimal()
+		delete(cfg, "api_url")
+		errors := registered.ValidateConfig(cfg)
+		require.NotEmpty(t, errors)
+		assert.Equal(t, "/api_url", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "required")
+	})
+
+	t.Run("missing auth", func(t *testing.T) {
+		t.Parallel()
+		cfg := validMinimal()
+		delete(cfg, "auth")
+		errors := registered.ValidateConfig(cfg)
+		require.NotEmpty(t, errors)
+		assert.Equal(t, "/auth", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "required")
+	})
+
+	t.Run("missing method", func(t *testing.T) {
+		t.Parallel()
+		cfg := validMinimal()
+		delete(cfg, "method")
+		errors := registered.ValidateConfig(cfg)
+		require.NotEmpty(t, errors)
+		assert.Equal(t, "/method", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "required")
+	})
+
+	t.Run("missing format", func(t *testing.T) {
+		t.Parallel()
+		cfg := validMinimal()
+		delete(cfg, "format")
+		errors := registered.ValidateConfig(cfg)
+		require.NotEmpty(t, errors)
+		assert.Equal(t, "/format", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "required")
+	})
+
+	t.Run("invalid api_url is rejected", func(t *testing.T) {
+		t.Parallel()
+		cfg := validMinimal()
+		cfg["api_url"] = "ftp://example.com"
+		errors := registered.ValidateConfig(cfg)
+		require.NotEmpty(t, errors)
+		assert.Equal(t, "/api_url", errors[0].Path)
+	})
+
+	t.Run("localhost api_url is rejected", func(t *testing.T) {
+		t.Parallel()
+		cfg := validMinimal()
+		cfg["api_url"] = "https://localhost:8080/webhook"
+		errors := registered.ValidateConfig(cfg)
+		require.NotEmpty(t, errors)
+		assert.Equal(t, "/api_url", errors[0].Path)
+	})
+
+	t.Run("ngrok api_url is rejected", func(t *testing.T) {
+		t.Parallel()
+		cfg := validMinimal()
+		cfg["api_url"] = "https://myapp.ngrok.io/webhook"
+		errors := registered.ValidateConfig(cfg)
+		require.NotEmpty(t, errors)
+		assert.Equal(t, "/api_url", errors[0].Path)
+	})
+
+	t.Run("invalid auth is rejected", func(t *testing.T) {
+		t.Parallel()
+		cfg := validMinimal()
+		cfg["auth"] = "oauth"
+		errors := registered.ValidateConfig(cfg)
+		require.NotEmpty(t, errors)
+		assert.Equal(t, "/auth", errors[0].Path)
+	})
+
+	t.Run("invalid method is rejected", func(t *testing.T) {
+		t.Parallel()
+		cfg := validMinimal()
+		cfg["method"] = "HEAD"
+		errors := registered.ValidateConfig(cfg)
+		require.NotEmpty(t, errors)
+		assert.Equal(t, "/method", errors[0].Path)
+	})
+
+	t.Run("invalid format is rejected", func(t *testing.T) {
+		t.Parallel()
+		cfg := validMinimal()
+		cfg["format"] = "CSV"
+		errors := registered.ValidateConfig(cfg)
+		require.NotEmpty(t, errors)
+		assert.Equal(t, "/format", errors[0].Path)
+	})
+
+	t.Run("invalid max_batch_size is rejected", func(t *testing.T) {
+		t.Parallel()
+		cfg := validMinimal()
+		cfg["max_batch_size"] = "500"
+		errors := registered.ValidateConfig(cfg)
+		require.NotEmpty(t, errors)
+		assert.Equal(t, "/max_batch_size", errors[0].Path)
+	})
+
+	t.Run("dynamic value satisfies enum", func(t *testing.T) {
+		t.Parallel()
+		cfg := validMinimal()
+		cfg["method"] = "{{ .HTTP_METHOD }}"
+		errors := registered.ValidateConfig(cfg)
+		assert.Empty(t, errors)
+	})
+
+	t.Run("secrets via var substitution", func(t *testing.T) {
+		t.Parallel()
+		cfg := validMinimal()
+		cfg["auth"] = "basicAuth"
+		cfg["username"] = "svc-account"
+		cfg["password"] = "{{ .HTTP_PASSWORD }}"
+		errors := registered.ValidateConfig(cfg)
+		assert.Empty(t, errors)
+	})
+
+	t.Run("valid full config", func(t *testing.T) {
+		t.Parallel()
+		errors := registered.ValidateConfig(map[string]any{
+			"api_url":       "https://example.com/collect",
+			"auth":          "apiKeyAuth",
+			"api_key_name":  "X-Api-Key",
+			"api_key_value": "secret-key-value",
+			"xml_root_key":  "root",
+			"method":        "PUT",
+			"format":        "XML",
+			"properties_mapping": []any{
+				map[string]any{"to": "userId", "from": "$.userId"},
+			},
+			"query_params": []any{
+				map[string]any{"to": "source", "from": "rudderstack"},
+			},
+			"headers": []any{
+				map[string]any{"to": "X-Trace", "from": "$.messageId"},
+			},
+			"path_params": []any{
+				map[string]any{"path": "$.userId"},
+			},
+			"is_batching_enabled": true,
+			"max_batch_size":      "50",
+			"event_filtering": map[string]any{
+				"whitelist": []any{"Product Viewed", "Order Completed"},
+			},
+			"is_default_mapping": false,
+			"consent_management": map[string]any{
+				"web": []any{
+					map[string]any{
+						"provider": "oneTrust",
+						"consents": []any{"analytics"},
+					},
+				},
+			},
+		})
+		assert.Empty(t, errors)
+	})
+
+	t.Run("unknown key rejected", func(t *testing.T) {
+		t.Parallel()
+		cfg := validMinimal()
+		cfg["not_a_field"] = true
+		errors := registered.ValidateConfig(cfg)
+		require.NotEmpty(t, errors)
+		assert.Equal(t, "/not_a_field", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "unknown config field")
+	})
+
+	t.Run("unsupported consent source rejected", func(t *testing.T) {
+		t.Parallel()
+		cfg := validMinimal()
+		cfg["consent_management"] = map[string]any{
+			"warehouse": []any{},
+		}
+		errors := registered.ValidateConfig(cfg)
+		require.Len(t, errors, 1)
+		assert.Equal(t, "/consent_management/warehouse", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "source type 'warehouse' is not supported")
+	})
+
+	t.Run("invalid consent provider rejected", func(t *testing.T) {
+		t.Parallel()
+		cfg := validMinimal()
+		cfg["consent_management"] = map[string]any{
+			"ios_swift": []any{
+				map[string]any{"provider": "unknown"},
+			},
+		}
+		errors := registered.ValidateConfig(cfg)
+		require.Len(t, errors, 1)
+		assert.Equal(t, "/consent_management/ios_swift/0/provider", errors[0].Path)
+		assert.Contains(t, errors[0].Message, "'provider' must be one of")
+	})
+}
+
+func TestHTTPConversionRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	def := http.NewDefinition()
+	testutil.AssertConversion(t, def.Properties, []testutil.ConversionCase{
+		{
+			Name: "minimal",
+			LocalJSON: `{
+				"api_url": "https://example.com/webhook",
+				"auth": "noAuth",
+				"method": "POST",
+				"format": "JSON"
+			}`,
+			APIJSON: `{
+				"apiUrl": "https://example.com/webhook",
+				"auth": "noAuth",
+				"method": "POST",
+				"format": "JSON"
+			}`,
+		},
+		{
+			Name: "auth and secrets",
+			LocalJSON: `{
+				"api_url": "https://example.com/webhook",
+				"auth": "apiKeyAuth",
+				"username": "svc",
+				"password": "pw",
+				"bearer_token": "tok",
+				"api_key_name": "X-Api-Key",
+				"api_key_value": "val",
+				"xml_root_key": "root",
+				"method": "PUT",
+				"format": "XML"
+			}`,
+			APIJSON: `{
+				"apiUrl": "https://example.com/webhook",
+				"auth": "apiKeyAuth",
+				"username": "svc",
+				"password": "pw",
+				"bearerToken": "tok",
+				"apiKeyName": "X-Api-Key",
+				"apiKeyValue": "val",
+				"xmlRootKey": "root",
+				"method": "PUT",
+				"format": "XML"
+			}`,
+		},
+		{
+			Name: "object arrays reshape",
+			LocalJSON: `{
+				"api_url": "https://example.com/webhook",
+				"auth": "noAuth",
+				"method": "POST",
+				"format": "JSON",
+				"properties_mapping": [{"to": "userId", "from": "$.userId"}],
+				"query_params": [{"to": "source", "from": "rudderstack"}],
+				"headers": [{"to": "X-Trace", "from": "$.messageId"}],
+				"path_params": [{"path": "$.userId"}]
+			}`,
+			APIJSON: `{
+				"apiUrl": "https://example.com/webhook",
+				"auth": "noAuth",
+				"method": "POST",
+				"format": "JSON",
+				"propertiesMapping": [{"to": "userId", "from": "$.userId"}],
+				"queryParams": [{"to": "source", "from": "rudderstack"}],
+				"headers": [{"to": "X-Trace", "from": "$.messageId"}],
+				"pathParams": [{"path": "$.userId"}]
+			}`,
+		},
+		{
+			Name: "event filtering whitelist discriminator",
+			LocalJSON: `{
+				"api_url": "https://example.com/webhook",
+				"auth": "noAuth",
+				"method": "POST",
+				"format": "JSON",
+				"event_filtering": {"whitelist": ["Product Viewed", "Order Completed"]}
+			}`,
+			APIJSON: `{
+				"apiUrl": "https://example.com/webhook",
+				"auth": "noAuth",
+				"method": "POST",
+				"format": "JSON",
+				"whitelistedEvents": [{"eventName": "Product Viewed"}, {"eventName": "Order Completed"}],
+				"eventFilteringOption": "whitelistedEvents"
+			}`,
+		},
+		{
+			Name: "event filtering blacklist discriminator",
+			LocalJSON: `{
+				"api_url": "https://example.com/webhook",
+				"auth": "noAuth",
+				"method": "POST",
+				"format": "JSON",
+				"event_filtering": {"blacklist": ["Internal Event"]}
+			}`,
+			APIJSON: `{
+				"apiUrl": "https://example.com/webhook",
+				"auth": "noAuth",
+				"method": "POST",
+				"format": "JSON",
+				"blacklistedEvents": [{"eventName": "Internal Event"}],
+				"eventFilteringOption": "blacklistedEvents"
+			}`,
+		},
+		{
+			Name: "batching and default mapping bools",
+			LocalJSON: `{
+				"api_url": "https://example.com/webhook",
+				"auth": "noAuth",
+				"method": "POST",
+				"format": "JSON",
+				"is_batching_enabled": true,
+				"max_batch_size": "50",
+				"is_default_mapping": false
+			}`,
+			APIJSON: `{
+				"apiUrl": "https://example.com/webhook",
+				"auth": "noAuth",
+				"method": "POST",
+				"format": "JSON",
+				"isBatchingEnabled": true,
+				"maxBatchSize": "50",
+				"isDefaultMapping": false
+			}`,
+		},
+		{
+			Name: "consent source boundary mappings",
+			LocalJSON: `{
+				"api_url": "https://example.com/webhook",
+				"auth": "noAuth",
+				"method": "POST",
+				"format": "JSON",
+				"consent_management": {
+					"android_kotlin": [{"provider": "oneTrust"}],
+					"ios_swift": [{"provider": "ketch"}],
+					"react_native": [{"provider": "iubenda"}]
+				}
+			}`,
+			APIJSON: `{
+				"apiUrl": "https://example.com/webhook",
+				"auth": "noAuth",
+				"method": "POST",
+				"format": "JSON",
+				"consentManagement": {
+					"androidKotlin": [{"provider": "oneTrust"}],
+					"iosSwift": [{"provider": "ketch"}],
+					"reactnative": [{"provider": "iubenda"}]
+				}
+			}`,
+		},
+	})
+}


### PR DESCRIPTION
## 🔗 Ticket

resolves [DEX-510](https://linear.app/rudderstack/issue/DEX-510/onboard-destination-http)

---

## Summary

Onboards the HTTP Webhook destination (upstream `APIType: HTTP`) into the CLI destination definition registry, following the `onboard-cli-destination` skill. Property mappings are ported from `terraform-provider-rudderstack`, config validations from integrations-config `schema.json`, and source types / connection modes / secrets from `db-config.json`. Registered as an unverified destination alongside `s3`, behind the `UnverifiedDestinations` flag.

---

## Changes

* Add `definitions/http/definition.go`: `httpConfig` model, property converters (auth/method/format enums, `{to,from}` object arrays for properties_mapping/query_params/headers, path_params, event-filtering whitelist/blacklist discriminator), and two named regex patterns (`http_api_url` with ngrok/localhost reject, `http_max_batch_size`).
* Add `definitions/http/definition_test.go`: metadata, config-validation, and conversion round-trip tests.
* Register `http` in `newDestinationRegistry` (`dependencies.go`) under the `UnverifiedDestinations` flag.
* Update `dependencies_test.go` flag-matrix expectation to `["http", "s3"]`.

Notes on intentional deviations from upstream:
* Source types `amp`, `shopify`, `warehouse` dropped to match the CLI event-stream ownership subset (S3 precedent).
* `connectionMode.*` kept as registry metadata, not config properties (S3 precedent).
* `SkipZeroValue` filters dropped on all `Simple` mappings; presence enforced via validation instead (avoids phantom diffs).
* Array element JSONPath regexes (to/from/path) validated by length only; the dual-branch env/template patterns are not re-encoded.

---

## Testing

* Unit: `go test ./cli/internal/providers/destination/... ./cli/internal/app/...` — all pass.
* Build: `go build ./...` — passes.
* Lint: `make lint` — 0 issues.
* Verified the example YAML config validates cleanly via `ValidateConfig`.

---

## Risk / Impact

Low — additive only, gated behind `experimental` + `flags.destinationSupport` + `flags.unverifiedDestinations`. No change to existing destinations or the apply cycle for enabled configs.

---

## Checklist

* [x] Ticket linked
* [x] Tests added/updated
* [x] No breaking changes (or documented)