### PR TITLE
feat: add externalId support to the connections API client

### DIFF
--- a/api/client/connections.go
+++ b/api/client/connections.go
@@ -1,12 +1,23 @@
 package client
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"strconv"
 	"time"
 )
 
+// ErrExternalIDAlreadyInUse signals a 409 from the set external ID endpoint:
+// the external ID is already claimed by another connection in the workspace.
+var ErrExternalIDAlreadyInUse = fmt.Errorf("external ID already in use")
+
 type Connection struct {
 	ID            string     `json:"id,omitempty"`
+	ExternalID    string     `json:"externalId,omitempty"`
 	SourceID      string     `json:"sourceId"`
 	DestinationID string     `json:"destinationId"`
 	IsEnabled     bool       `json:"enabled"`
@@ -23,6 +34,18 @@ type ConnectionsPage struct {
 	Connections []Connection `json:"connections"`
 }
 
+type ListConnectionsOption func(*ListConnectionsOptions)
+
+func WithConnectionsHasExternalID(hasExternalID bool) ListConnectionsOption {
+	return func(o *ListConnectionsOptions) {
+		o.HasExternalID = &hasExternalID
+	}
+}
+
+type ListConnectionsOptions struct {
+	HasExternalID *bool
+}
+
 func (s *connections) Next(ctx context.Context, paging Paging) (*ConnectionsPage, error) {
 	page := &ConnectionsPage{}
 	ok, err := s.service.next(ctx, paging, page)
@@ -32,13 +55,32 @@ func (s *connections) Next(ctx context.Context, paging Paging) (*ConnectionsPage
 	return page, err
 }
 
-func (s *connections) List(ctx context.Context) (*ConnectionsPage, error) {
+func (s *connections) List(ctx context.Context, opts ...ListConnectionsOption) (*ConnectionsPage, error) {
 	page := &ConnectionsPage{}
-	if err := s.list(ctx, page); err != nil {
+	if err := s.list(ctx, page, opts...); err != nil {
 		return nil, err
 	}
 
 	return page, nil
+}
+
+func (s *connections) list(ctx context.Context, result interface{}, opts ...ListConnectionsOption) error {
+	options := &ListConnectionsOptions{}
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	path := s.basePath
+	query := url.Values{}
+	if options.HasExternalID != nil {
+		query.Add("hasExternalId", strconv.FormatBool(*options.HasExternalID))
+	}
+	if len(query) > 0 {
+		path = fmt.Sprintf("%s?%s", path, query.Encode())
+	}
+
+	_, err := s.next(ctx, Paging{Next: path}, result)
+	return err
 }
 
 func (s *connections) Get(ctx context.Context, id string) (*Connection, error) {
@@ -64,9 +106,12 @@ func (s *connections) Create(ctx context.Context, connection *Connection) (*Conn
 }
 
 func (s *connections) Update(ctx context.Context, connection *Connection) (*Connection, error) {
-	// copy input and remove ID from request body without modifying input
+	// copy input and remove fields that should not be in request body without
+	// modifying input; externalId can only be set through the external-id
+	// endpoint, the generic update rejects bodies carrying it
 	conn := *connection
 	conn.ID = ""
+	conn.ExternalID = ""
 
 	response := struct{ Connection *Connection }{}
 	if err := s.update(ctx, connection.ID, &conn, &response); err != nil {
@@ -78,4 +123,22 @@ func (s *connections) Update(ctx context.Context, connection *Connection) (*Conn
 
 func (s *connections) Delete(ctx context.Context, id string) error {
 	return s.service.delete(ctx, id)
+}
+
+func (s *connections) SetExternalID(ctx context.Context, id, externalID string) error {
+	body, err := json.Marshal(map[string]string{"externalId": externalID})
+	if err != nil {
+		return fmt.Errorf("marshalling external ID: %w", err)
+	}
+
+	path := fmt.Sprintf("%s/%s/external-id", s.basePath, id)
+	if _, err := s.client.Do(ctx, "PUT", path, bytes.NewReader(body)); err != nil {
+		var apiError *APIError
+		if errors.As(err, &apiError) && apiError.HTTPStatusCode == 409 {
+			return ErrExternalIDAlreadyInUse
+		}
+		return fmt.Errorf("setting external ID: %w", err)
+	}
+
+	return nil
 }

--- a/api/client/connections_test.go
+++ b/api/client/connections_test.go
@@ -98,11 +98,12 @@ func TestClientConnectionsGet(t *testing.T) {
 			ResponseBody: `{
 				"connection": {
 					"id": "some-id",
+					"externalId": "external-id-1",
 					"sourceId": "source-id",
 					"destinationId": "destination-id",
 					"enabled": true,
 					"createdAt": "2020-01-01T01:01:01Z",
-					"updatedAt": "2020-01-02T01:01:01Z"	
+					"updatedAt": "2020-01-02T01:01:01Z"
 				}
 			}`,
 		},
@@ -117,6 +118,7 @@ func TestClientConnectionsGet(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, connection)
 	assert.Equal(t, "some-id", connection.ID)
+	assert.Equal(t, "external-id-1", connection.ExternalID)
 	assert.Equal(t, "source-id", connection.SourceID)
 	assert.Equal(t, "destination-id", connection.DestinationID)
 	assert.Equal(t, true, connection.IsEnabled)
@@ -171,6 +173,49 @@ func TestClientConnectionsCreate(t *testing.T) {
 	httpClient.AssertNumberOfCalls()
 }
 
+func TestClientConnectionsCreateWithExternalID(t *testing.T) {
+	ctx := context.Background()
+
+	calls := []testutils.Call{
+		{
+			Validate: func(req *http.Request) bool {
+				return testutils.ValidateRequest(t, req, "POST", "https://api.rudderstack.com/v2/connections", `{
+					"externalId": "external-id-1",
+					"sourceId": "source-id",
+					"destinationId": "destination-id",
+					"enabled": false
+				}`)
+			},
+			ResponseStatus: 200,
+			ResponseBody: `{
+				"connection": {
+					"id": "some-id",
+					"externalId": "external-id-1",
+					"sourceId": "source-id",
+					"destinationId": "destination-id"
+				}
+			}`,
+		},
+	}
+
+	httpClient := testutils.NewMockHTTPClient(t, calls...)
+
+	c, err := client.New("some-access-token", client.WithHTTPClient(httpClient))
+	require.NoError(t, err)
+
+	connection, err := c.Connections.Create(ctx, &client.Connection{
+		ExternalID:    "external-id-1",
+		SourceID:      "source-id",
+		DestinationID: "destination-id",
+	})
+	require.NoError(t, err)
+	assert.NotNil(t, connection)
+	assert.Equal(t, "some-id", connection.ID)
+	assert.Equal(t, "external-id-1", connection.ExternalID)
+
+	httpClient.AssertNumberOfCalls()
+}
+
 func TestClientConnectionsUpdate(t *testing.T) {
 	ctx := context.Background()
 
@@ -214,6 +259,158 @@ func TestClientConnectionsUpdate(t *testing.T) {
 	assert.Equal(t, "destination-id", connection.DestinationID)
 	assert.Equal(t, time.Date(2020, 1, 1, 1, 1, 1, 0, time.UTC), *connection.CreatedAt)
 	assert.Equal(t, time.Date(2020, 1, 2, 1, 1, 1, 0, time.UTC), *connection.UpdatedAt)
+
+	httpClient.AssertNumberOfCalls()
+}
+
+func TestClientConnectionsUpdateStripsExternalID(t *testing.T) {
+	ctx := context.Background()
+
+	calls := []testutils.Call{
+		{
+			// externalId can only be set through the external-id endpoint; the
+			// generic update rejects bodies carrying it, so it must be absent here.
+			Validate: func(req *http.Request) bool {
+				return testutils.ValidateRequest(t, req, "PUT", "https://api.rudderstack.com/v2/connections/some-id", `{
+					"sourceId": "source-id",
+					"destinationId": "destination-id",
+					"enabled": true
+				}`)
+			},
+			ResponseStatus: 200,
+			ResponseBody: `{
+				"connection": {
+					"id": "some-id",
+					"externalId": "external-id-1",
+					"sourceId": "source-id",
+					"destinationId": "destination-id",
+					"enabled": true
+				}
+			}`,
+		},
+	}
+
+	httpClient := testutils.NewMockHTTPClient(t, calls...)
+
+	c, err := client.New("some-access-token", client.WithHTTPClient(httpClient))
+	require.NoError(t, err)
+
+	connection, err := c.Connections.Update(ctx, &client.Connection{
+		ID:            "some-id",
+		ExternalID:    "external-id-1",
+		SourceID:      "source-id",
+		DestinationID: "destination-id",
+		IsEnabled:     true,
+	})
+	require.NoError(t, err)
+	assert.NotNil(t, connection)
+	assert.Equal(t, "external-id-1", connection.ExternalID)
+
+	httpClient.AssertNumberOfCalls()
+}
+
+func TestClientConnectionsListWithHasExternalID(t *testing.T) {
+	ctx := context.Background()
+
+	httpClient := testutils.NewMockHTTPClient(t,
+		testutils.Call{
+			Validate: func(req *http.Request) bool {
+				// testutils.ValidateRequest does not compare URLs, and the query
+				// string is the behaviour under test here
+				return assert.Equal(t, "https://api.rudderstack.com/v2/connections?hasExternalId=true", req.URL.String()) &&
+					testutils.ValidateRequest(t, req, "GET", "", "")
+			},
+			ResponseStatus: 200,
+			ResponseBody: `{
+				"connections": [{
+					"id": "id-1",
+					"externalId": "external-id-1",
+					"sourceId": "source-1",
+					"destinationId": "destination-1",
+					"enabled": true
+				}],
+				"paging": {
+					"total": 1
+				}
+			}`,
+		},
+		testutils.Call{
+			Validate: func(req *http.Request) bool {
+				return assert.Equal(t, "https://api.rudderstack.com/v2/connections?hasExternalId=false", req.URL.String()) &&
+					testutils.ValidateRequest(t, req, "GET", "", "")
+			},
+			ResponseStatus: 200,
+			ResponseBody: `{
+				"connections": [{
+					"id": "id-2",
+					"sourceId": "source-2",
+					"destinationId": "destination-2",
+					"enabled": true
+				}],
+				"paging": {
+					"total": 1
+				}
+			}`,
+		},
+	)
+
+	c, err := client.New("some-access-token", client.WithHTTPClient(httpClient))
+	require.NoError(t, err)
+
+	page, err := c.Connections.List(ctx, client.WithConnectionsHasExternalID(true))
+	require.NoError(t, err)
+	require.NotNil(t, page)
+	require.Len(t, page.Connections, 1)
+	assert.Equal(t, "external-id-1", page.Connections[0].ExternalID)
+
+	page, err = c.Connections.List(ctx, client.WithConnectionsHasExternalID(false))
+	require.NoError(t, err)
+	require.NotNil(t, page)
+	require.Len(t, page.Connections, 1)
+	assert.Equal(t, "", page.Connections[0].ExternalID)
+
+	httpClient.AssertNumberOfCalls()
+}
+
+func TestClientConnectionsSetExternalID(t *testing.T) {
+	ctx := context.Background()
+
+	httpClient := testutils.NewMockHTTPClient(t, testutils.Call{
+		Validate: func(req *http.Request) bool {
+			// testutils.ValidateRequest does not compare URLs, and the path is
+			// part of the behaviour under test here
+			return assert.Equal(t, "https://api.rudderstack.com/v2/connections/some-id/external-id", req.URL.String()) &&
+				testutils.ValidateRequest(t, req, "PUT", "", `{
+					"externalId": "external-id-1"
+				}`)
+		},
+		ResponseStatus: 200,
+		ResponseBody:   `{"id": "some-id", "externalId": "external-id-1"}`,
+	})
+
+	c, err := client.New("some-access-token", client.WithHTTPClient(httpClient))
+	require.NoError(t, err)
+
+	err = c.Connections.SetExternalID(ctx, "some-id", "external-id-1")
+	require.NoError(t, err)
+
+	httpClient.AssertNumberOfCalls()
+}
+
+func TestClientConnectionsSetExternalIDConflict(t *testing.T) {
+	ctx := context.Background()
+
+	httpClient := testutils.NewMockHTTPClient(t, testutils.Call{
+		ResponseStatus: 409,
+		ResponseBody:   `{"error": "externalId is already in use by another connection"}`,
+	})
+
+	c, err := client.New("some-access-token", client.WithHTTPClient(httpClient))
+	require.NoError(t, err)
+
+	err = c.Connections.SetExternalID(ctx, "some-id", "external-id-1")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, client.ErrExternalIDAlreadyInUse)
 
 	httpClient.AssertNumberOfCalls()
 }


### PR DESCRIPTION
## 🔗 Ticket

Resolves [DEX-648](https://linear.app/rudderstack/issue/DEX-648/2-add-externalid-support-to-the-connections-api-client)

---

## Summary

Adds externalId support to the generic connections API client so event stream connections can carry IaC identity, mirroring the existing accounts (#638) and destinations externalId patterns in the same package.

---

## Changes

- `ExternalID` field on the `Connection` model (`externalId,omitempty`): read from API responses (tolerates the key being absent), and forwarded on `Create` so an externalId can be claimed atomically at create time
- `Update` strips `ExternalID` from the request body — externalId can only be set through the dedicated endpoint; the generic `PUT /v2/connections/{id}` rejects bodies carrying it
- `List` accepts variadic functional options with `WithConnectionsHasExternalID(bool)`, adding the `hasExternalId` query param used for CLI state loading (backward-compatible for existing callers)
- `SetExternalID(ctx, id, externalID)` calling `PUT /v2/connections/{id}/external-id`, mapping HTTP 409 to the new `ErrExternalIDAlreadyInUse` sentinel so callers can distinguish "already in use by another connection"

---

## Testing

- Unit tests for all new behaviour: externalId read on `Get`/`List`, forwarded on `Create`, stripped on `Update`, `hasExternalId=true|false` query encoding, `SetExternalID` request path/body, and 409 → `ErrExternalIDAlreadyInUse`
- `make lint` (0 issues) and full `make test` (0 failures)

---

## Risk / Impact

Low
Notes: purely additive client surface; existing callers are unaffected (`List` change is variadic, whole repo compiles unchanged).

---

## Checklist

- [x] Ticket linked
- [x] Tests added/updated
- [x] No breaking changes (or documented)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
