### PR TITLE
fix(varsubst): claim only dot-prefixed {{ .VAR }} tokens

### DIFF
--- a/cli/internal/varsubst/README.md
+++ b/cli/internal/varsubst/README.md
@@ -104,7 +104,9 @@ rudder-cli experimental enable enableVarSubstitution
 host: "{{ .DB_HOST }}"
 ```
 
-- The token is `{{ .NAME }}` — the **leading dot is required** (`{{ DB_HOST }}` is invalid).
+- The token is `{{ .NAME }}` — the **leading dot is required**. Substitution claims only
+  dot-prefixed tokens, so `{{ DB_HOST }}` is not a variable reference and is passed through
+  as a literal rather than reported as an error.
 - Whitespace inside the braces is flexible: `{{.DB_HOST}}`, `{{ .DB_HOST }}`, and
   `{{  .DB_HOST  }}` are all equivalent.
 - Variable names may contain only **letters, digits, and underscores**, and must **start
@@ -261,7 +263,7 @@ error[project/var-substitution]: undefined variable "DB_PASSWORD"
 | Error | Cause |
 | ----- | ----- |
 | `undefined variable` | `{{ .VAR }}` not found in env vars or var files, and no default given. |
-| `invalid variable syntax` | Malformed token, e.g. missing dot (`{{ VAR }}`) or an invalid name (`{{ .1A }}`). |
+| `invalid variable syntax` | Dot-prefixed token with an invalid name, e.g. `{{ .1A }}`. A token without the dot (`{{ VAR }}`) is not claimed at all and passes through. |
 | `variable file not found` | A `--var-file` path does not exist. |
 | `variable file must use the .vars.yaml or .vars.yml suffix` | A `--var-file` path does not end in `.vars.yaml`/`.vars.yml`. |
 | `failed to parse variable file` | The file is invalid YAML, has nested values, or has a null/empty value. |
@@ -290,17 +292,31 @@ The command fails with an `undefined variable` error pointing at the line and co
 variable a value (env var or var file) or add an inline default: `{{ .VAR | fallback }}`.
 
 **Q: How do I write a literal `{{ .X }}` that should *not* be substituted?**
-There is currently **no escape syntax**. Any `{{ .NAME }}`-shaped token outside a comment is
-treated as a variable. The only built-in exception is YAML comments — a token after an
-unquoted `#` is left untouched:
+There is currently **no escape syntax** for a dot-prefixed token. Any `{{ .NAME }}`-shaped
+token outside a comment is treated as a variable. The only built-in exception is YAML
+comments — a token after an unquoted `#` is left untouched:
 
 ```yaml
 # TODO: wire up {{ .DB_HOST }} later   <- not substituted (it's in a comment)
 host: "{{ .DB_HOST }}"                 <- substituted
 ```
 
-If you genuinely need a literal `{{ .X }}` in a value, avoid the dot-prefixed pattern, or
-restructure so the token sits in a comment.
+If you genuinely need a literal dot-prefixed token in a value, restructure so it sits in a
+comment.
+
+**Q: What about `{{ … }}` tokens that aren't variables?**
+Substitution claims only the dot-prefixed form, so other `{{ … }}` dialects pass through
+untouched. That is what lets destination configs carry RudderStack UI templates, which use
+a path rather than a dot:
+
+```yaml
+bucket_name: '{{ config.bucketName || my-bucket }}'   <- left alone, sent upstream as written
+credentials: '{{ .GCS_CREDENTIALS }}'                 <- substituted from the var file
+```
+
+The trade-off is that a mistyped variable missing its dot — `{{ VAR }}` — is no longer
+reported; it is indistinguishable from another dialect's token and passes through as a
+literal. A malformed *dotted* token such as `{{ .9BAD }}` is still claimed and still errors.
 
 **Q: Is a `#` inside a quoted string treated as a comment?**
 No. A `#` only starts a comment when it is unquoted. These tokens are still substituted:

--- a/cli/internal/varsubst/substitutor.go
+++ b/cli/internal/varsubst/substitutor.go
@@ -10,13 +10,16 @@ type Resolver interface {
 	Resolve(name string) (value string, found bool)
 }
 
-// Matches any {{ content }} token. Group 1 captures the token (anything that
-// isn't whitespace, pipe, or closing brace). Group 2 (optional) captures the
+// Matches a {{ .VAR }} token. Group 1 captures the dot-prefixed token; the dot
+// is required so substitution claims only its own syntax and leaves other
+// `{{ … }}` dialects — notably the RudderStack UI's `{{ path || fallback }}`
+// destination config templates — untouched. Group 2 (optional) captures the
 // default value after pipe — a single `}` is allowed (so defaults can contain
 // regex like `[a-z]{3}`), but `}}` always terminates the token. Surrounding
-// whitespace is stripped by the enclosing \s* groups. Validation of the token
-// (dot prefix, variable name pattern) happens in code after matching.
-var varRegex = regexp.MustCompile(`\{\{\s*([^}\s|]+)(?:\s*\|\s*((?:[^}]|}[^}])*?))?\s*\}\}`)
+// whitespace is stripped by the enclosing \s* groups. The variable name pattern
+// is still validated in code after matching, so a malformed dotted token like
+// `{{ .9BAD }}` is reported rather than silently passed through.
+var varRegex = regexp.MustCompile(`\{\{\s*(\.[^}\s|]+)(?:\s*\|\s*((?:[^}]|}[^}])*?))?\s*\}\}`)
 
 var validVarName = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
 

--- a/cli/internal/varsubst/substitutor_test.go
+++ b/cli/internal/varsubst/substitutor_test.go
@@ -158,12 +158,35 @@ func TestSubstituteBytes(t *testing.T) {
 			},
 		},
 		{
-			name:      "missing dot prefix reports error",
+			// Only dot-prefixed tokens belong to substitution. Anything else is
+			// another dialect's syntax (e.g. the RudderStack UI's
+			// `{{ path || fallback }}`) and passes through untouched.
+			name:      "missing dot prefix passes through untouched",
 			resolvers: []Resolver{mapResolver{"VAR": "value"}},
 			input:     "key: {{ VAR }}",
 			wantData:  "key: {{ VAR }}",
+		},
+		{
+			name:      "ui template passes through untouched",
+			resolvers: []Resolver{mapResolver{"BUCKET": "value"}},
+			input:     "bucket_name: {{ config.bucketName || my-bucket }}",
+			wantData:  "bucket_name: {{ config.bucketName || my-bucket }}",
+		},
+		{
+			name:      "ui template alongside a variable reference",
+			resolvers: []Resolver{mapResolver{"PREFIX": "rudder/"}},
+			input:     "a: {{ config.bucketName || my-bucket }}\nb: {{ .PREFIX }}",
+			wantData:  "a: {{ config.bucketName || my-bucket }}\nb: rudder/",
+		},
+		{
+			// A malformed *dotted* token is still claimed and still reported: the
+			// narrower match must not silence genuine typos in variable names.
+			name:      "malformed dotted token still reports error",
+			resolvers: []Resolver{mapResolver{"VAR": "value"}},
+			input:     "key: {{ .9BAD }}",
+			wantData:  "key: {{ .9BAD }}",
 			wantErrs: []SubstitutionError{
-				{Name: "VAR", Line: 1, Column: 6, LineText: "key: {{ VAR }}", Err: ErrInvalidVarSyntax},
+				{Name: "9BAD", Line: 1, Column: 6, LineText: "key: {{ .9BAD }}", Err: ErrInvalidVarSyntax},
 			},
 		},
 	}

--- a/cli/internal/varsubst/utils_test.go
+++ b/cli/internal/varsubst/utils_test.go
@@ -67,11 +67,17 @@ func TestUnquoteTokens(t *testing.T) {
 			want: `region: {{ .REGION | us-east-1 }}`,
 		},
 		{
-			// Validity is not checked: substitution rejects a malformed token
-			// loudly whether quoted or not.
-			name: "malformed token also unquoted",
+			// Not a variable reference, so it keeps its quotes — unquoting a
+			// non-variable token would emit a scalar starting with '{', which
+			// YAML reads as a flow mapping.
+			name: "non variable token keeps quotes",
 			in:   `a: "{{ NO_DOT }}"`,
-			want: `a: {{ NO_DOT }}`,
+			want: `a: "{{ NO_DOT }}"`,
+		},
+		{
+			name: "ui template keeps quotes",
+			in:   `a: "{{ config.bucketName || my-bucket }}"`,
+			want: `a: "{{ config.bucketName || my-bucket }}"`,
 		},
 		{
 			name: "token embedded in longer string keeps quotes",


### PR DESCRIPTION
## 🔗 Ticket

Resolves [DEX-666](https://linear.app/rudderstack/issue/DEX-666/variable-substitution-should-claim-only-dot-prefixed-var-tokens)

---

## Summary

Variable substitution claimed **every** `{{ … }}` token in a spec and errored when the token was not dot-prefixed. But `{{ … }}` is not exclusively CLI syntax: RudderStack destination configs use the UI template dialect `{{ path || fallback }}`, which integrations-config `schema.json` declares for practically every string field — 7056 of 7059 template branches across all destinations are exactly `(^\{\{.*\|\|(.*)\}\}$)` — and rudder-transformer resolves them at event time.

Because substitution runs before validation, a spec carrying a UI template failed outright whenever var substitution was enabled:

```
error[project/var-substitution]: invalid variable syntax "config.bucketName"
  --> gcs.yaml:12:19
   12 |     bucket_name: '{{ config.bucketName || rudder-cli-e2e-gcs }}'
```

The same spec validated fine with substitution off, so the two features were mutually exclusive. This makes substitution claim only its own syntax and pass everything else through.

---

## Changes

- Require the dot in the token regex so only `{{ .VAR }}` is claimed:
  ```go
  var varRegex = regexp.MustCompile(`\{\{\s*(\.[^}\s|]+)(?:\s*\|\s*((?:[^}]|}[^}])*?))?\s*\}\}`)
  ```
- Malformed *dotted* tokens (`{{ .9BAD }}`) are still claimed and still reported, so genuine variable-name typos stay loud
- Correct the README in three places that documented the old behaviour: the token-grammar bullet, the "no escape syntax" FAQ, and the error table

### Bonus fix: `UnquoteTokens`

`UnquoteTokens` is built from the same regex, so it was stripping quotes from UI templates and emitting:

```yaml
bucket_name: {{ config.x || y }}
```

— a scalar starting with `{`, which YAML parses as a flow mapping. Any generated or exported spec carrying a template was therefore invalid YAML. Narrowing the regex fixes that too; such tokens now keep their quotes.

---

## Trade-off

A variable reference with a forgotten dot — `{{ VAR }}` — previously errored with `invalid variable syntax`. It now passes through as a literal.

This is unavoidable: once the CLI stops claiming the namespace, a typo and another dialect's token are indistinguishable. Malformed dotted tokens are unaffected. The trade-off is called out explicitly in the README FAQ and the error table so it is discoverable rather than surprising.

---

## Testing

- `TestSubstituteBytes`: UI template passes through untouched; passes through alongside a `{{ .VAR }}` reference in the same file; missing-dot token passes through; **malformed dotted token still reports `invalid variable syntax`** (this one guards the trade-off from widening)
- `TestUnquoteTokens`: non-variable tokens and UI templates keep their quotes
- `make test`, `make lint` — clean
- Verified end to end with the real CLI: a destination spec mixing both dialects validates with substitution enabled, where it previously failed

---

## Risk / Impact

Medium

Notes: `varsubst` is shared by every spec-loading path (`validate`, `apply`, `import`), so the behaviour change is broad even though the diff is small. No spec that works today stops working: the change only *widens* what passes. The single regression surface is the lost error for a dot-less typo, documented above.

---

## Checklist

- [x] Ticket linked
- [x] Tests added/updated
- [x] No breaking changes (or documented)
