### PR TITLE
fix(destination): prune empty non-required config fields on import export

### DIFF
--- a/cli/internal/providers/destination/definitions/http/prune_test.go
+++ b/cli/internal/providers/destination/definitions/http/prune_test.go
@@ -1,0 +1,141 @@
+package http_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions"
+	httpdest "github.com/rudderlabs/rudder-iac/cli/internal/providers/destination/definitions/http"
+)
+
+func registeredHTTP(t *testing.T) *definitions.RegisteredDefinition {
+	t.Helper()
+	registry := definitions.NewRegistry()
+	require.NoError(t, registry.Register(httpdest.NewDefinition()))
+	registered, err := registry.Get("http", 1)
+	require.NoError(t, err)
+	return registered
+}
+
+func TestPruneEmptyOptional_NoAuthDropsAuthFields(t *testing.T) {
+	t.Parallel()
+
+	registered := registeredHTTP(t)
+
+	// Mirrors the backend's full-schema response for a noAuth HTTP destination:
+	// every field present, most empty.
+	full := map[string]any{
+		"api_url":             "http://abcd.com",
+		"auth":                "noAuth",
+		"username":            "",
+		"password":            "",
+		"bearer_token":        "",
+		"api_key_name":        "x-api-key",
+		"api_key_value":       "",
+		"xml_root_key":        "",
+		"method":              "POST",
+		"format":              "JSON",
+		"properties_mapping":  []any{},
+		"query_params":        []any{},
+		"headers":             []any{},
+		"path_params":         []any{},
+		"is_batching_enabled": false,
+		"max_batch_size":      "",
+		"is_default_mapping":  true,
+		"event_filtering": map[string]any{
+			"whitelist": []any{""},
+			"blacklist": []any{""},
+		},
+	}
+
+	pruned := registered.PruneEmptyOptional(full)
+
+	// Meaningful fields survive.
+	assert.Equal(t, "http://abcd.com", pruned["api_url"])
+	assert.Equal(t, "noAuth", pruned["auth"])
+	assert.Equal(t, "POST", pruned["method"])
+	assert.Equal(t, "JSON", pruned["format"])
+	assert.Equal(t, "x-api-key", pruned["api_key_name"], "non-empty optional stays")
+	assert.Equal(t, true, pruned["is_default_mapping"], "bool value stays")
+	assert.Equal(t, false, pruned["is_batching_enabled"], "bool value stays")
+
+	// Empty, not-required fields are dropped — no phantom secret placeholders.
+	for _, key := range []string{
+		"username", "password", "bearer_token", "api_key_value",
+		"xml_root_key", "max_batch_size",
+		"properties_mapping", "query_params", "headers", "path_params",
+		"event_filtering",
+	} {
+		assert.NotContains(t, pruned, key, "empty non-required %q should be pruned", key)
+	}
+
+	// The pruned config still validates.
+	assert.Empty(t, registered.ValidateConfig(pruned))
+}
+
+func TestPruneEmptyOptional_BasicAuthKeepsRequiredEmpties(t *testing.T) {
+	t.Parallel()
+
+	registered := registeredHTTP(t)
+
+	// basicAuth makes username/password required; even if the backend returned
+	// them empty, they must be kept (they are the fields the user must fill).
+	config := map[string]any{
+		"api_url":  "https://example.com/hook",
+		"auth":     "basicAuth",
+		"username": "",
+		"password": "",
+		"method":   "POST",
+		"format":   "JSON",
+	}
+
+	pruned := registered.PruneEmptyOptional(config)
+
+	assert.Contains(t, pruned, "username", "required-when-basicAuth field kept even if empty")
+	assert.Contains(t, pruned, "password", "required-when-basicAuth field kept even if empty")
+}
+
+func TestPruneEmptyOptional_KeepsUserSetOptional(t *testing.T) {
+	t.Parallel()
+
+	registered := registeredHTTP(t)
+
+	config := map[string]any{
+		"api_url":      "https://example.com/hook",
+		"auth":         "noAuth",
+		"method":       "POST",
+		"format":       "XML",
+		"xml_root_key": "rudderEvent", // optional but user-set
+		"headers": []any{
+			map[string]any{"to": "X-Source", "from": "rudder"},
+		},
+	}
+
+	pruned := registered.PruneEmptyOptional(config)
+
+	assert.Equal(t, "rudderEvent", pruned["xml_root_key"], "non-empty optional survives")
+	assert.Contains(t, pruned, "headers", "non-empty array survives")
+}
+
+func TestPruneEmptyOptional_BatchingRequiresMaxBatchSize(t *testing.T) {
+	t.Parallel()
+
+	registered := registeredHTTP(t)
+
+	// is_batching_enabled=true makes max_batch_size required_if; keep it even
+	// if empty so the user sees the field they must fill.
+	config := map[string]any{
+		"api_url":             "https://example.com/hook",
+		"auth":                "noAuth",
+		"method":              "POST",
+		"format":              "JSON",
+		"is_batching_enabled": true,
+		"max_batch_size":      "",
+	}
+
+	pruned := registered.PruneEmptyOptional(config)
+
+	assert.Contains(t, pruned, "max_batch_size", "required_if=IsBatchingEnabled true kept even if empty")
+}

--- a/cli/internal/providers/destination/definitions/prune.go
+++ b/cli/internal/providers/destination/definitions/prune.go
@@ -1,0 +1,98 @@
+package definitions
+
+import (
+	"strings"
+)
+
+// PruneEmptyOptional returns a shallow copy of config with keys removed when
+// their value is empty AND the field is not required given the config's other
+// values. It exists for the export/import path: the backend returns the full
+// config schema with every field populated (empty strings, empty arrays,
+// arrays of empty objects), which otherwise clutters imported YAML with fields
+// irrelevant to the destination's actual configuration — e.g. a noAuth HTTP
+// destination importing empty username/password/token fields.
+//
+// Requiredness is evaluated with the same validator project validation uses, so
+// conditionally-required fields (required_if) are honored: an empty field that
+// is required given the current sibling values (e.g. password when
+// auth=basicAuth) is kept, while an empty field that is not required
+// (password when auth=noAuth) is dropped. Non-empty values are always kept, so
+// user-set optional fields survive.
+//
+// This never runs in the apply/converter path — pruning empty values there would
+// cause phantom, non-converging diffs. Export only.
+func (d *RegisteredDefinition) PruneEmptyOptional(config map[string]any) map[string]any {
+	if len(config) == 0 {
+		return config
+	}
+
+	pruned := make(map[string]any, len(config))
+	var dropped []string
+	for key, value := range config {
+		if isEmptyConfigValue(value) {
+			dropped = append(dropped, key)
+			continue
+		}
+		pruned[key] = value
+	}
+
+	if len(dropped) == 0 {
+		return pruned
+	}
+
+	// Restore any dropped key the validator now flags as required. Restoring a
+	// field only satisfies requiredness, so a single pass reaches a fixed point.
+	requiredPaths := requiredErrorPaths(d.ValidateConfig(pruned))
+	for _, key := range dropped {
+		if requiredPaths["/"+key] {
+			pruned[key] = config[key]
+		}
+	}
+
+	return pruned
+}
+
+// requiredErrorPaths collects the JSON-pointer paths of required / required_if
+// validation failures. Required messages are the only ones containing the word
+// "required" (pattern/oneof/type errors use distinct wording).
+func requiredErrorPaths(errors []ConfigError) map[string]bool {
+	paths := make(map[string]bool)
+	for _, e := range errors {
+		if strings.Contains(e.Message, "required") {
+			paths[e.Path] = true
+		}
+	}
+	return paths
+}
+
+// isEmptyConfigValue reports whether a decoded config value carries no
+// meaningful data: the zero string, nil, an empty/all-empty slice, or an
+// empty/all-empty map. Arrays of empty objects (e.g. the backend's
+// [{"eventName":""}] event filter) are treated as empty.
+func isEmptyConfigValue(value any) bool {
+	switch v := value.(type) {
+	case nil:
+		return true
+	case string:
+		return v == ""
+	case bool:
+		// A bool carries meaning (false is a real setting), never prune it.
+		return false
+	case []any:
+		for _, item := range v {
+			if !isEmptyConfigValue(item) {
+				return false
+			}
+		}
+		return true
+	case map[string]any:
+		for _, item := range v {
+			if !isEmptyConfigValue(item) {
+				return false
+			}
+		}
+		return true
+	default:
+		return false
+	}
+}

--- a/cli/internal/providers/destination/definitions/prune_test.go
+++ b/cli/internal/providers/destination/definitions/prune_test.go
@@ -1,0 +1,49 @@
+package definitions
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsEmptyConfigValue(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		value any
+		empty bool
+	}{
+		{"nil", nil, true},
+		{"empty string", "", true},
+		{"non-empty string", "x", false},
+		{"false bool is meaningful", false, false},
+		{"true bool", true, false},
+		{"empty slice", []any{}, true},
+		{"slice of empty strings", []any{"", ""}, true},
+		{"slice with a value", []any{"", "x"}, false},
+		{"empty map", map[string]any{}, true},
+		{"map of empty values", map[string]any{"a": "", "b": []any{""}}, true},
+		{"map with a value", map[string]any{"a": "x"}, false},
+		{"event filter shape all empty", map[string]any{"whitelist": []any{""}, "blacklist": []any{""}}, true},
+		{"number kept", float64(0), false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.empty, isEmptyConfigValue(tc.value))
+		})
+	}
+}
+
+func TestPruneEmptyOptional_EmptyConfig(t *testing.T) {
+	t.Parallel()
+
+	// A definition with no required fields: every empty key is pruned, non-empty
+	// kept. Uses the exported entrypoint via a minimal registered definition is
+	// covered in the http package; here we only guard the nil/empty fast path.
+	d := &RegisteredDefinition{}
+	assert.Empty(t, d.PruneEmptyOptional(map[string]any{}))
+	assert.Nil(t, d.PruneEmptyOptional(nil))
+}

--- a/cli/internal/providers/destination/handler.go
+++ b/cli/internal/providers/destination/handler.go
@@ -441,6 +441,11 @@ func (h *HandlerImpl) toExportSpecMap(externalID string, remote *RemoteDestinati
 		return nil, fmt.Errorf("converting destination %s config to local: %w", remote.ID, err)
 	}
 
+	// Drop empty fields the backend echoes but that aren't required for this
+	// destination's actual config (e.g. auth secrets on a noAuth destination),
+	// before masking so absent secrets don't become phantom {{ .VAR }} refs.
+	localConfig = registered.PruneEmptyOptional(localConfig)
+
 	if err := secret.MaskSecrets(localConfig, externalID, registered.SecretKeys()); err != nil {
 		return nil, fmt.Errorf("masking destination %s secrets: %w", remote.ID, err)
 	}

--- a/cli/internal/providers/destination/handler_test.go
+++ b/cli/internal/providers/destination/handler_test.go
@@ -1297,6 +1297,36 @@ func TestHandlerImpl_FormatForExport(t *testing.T) {
 		assert.Equal(t, "G-123", config["measurement_id"])
 	})
 
+	t.Run("prunes empty non-required fields the backend echoes", func(t *testing.T) {
+		enableVarSubstitution(t)
+
+		h := destination.NewHandler(nil, registry)
+
+		collection := map[string]*destination.RemoteDestination{
+			"ga4-production": {Destination: &client.Destination{
+				ID:        "dst-2",
+				Name:      "GA4",
+				Type:      "GA4",
+				Version:   1,
+				IsEnabled: true,
+				// Backend echoes the full schema: required apiSecret plus an empty
+				// optional measurementId.
+				Config: []byte(`{"apiSecret":"super-secret","measurementId":""}`),
+			}},
+		}
+
+		entities, _, err := h.Impl.FormatForExport(collection, nil, stubResolver{})
+		require.NoError(t, err)
+		require.Len(t, entities, 1)
+
+		spec, ok := entities[0].Content.(*specs.Spec)
+		require.True(t, ok)
+		config, ok := spec.Spec["config"].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "{{ .GA4_PRODUCTION_API_SECRET }}", config["api_secret"], "required secret kept and masked")
+		assert.NotContains(t, config, "measurement_id", "empty optional field pruned from imported YAML")
+	})
+
 	t.Run("resolves transformation reference", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
## 🔗 Ticket

resolves [DEX-612](https://linear.app/rudderstack/issue/DEX-612/prune-empty-non-required-config-fields-on-destination-import)

---

## Summary

Importing a destination produced cluttered, misleading YAML: the backend echoes the full config schema with every field populated (empty strings, empty arrays, arrays of empty objects), the converter copies every present key, and `MaskSecrets` then wraps empty secret fields into `{{ .VAR }}` references. For a noAuth HTTP destination this meant phantom `password`/`bearer_token`/`api_key_value` placeholders plus a pile of empty fields. This change prunes a config field on the import/export path when it is **empty AND not required** given the config's other values, using the same validator project validation uses (so `required_if` conditionals are honored). The apply/converter path is untouched.

---

## Changes

* Add `RegisteredDefinition.PruneEmptyOptional` (`definitions/prune.go`): drops empty, non-required fields; keeps required-if-conditional empties (e.g. basicAuth username/password), non-empty optionals, and bools.
* Wire the prune into `toExportSpecMap` before `MaskSecrets`, so absent secrets never become masked `{{ .VAR }}` placeholders.
* Unit tests: prune logic + empty-value detection, http auth-mode matrix (noAuth drops / basicAuth keeps / batching keeps max_batch_size / user-set optional survives), and an end-to-end `FormatForExport` case.

---

## Testing

* Unit: `go test ./cli/internal/providers/destination/...` — all pass.
* Build: `go build ./...`; Lint: `make lint` (0 issues).
* Manual: imported a live noAuth HTTP destination → clean minimal spec (no phantom secrets/empties); `apply` then re-`apply` of the imported spec is idempotent ("No changes to apply"). Confirmed pruning is export-only — not in Create/Update/LocalToAPI.

---

## Risk / Impact

Low — import/export output only; the apply cycle and converter are unchanged, so no phantom-diff risk. Only affects the human-facing imported YAML.

---

## Checklist

* [x] Ticket linked
* [x] Tests added/updated
* [x] No breaking changes (or documented)